### PR TITLE
Absorption phase-01 (Basket B): variables/mode stdlib, variant-matrix component-set

### DIFF
--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -1,0 +1,64 @@
+# Third-party attribution
+
+This repo absorbs specific capabilities studied from a fork of an existing open-source
+Figma tool, under its MIT license. This file lists exactly what was adapted, from where,
+and how — the citations in `plugin/src/main/` doc comments and `knowledge/` point back
+here.
+
+## Source
+
+- Project: `figma-console-mcp` (Figma Desktop Bridge)
+- Read at: `southleft/figma-console-mcp` (studied locally as
+  `/Users/jang/Products/research/figma-console-mcp`)
+- Version read: **v1.38.2**
+- Read date: **2026-07-31**
+- License: MIT
+
+Verbatim MIT notice from that project's `LICENSE`:
+
+```
+MIT License
+
+Copyright (c) 2025 Figma Console MCP Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+## Derivations
+
+| Our file | Derives from | Nature of derivation |
+|---|---|---|
+| `plugin/src/main/exec-stdlib-component-set.ts` + `exec-stdlib-component-matrix.ts` | `src/core/write-tools.ts:2825-3050` (`figma_create_component_set` tool contract) + `figma-desktop-bridge/code.js:2121-2411` (`CREATE_COMPONENT_SET` handler) | Adapted algorithm + constraint list: the two-mode contract (base+axes vs. combine-existing), the `=`/`,` name-token ban, the 100-combination hard cap and 40-variant size-warning threshold, and the cartesian-product-then-`combineAsVariants` approach. NOT ported: the handler's manual clone/rename rollback bookkeeping (`rollbackComponentSetWork`) — this repo's own `--undo-group` bracket (`executor-exec-js.ts`) already gives atomic rollback over the whole script via Figma's real undo stack, so a second hand-rolled mechanism would duplicate it. Also not ported: `autoArrange`/grid-layout — out of scope for this phase. |
+
+## Facts cited, not derived expression
+
+`knowledge/component-sets.md`'s state→CSS-selector table and its case-sensitivity
+warning are **facts about Figma's own naming convention and about a bug observed in the
+source project's analysis code** (`code.js:1318`, `code.js:1176-1197`), cited for
+re-verifiability — so a reader can go check the claim against the source — not
+reproduced as licensed expression. The table itself is rewritten in this repo's own
+words per `knowledge/component-sets.md` §2.3.
+
+## Attribution already carried in `knowledge/figma-agent-hand.md`
+
+The broker/relay design (websocket-server pending-request correlation, heartbeat
+approach) and the `scripts/probe/visual-diff.mjs` pixel-diff approach were adapted from
+other MIT-licensed projects prior to this repo's own extraction from the `ease-design`
+monorepo — see the top-level `README.md`'s Attribution section for those (pre-existing,
+unrelated to this phase's absorption work).

--- a/knowledge/component-sets.md
+++ b/knowledge/component-sets.md
@@ -32,6 +32,14 @@ return await ui.componentSet({
 });
 ```
 
+- **Run this behind `--undo-group`.** `ui.componentSet` cleans up its OWN mutations
+  (restores a renamed base, removes the clones it created) if one of ITS OWN later
+  steps throws — that is a narrow, self-scoped safety net, not a substitute for the
+  real undo bracket. If a DIFFERENT step in the same script fails after
+  `ui.componentSet` already returned successfully, `--undo-group` is what rolls the
+  whole script back; without it, a successfully-built set stays on the canvas even
+  if a later line in the same script throws. Always wrap a script that calls this
+  in `exec-js --undo-group` unless you specifically want partial results to survive.
 - **Exactly one of `base`+`axes` or `components`** — both or neither throws, naming the
   two valid shapes.
 - **Axis and value names must not contain `=` or `,`** — Figma parses variant properties

--- a/knowledge/component-sets.md
+++ b/knowledge/component-sets.md
@@ -1,0 +1,127 @@
+# Component sets — build from a matrix, analyse an existing one
+
+Two recipes (absorption phase-01, Basket B): `ui.componentSet(...)` builds a
+COMPONENT_SET from a variant matrix or from existing components; the analysis recipe
+below composes tools this repo already has (`figma-agent scan-node`, `ui.q`,
+`ui.componentSet`'s own `propertyDefinitions`) to answer the same question the fork's
+`figma_analyze_component_set` does — **without** its case-sensitivity bug or its
+"guess the main interactive child" heuristic (both explained below, so neither comes
+back by accident).
+
+All snippets are `figma-agent exec-js` ready (async body, `ui`/`figma` globals, `return`
+a JSON-safe value). Companion: `knowledge/figma-craft/components-variables-styles.md`
+§1.3 (the `combineAsVariants` naming contract this builds on).
+
+---
+
+## 1. Build a set from a variant matrix
+
+```js
+// Mode 1 — generate from a base COMPONENT + axes (cartesian product):
+return await ui.componentSet({
+  base: '12:34',
+  axes: { State: ['default', 'hover', 'disabled'], Size: ['sm', 'lg'] },
+});
+// → 6 variants. The BASE keeps its node id (variants[0].id === '12:34'), so any
+//   existing instance of the base survives as an instance of that first variant.
+
+// Mode 2 — combine existing COMPONENT nodes, naming them via variantProps:
+return await ui.componentSet({
+  components: ['1:1', '1:2', '1:3'],
+  variantProps: [{ State: 'default' }, { State: 'hover' }, { State: 'disabled' }],
+});
+```
+
+- **Exactly one of `base`+`axes` or `components`** — both or neither throws, naming the
+  two valid shapes.
+- **Axis and value names must not contain `=` or `,`** — Figma parses variant properties
+  by splitting the name on those characters, so a stray comma silently creates a bogus
+  extra axis. Rejected before anything is created.
+- **Deterministic order**: axis insertion order, then values in the order given — the
+  variant list is reproducible, never shuffled.
+- **Hard cap: 100 combinations** — throws naming the computed count and advising a split
+  by one axis. **Above 40**, the reply carries `sizeWarning` (not a rejection) — large
+  matrices are slow to build; split by Size or another axis if it matters.
+  `[re-verify]` both thresholds against a real build; they're the fork's own numbers,
+  not independently measured here.
+- **Mode 2, no `variantProps`**: existing names are kept as-is. A name lacking `=`
+  triggers a `warnings` entry — Figma will file it under `Property 1=<name>`
+  `[re-verify]` — pass `variantProps` if you want to choose the axis explicitly.
+- **A component already inside a COMPONENT_SET is rejected** in both modes, naming the
+  set it's already in.
+- **Instances come from a variant's own `key`/`id`, never the set's** — the reply's
+  `variants[]` carries both per variant.
+- **A big matrix can outrun `exec-js`'s default 30s timeout.** Raise `--timeout` (cap
+  120s) and, if it still times out, the build **keeps running** server-side — split
+  large matrices across multiple `ui.componentSet` calls (one per Size, say) rather than
+  one call for everything.
+- Not ported from the fork: automatic grid layout (`autoArrange`). This is a knowledge
+  recipe only, built when a task actually asks for it — see
+  `components-variables-styles.md` §1.3's post-combine geometry recipe for how to lay
+  variants out by hand (walk child bounds, resize the set, let auto-layout space them).
+
+## 2. Analyse an existing set
+
+No dedicated command — compose what already exists:
+
+```js
+const set = await ui.q('12:34', { depth: 2 });          // figma-agent scan-node's shape
+// set.propertyDefinitions came back from ui.componentSet when YOU built it; for a set
+// you didn't build, read componentPropertyDefinitions directly:
+const defs = await ui.q('12:34', { fields: ['componentPropertyDefinitions', 'children'] });
+```
+
+Then, per variant child (`figma-agent scan-node` or `ui.q(childId, {depth:N})`):
+
+1. **Parse the variant's name** into an axis map the same way `ui.componentSet` does
+   (`Prop=Value, Prop2=Value2`) — case-SENSITIVE splitting on `=`/`,`, but axis-value
+   **matching** below must be case-insensitive (see the headline warning).
+2. **Diff every variant against the default** by comparing the full serialized subtrees
+   (`ui.q(id, {depth:N})`), not a single "main interactive child" guess. Report the
+   changed paths — whatever they are, structural or visual.
+3. **Map to CSS pseudo-classes / ARIA attributes** for the state axis (rewritten in our
+   own words from the observed convention, not copied verbatim):
+
+   | State value | Selector |
+   |---|---|
+   | default | *(none)* |
+   | hover | `:hover` |
+   | focus / focus-visible / focused | `:focus-visible` |
+   | active / pressed | `:active` |
+   | disabled | `:disabled, [aria-disabled="true"]` |
+   | error / invalid | `[aria-invalid="true"]` |
+   | filled | `.has-value` |
+   | selected | `[aria-selected="true"]` |
+   | checked | `:checked` |
+   | loading | `[aria-busy="true"]` |
+   | readonly | `[readonly]` |
+   | open | `[aria-expanded="true"]` |
+   | closed | `[aria-expanded="false"]` |
+
+4. **Map property types to code props**: `BOOLEAN` → boolean prop, `TEXT` → string prop,
+   `INSTANCE_SWAP` → a slot/`ReactNode` prop, `VARIANT` → a union of the axis's
+   `variantOptions`. `SLOT` (Figma's named-slot property) maps to a named
+   slot/`children` prop — forward-reference to phase-02's slots/annotations work; not
+   built here.
+
+### Headline warning: match axis values case-insensitively
+
+**A conventionally-named set (`State=Default`, `State=Hover`, …) must still find its
+default variant.** A known prior implementation of this analysis (the fork this recipe
+studies) compares the RAW variant name against the literal lowercase string
+`'state=default'` — so a set authored `State=Default` (capitalized, the natural way to
+name a Figma variant) never matches, `defaultVariant` comes back null, and every diff
+silently comes back empty. Lower-case BOTH sides before comparing the axis name and its
+value; never compare a variant name against a literal-cased template.
+
+### No invented default, no invented "main interactive element"
+
+- If no axis value normalizes to `default` (case-insensitively), report
+  `defaultVariant: null` **plus the axis values actually found** — never guess a
+  stand-in. A caller with `defaultVariant: null` knows to look closer, not to trust a
+  silently-wrong pick.
+- A prior implementation studied here also picks one "main interactive" child per
+  variant (first child with strokes, else first FRAME child) to diff against. That
+  heuristic answers differently per component shape and can't be validated generically —
+  it was rejected here in favor of a full-subtree diff (§2 step 2) specifically so this
+  mistake doesn't get re-added later.

--- a/knowledge/variables-and-modes.md
+++ b/knowledge/variables-and-modes.md
@@ -1,0 +1,93 @@
+# Variables & modes — lifecycle over exec-js
+
+`ui.vars.*` (absorption phase-01, Basket B) covers the variable/mode operations the
+typed wire commands don't: rename, remove, describe, and per-mode add/rename/remove/set.
+Every helper here is **verified** — it re-reads what it wrote and throws `E_EVAL` if the
+canvas disagrees, never a "success" that didn't actually take.
+
+All snippets are `figma-agent exec-js` ready (async body, `ui` global, `return` a
+JSON-safe value). Companion: `knowledge/figma-craft/components-variables-styles.md`
+§3 (creation, tiers, binding) — this file is the lifecycle/mode side, not a duplicate.
+
+---
+
+## 1. Rename, describe, remove
+
+```js
+// Rename — ref is a VariableID: or an exact name.
+return await ui.vars.rename('color/old-name', 'color/new-name');
+// → { id, name: 'color/new-name', oldName: 'color/old-name' }
+
+// Describe — documents intent inline; shows in the Figma variables panel.
+return await ui.vars.describe('color/brand', 'Primary brand color, WCAG AA on white');
+// → { id, name, description }
+
+// Remove.
+return await ui.vars.remove('color/dead-token');
+// → { id, name, boundReferencesChecked: false }
+```
+
+- **`remove` never claims a bound-reference count it cannot back.** `figma.currentPage
+  .findAll` is page-scoped — a file-wide total built from it would silently under-report
+  on a multi-page file. Rather than lie with a number, `boundReferencesChecked` stays
+  `false` and no count is returned at all. `es-debt: page-scoped reference counting
+  omitted, not faked. Upgrade trigger: a real task needs the count, or a file-wide
+  bound-reference reader lands.`
+- `[re-verify]`: whether `Variable.remove()` leaves dangling `boundVariables` entries on
+  nodes that referenced it. Figma's own docs don't say; confirm on a real canvas before
+  relying on "removing a variable also clears every bind" as a fact.
+- Provenance: https://developers.figma.com/docs/plugins/api/figma-variables/
+
+## 2. Modes — add, rename, remove, set a value
+
+```js
+const col = (await figma.variables.getLocalVariableCollectionsAsync())
+  .find(c => c.name === 'Tokens');
+
+return await ui.vars.addMode(col.id, 'Dark');
+// → { collectionId, name, modes: [{modeId, name}, ...] }  — the FULL list read back,
+//   never just the caller's echoed name.
+
+return await ui.vars.renameMode(col.id, col.modes[0].modeId, 'Light');
+// → { collectionId, modes, oldName: 'Mode 1' }
+
+return await ui.vars.removeMode(col.id, darkModeId);
+// → { collectionId, modes }  — throws if that would remove the LAST mode (Figma
+//   itself refuses that); the message names the modes that remain.
+
+return await ui.vars.setModeValue('color/bg/surface', 'Dark', { r: 0.1, g: 0.1, b: 0.1, a: 1 });
+// → { id, name, mode: {modeId, name}, value }
+```
+
+- **`setModeValue` throws on an unknown mode name**, naming the modes that do exist —
+  the deliberate opposite of a bug this same phase fixed in the typed
+  `CREATE_VARIABLE --mode` command: that command used to silently set nothing and
+  report success when the mode name didn't match. Both now agree: a bad mode name is
+  always an error, never a quiet no-op.
+- **Free-plan mode caps are a thrown Figma error, not a warning** — `addMode` lets it
+  through (`in addMode: Limited to N modes only`) rather than swallowing it. That
+  swallow is correct for *token import* (`createVariablesFromTokens` in
+  `executor-variables.ts` intentionally does this so one blocked variable doesn't abort
+  a whole import) and wrong here, where the caller asked for this exact mode and needs
+  to know it didn't happen.
+- Mode limits, current as of Schema 2025: Starter 1 · Professional 10 · Organization 20
+  · Enterprise 40. Treat the exact number as plan- **and** date-dependent — the
+  authoritative check is the thrown message, not a memorized constant (see
+  `components-variables-styles.md` §3.1 for the full citation).
+
+## 3. The `--undo-group` caveat
+
+Every `ui.vars.*` call runs inside `exec-js`, which is a mutating command
+(`shared/mutating-commands.ts`) — each run seals its own undo step. Wrapping a script in
+`--undo-group` (`plugin/src/main/executor-exec-js.ts`) gives ONE revertible bracket over
+everything the script does, but the script itself must **never call
+`figma.commitUndo()`/`triggerUndo()`** — that's the bracket's own job, and a script that
+does it anyway breaks the sentinel the bracket uses to detect an empty run.
+
+```
+figma-agent exec-js --code '...builds several modes and variables...' --undo-group
+```
+
+If the script throws partway through, `--undo-group` rolls back **everything** it did —
+there is no need for (and `ui.componentSet`, this phase's other addition, deliberately
+does not add) hand-rolled per-object rollback bookkeeping on top of that bracket.

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -732,7 +732,13 @@
     const { variable, reused } = await createOrReuseVariable(collection, name, type, value);
     if (typeof params.mode === "string") {
       const mode = collection.modes.find((m) => m.name === params.mode);
-      if (mode) variable.setValueForMode(mode.modeId, value);
+      if (!mode) {
+        throw withCode(
+          new Error(`CREATE_VARIABLE mode "${params.mode}" not found on collection "${collection.name}" \u2014 available modes: ${collection.modes.map((m) => m.name).join(", ")}`),
+          "E_INVALID_ARGS"
+        );
+      }
+      variable.setValueForMode(mode.modeId, value);
     }
     return { id: variable.id, name: variable.name, reused };
   }
@@ -2513,6 +2519,295 @@
     return { id: inst.id, mainComponent: { id: component.id, name: component.name } };
   }
 
+  // plugin/src/main/exec-stdlib-variables.ts
+  async function resolveCollection(ref) {
+    const all = await figma.variables.getLocalVariableCollectionsAsync();
+    const byId = all.find((c) => c.id === ref);
+    if (byId) return byId;
+    const byName = all.find((c) => c.name === ref);
+    if (byName) return byName;
+    const names20 = all.slice(0, 20).map((c) => c.name).join(", ");
+    throw withCode(new Error(`collection not found: "${ref}" \u2014 available: ${names20}`), "E_INVALID_ARGS");
+  }
+  function modeList(collection) {
+    return collection.modes.map((m) => ({ modeId: m.modeId, name: m.name }));
+  }
+  function findMode(collection, modeId) {
+    const mode = collection.modes.find((m) => m.modeId === modeId);
+    if (!mode) {
+      throw withCode(
+        new Error(`mode not found: "${modeId}" on collection "${collection.name}" \u2014 available: ${collection.modes.map((m) => m.name).join(", ")}`),
+        "E_INVALID_ARGS"
+      );
+    }
+    return mode;
+  }
+  async function rename(ref, newName) {
+    if (typeof newName !== "string" || newName.length === 0) {
+      throw withCode(new Error("rename requires a non-empty newName"), "E_INVALID_ARGS");
+    }
+    const variable = await resolveVariable(ref);
+    const oldName = variable.name;
+    variable.name = newName;
+    if (variable.name !== newName) {
+      throw withCode(new Error(`rename applied but variable.name is still "${variable.name}"`), "E_EVAL");
+    }
+    return { id: variable.id, name: variable.name, oldName };
+  }
+  async function remove(ref) {
+    const variable = await resolveVariable(ref);
+    const id = variable.id;
+    const name = variable.name;
+    variable.remove();
+    return { id, name, boundReferencesChecked: false };
+  }
+  async function describe(ref, description) {
+    if (typeof description !== "string") {
+      throw withCode(new Error("describe requires a string description"), "E_INVALID_ARGS");
+    }
+    const variable = await resolveVariable(ref);
+    variable.description = description;
+    if (variable.description !== description) {
+      throw withCode(new Error(`describe applied but variable.description is still "${variable.description}"`), "E_EVAL");
+    }
+    return { id: variable.id, name: variable.name, description: variable.description };
+  }
+  async function addMode(collectionRef, modeName) {
+    if (typeof modeName !== "string" || modeName.length === 0) {
+      throw withCode(new Error("addMode requires a non-empty modeName"), "E_INVALID_ARGS");
+    }
+    const collection = await resolveCollection(collectionRef);
+    const before = collection.modes.length;
+    let modeId;
+    try {
+      modeId = collection.addMode(modeName);
+    } catch (err) {
+      throw withCode(new Error(`addMode "${modeName}" failed: ${String(err)}`), "E_EVAL");
+    }
+    if (collection.modes.length !== before + 1 || !collection.modes.some((m) => m.modeId === modeId)) {
+      throw withCode(new Error(`addMode "${modeName}" did not take \u2014 modes: ${collection.modes.map((m) => m.name).join(", ")}`), "E_EVAL");
+    }
+    return { collectionId: collection.id, name: collection.name, modes: modeList(collection) };
+  }
+  async function renameMode(collectionRef, modeId, newName) {
+    if (typeof newName !== "string" || newName.length === 0) {
+      throw withCode(new Error("renameMode requires a non-empty newName"), "E_INVALID_ARGS");
+    }
+    const collection = await resolveCollection(collectionRef);
+    const mode = findMode(collection, modeId);
+    const oldName = mode.name;
+    collection.renameMode(modeId, newName);
+    const after = findMode(collection, modeId);
+    if (after.name !== newName) {
+      throw withCode(new Error(`renameMode applied but mode "${modeId}" is still "${after.name}"`), "E_EVAL");
+    }
+    return { collectionId: collection.id, modes: modeList(collection), oldName };
+  }
+  async function removeMode(collectionRef, modeId) {
+    const collection = await resolveCollection(collectionRef);
+    findMode(collection, modeId);
+    collection.removeMode(modeId);
+    if (collection.modes.some((m) => m.modeId === modeId)) {
+      throw withCode(new Error(`removeMode applied but "${modeId}" is still present`), "E_EVAL");
+    }
+    return { collectionId: collection.id, modes: modeList(collection) };
+  }
+  async function setModeValue(ref, modeName, value) {
+    const variable = await resolveVariable(ref);
+    const collection = await resolveCollectionOfVariable(variable);
+    const mode = collection.modes.find((m) => m.name === modeName);
+    if (!mode) {
+      throw withCode(
+        new Error(`mode "${modeName}" not found on collection "${collection.name}" \u2014 available: ${collection.modes.map((m) => m.name).join(", ")}`),
+        "E_INVALID_ARGS"
+      );
+    }
+    variable.setValueForMode(mode.modeId, value);
+    const actual = variable.valuesByMode[mode.modeId];
+    const matches = variable.resolvedType === "COLOR" ? valuesEqual(actual, value) : actual === value;
+    if (!matches) {
+      throw withCode(new Error(`setModeValue applied but "${modeName}" reads back ${JSON.stringify(actual)}, not ${JSON.stringify(value)}`), "E_EVAL");
+    }
+    return { id: variable.id, name: variable.name, mode: { modeId: mode.modeId, name: mode.name }, value: actual };
+  }
+  async function resolveCollectionOfVariable(variable) {
+    const all = await figma.variables.getLocalVariableCollectionsAsync();
+    const collection = all.find((c) => c.id === variable.variableCollectionId);
+    if (!collection) {
+      throw withCode(new Error(`collection not found for variable "${variable.name}" (${variable.variableCollectionId})`), "E_EVAL");
+    }
+    return collection;
+  }
+  function createExecStdlibVars() {
+    return { rename, remove, describe, addMode, renameMode, removeMode, setModeValue };
+  }
+
+  // plugin/src/main/exec-stdlib-component-matrix.ts
+  var MAX_VARIANTS = 100;
+  var WARN_ABOVE = 40;
+  function assertCleanToken(kind, s) {
+    if (s.includes("=") || s.includes(",")) {
+      throw withCode(new Error(`${kind} "${s}" must not contain "=" or "," \u2014 Figma parses variant names on those characters`), "E_INVALID_ARGS");
+    }
+  }
+  function comboName(combo, axisOrder) {
+    return axisOrder.map((a) => `${a}=${combo[a]}`).join(", ");
+  }
+  function cartesianProduct(axes) {
+    const axisOrder = Object.keys(axes);
+    let combos = [{}];
+    for (const axis of axisOrder) {
+      const next = [];
+      for (const c of combos) for (const v of axes[axis]) next.push({ ...c, [axis]: v });
+      combos = next;
+    }
+    return combos;
+  }
+  function parseComboName(name) {
+    const out = {};
+    for (const part of name.split(", ")) {
+      const eq = part.indexOf("=");
+      if (eq === -1) continue;
+      out[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+    }
+    return out;
+  }
+  function sameAxisMap(a, b) {
+    const ak = Object.keys(a).sort();
+    const bk = Object.keys(b).sort();
+    if (ak.length !== bk.length || ak.some((k, i) => k !== bk[i])) return false;
+    return ak.every((k) => a[k] === b[k]);
+  }
+
+  // plugin/src/main/exec-stdlib-component-set.ts
+  async function resolveParent(ref) {
+    if (!ref) return figma.currentPage;
+    const node = await figma.getNodeByIdAsync(ref);
+    if (!node || !("appendChild" in node)) {
+      throw withCode(new Error(`parent not found or cannot contain a component set: ${ref}`), "E_INVALID_ARGS");
+    }
+    return node;
+  }
+  async function buildModeA(base, axes) {
+    const baseNode = await figma.getNodeByIdAsync(base);
+    if (!baseNode || baseNode.type !== "COMPONENT") {
+      throw withCode(new Error(`base must be a COMPONENT node id, got ${baseNode?.type ?? "not found"}: ${base}`), "E_INVALID_ARGS");
+    }
+    if (baseNode.parent?.type === "COMPONENT_SET") {
+      throw withCode(new Error(`base "${baseNode.name}" is already a variant inside "${baseNode.parent.name}"`), "E_INVALID_ARGS");
+    }
+    const axisOrder = Object.keys(axes);
+    for (const axis of axisOrder) {
+      assertCleanToken("axis", axis);
+      const values = axes[axis];
+      if (values.length === 0) throw withCode(new Error(`axis "${axis}" has no values`), "E_INVALID_ARGS");
+      for (const v of values) assertCleanToken("value", v);
+    }
+    const combos = cartesianProduct(axes);
+    if (combos.length > MAX_VARIANTS) {
+      throw withCode(new Error(`${combos.length} variants requested \u2014 capped at ${MAX_VARIANTS}. Split by one axis and build multiple sets.`), "E_INVALID_ARGS");
+    }
+    const stepY = Math.ceil(baseNode.height) + 40;
+    baseNode.name = comboName(combos[0], axisOrder);
+    const nodes = [baseNode];
+    for (let i = 1; i < combos.length; i++) {
+      const clone = baseNode.clone();
+      clone.name = comboName(combos[i], axisOrder);
+      clone.y = baseNode.y + i * stepY;
+      nodes.push(clone);
+    }
+    return { nodes, expected: combos };
+  }
+  async function buildModeB(ids, variantProps) {
+    if (ids.length > MAX_VARIANTS) {
+      throw withCode(new Error(`${ids.length} components requested \u2014 capped at ${MAX_VARIANTS}.`), "E_INVALID_ARGS");
+    }
+    if (variantProps && variantProps.length !== ids.length) {
+      throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), "E_INVALID_ARGS");
+    }
+    const nodes = [];
+    const expected = [];
+    const warnings2 = [];
+    for (let i = 0; i < ids.length; i++) {
+      const node = await figma.getNodeByIdAsync(ids[i]);
+      if (!node || node.type !== "COMPONENT") {
+        throw withCode(new Error(`components[${i}] must be a COMPONENT node id, got ${node?.type ?? "not found"}: ${ids[i]}`), "E_INVALID_ARGS");
+      }
+      if (node.parent?.type === "COMPONENT_SET") {
+        throw withCode(new Error(`components[${i}] "${node.name}" is already a variant inside "${node.parent.name}"`), "E_INVALID_ARGS");
+      }
+      if (variantProps) {
+        const props = variantProps[i];
+        const keys = Object.keys(props);
+        if (keys.length === 0) throw withCode(new Error(`variantProps[${i}] is empty \u2014 needs at least one property`), "E_INVALID_ARGS");
+        for (const k of keys) {
+          assertCleanToken("property", k);
+          assertCleanToken("value", props[k]);
+        }
+        node.name = comboName(props, keys);
+        expected.push({ ...props });
+      } else {
+        if (!node.name.includes("=")) {
+          warnings2.push(`component "${node.name}" is not named "Prop=Value" \u2014 Figma will file it under "Property 1=${node.name}"`);
+          expected.push({});
+        } else {
+          expected.push(parseComboName(node.name));
+        }
+      }
+      nodes.push(node);
+    }
+    return { nodes, expected, warnings: warnings2 };
+  }
+  async function componentSet(opts) {
+    const hasBase = typeof opts.base === "string";
+    const hasComponents = Array.isArray(opts.components) && opts.components.length > 0;
+    if (hasBase === hasComponents) {
+      throw withCode(new Error("componentSet needs exactly one of: base + axes, or components"), "E_INVALID_ARGS");
+    }
+    let nodes;
+    let expected;
+    let warnings2 = [];
+    if (hasBase) {
+      if (!opts.axes || Object.keys(opts.axes).length === 0) {
+        throw withCode(new Error('axes is required with base \u2014 e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), "E_INVALID_ARGS");
+      }
+      ({ nodes, expected } = await buildModeA(opts.base, opts.axes));
+    } else {
+      ({ nodes, expected, warnings: warnings2 } = await buildModeB(opts.components, opts.variantProps));
+    }
+    const parent = await resolveParent(opts.parent);
+    const set = figma.combineAsVariants(nodes, parent);
+    if (opts.name) set.name = opts.name;
+    if (typeof opts.x === "number") set.x = opts.x;
+    if (typeof opts.y === "number") set.y = opts.y;
+    const children = set.children.filter((c) => c.type === "COMPONENT");
+    if (children.length !== nodes.length) {
+      throw withCode(new Error(`componentSet combined ${children.length} children, expected ${nodes.length}`), "E_EVAL");
+    }
+    const actualAxes = children.map((c) => parseComboName(c.name));
+    const mismatches = expected.map((exp, i) => ({ i, exp, actual: actualAxes[i] })).filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
+    if (mismatches.length > 0) {
+      throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), "E_EVAL");
+    }
+    const propertyDefinitions = set.componentPropertyDefinitions ?? {};
+    const variantCount = children.length;
+    const sizeWarning = variantCount > WARN_ABOVE ? `${variantCount} variants \u2014 large sets are slow to build; consider splitting by one axis` : void 0;
+    return {
+      id: set.id,
+      name: set.name,
+      variantCount,
+      // Each variant's key AND id — instances come from a variant's key/id, never
+      // the set's (fork's hint, write-tools.ts ~3040).
+      variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i] })),
+      propertyDefinitions,
+      ...sizeWarning ? { sizeWarning } : {},
+      ...warnings2.length ? { warnings: warnings2 } : {}
+    };
+  }
+  function createExecStdlibComponentSet() {
+    return { componentSet };
+  }
+
   // plugin/src/main/exec-stdlib.ts
   var BOUND_FIELD_EXPANSIONS = {
     cornerRadius: ["cornerRadius", "topLeftRadius", "topRightRadius", "bottomLeftRadius", "bottomRightRadius"],
@@ -2602,7 +2897,16 @@
     return jsonSafe(fields ? projectSerialized(full, fields) : full);
   }
   function createExecStdlib() {
-    return { setProps, swapInstance, boundFill, byPath, q };
+    const { componentSet: componentSet2 } = createExecStdlibComponentSet();
+    return {
+      setProps,
+      swapInstance,
+      boundFill,
+      byPath,
+      q,
+      componentSet: componentSet2,
+      vars: createExecStdlibVars()
+    };
   }
 
   // plugin/src/main/exec-js-normalize.ts

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -625,11 +625,17 @@
     return all.find((c) => c.name === name) ?? figma.variables.createVariableCollection(name);
   }
   function valuesEqual(a, b) {
-    if (typeof a === "object" && a !== null && typeof b === "object" && b !== null && "r" in a && "r" in b) {
-      const ca = a;
-      const cb = b;
-      const eps = 1 / 512;
-      return Math.abs(ca.r - cb.r) < eps && Math.abs(ca.g - cb.g) < eps && Math.abs(ca.b - cb.b) < eps && Math.abs((ca.a ?? 1) - (cb.a ?? 1)) < eps;
+    if (typeof a === "object" && a !== null && typeof b === "object" && b !== null) {
+      if ("r" in a && "r" in b) {
+        const ca = a;
+        const cb = b;
+        const eps = 1 / 512;
+        return Math.abs(ca.r - cb.r) < eps && Math.abs(ca.g - cb.g) < eps && Math.abs(ca.b - cb.b) < eps && Math.abs((ca.a ?? 1) - (cb.a ?? 1)) < eps;
+      }
+      const aa = a;
+      const bb = b;
+      if (aa.type === "VARIABLE_ALIAS" && bb.type === "VARIABLE_ALIAS") return aa.id === bb.id;
+      return JSON.stringify(a) === JSON.stringify(b);
     }
     return a === b;
   }
@@ -2520,14 +2526,21 @@
   }
 
   // plugin/src/main/exec-stdlib-variables.ts
+  function listWithMore(names, cap = 20) {
+    const shown = names.slice(0, cap).join(", ");
+    const rest = names.length - cap;
+    return rest > 0 ? `${shown} (+${rest} more)` : shown;
+  }
   async function resolveCollection(ref) {
     const all = await figma.variables.getLocalVariableCollectionsAsync();
     const byId = all.find((c) => c.id === ref);
     if (byId) return byId;
     const byName = all.find((c) => c.name === ref);
     if (byName) return byName;
-    const names20 = all.slice(0, 20).map((c) => c.name).join(", ");
-    throw withCode(new Error(`collection not found: "${ref}" \u2014 available: ${names20}`), "E_INVALID_ARGS");
+    throw withCode(
+      new Error(`collection not found: "${ref}" \u2014 available: ${listWithMore(all.map((c) => c.name))}`),
+      "E_INVALID_ARGS"
+    );
   }
   function modeList(collection) {
     return collection.modes.map((m) => ({ modeId: m.modeId, name: m.name }));
@@ -2536,7 +2549,7 @@
     const mode = collection.modes.find((m) => m.modeId === modeId);
     if (!mode) {
       throw withCode(
-        new Error(`mode not found: "${modeId}" on collection "${collection.name}" \u2014 available: ${collection.modes.map((m) => m.name).join(", ")}`),
+        new Error(`mode not found: "${modeId}" on collection "${collection.name}" \u2014 available: ${listWithMore(collection.modes.map((m) => m.name))}`),
         "E_INVALID_ARGS"
       );
     }
@@ -2618,14 +2631,13 @@
     const mode = collection.modes.find((m) => m.name === modeName);
     if (!mode) {
       throw withCode(
-        new Error(`mode "${modeName}" not found on collection "${collection.name}" \u2014 available: ${collection.modes.map((m) => m.name).join(", ")}`),
+        new Error(`mode "${modeName}" not found on collection "${collection.name}" \u2014 available: ${listWithMore(collection.modes.map((m) => m.name))}`),
         "E_INVALID_ARGS"
       );
     }
     variable.setValueForMode(mode.modeId, value);
     const actual = variable.valuesByMode[mode.modeId];
-    const matches = variable.resolvedType === "COLOR" ? valuesEqual(actual, value) : actual === value;
-    if (!matches) {
+    if (!valuesEqual(actual, value)) {
       throw withCode(new Error(`setModeValue applied but "${modeName}" reads back ${JSON.stringify(actual)}, not ${JSON.stringify(value)}`), "E_EVAL");
     }
     return { id: variable.id, name: variable.name, mode: { modeId: mode.modeId, name: mode.name }, value: actual };
@@ -2679,15 +2691,7 @@
     return ak.every((k) => a[k] === b[k]);
   }
 
-  // plugin/src/main/exec-stdlib-component-set.ts
-  async function resolveParent(ref) {
-    if (!ref) return figma.currentPage;
-    const node = await figma.getNodeByIdAsync(ref);
-    if (!node || !("appendChild" in node)) {
-      throw withCode(new Error(`parent not found or cannot contain a component set: ${ref}`), "E_INVALID_ARGS");
-    }
-    return node;
-  }
+  // plugin/src/main/exec-stdlib-component-build.ts
   async function buildModeA(base, axes) {
     const baseNode = await figma.getNodeByIdAsync(base);
     if (!baseNode || baseNode.type !== "COMPONENT") {
@@ -2707,6 +2711,7 @@
     if (combos.length > MAX_VARIANTS) {
       throw withCode(new Error(`${combos.length} variants requested \u2014 capped at ${MAX_VARIANTS}. Split by one axis and build multiple sets.`), "E_INVALID_ARGS");
     }
+    const originalBaseName = baseNode.name;
     const stepY = Math.ceil(baseNode.height) + 40;
     baseNode.name = comboName(combos[0], axisOrder);
     const nodes = [baseNode];
@@ -2716,7 +2721,16 @@
       clone.y = baseNode.y + i * stepY;
       nodes.push(clone);
     }
-    return { nodes, expected: combos };
+    const clones = nodes.slice(1);
+    return {
+      nodes,
+      expected: combos,
+      warnings: [],
+      cleanup() {
+        for (const c of clones) c.remove();
+        baseNode.name = originalBaseName;
+      }
+    };
   }
   async function buildModeB(ids, variantProps) {
     if (ids.length > MAX_VARIANTS) {
@@ -2728,6 +2742,7 @@
     const nodes = [];
     const expected = [];
     const warnings2 = [];
+    const renamed = [];
     for (let i = 0; i < ids.length; i++) {
       const node = await figma.getNodeByIdAsync(ids[i]);
       if (!node || node.type !== "COMPONENT") {
@@ -2744,6 +2759,7 @@
           assertCleanToken("property", k);
           assertCleanToken("value", props[k]);
         }
+        renamed.push({ node, originalName: node.name });
         node.name = comboName(props, keys);
         expected.push({ ...props });
       } else {
@@ -2756,7 +2772,25 @@
       }
       nodes.push(node);
     }
-    return { nodes, expected, warnings: warnings2 };
+    return {
+      nodes,
+      expected,
+      warnings: warnings2,
+      cleanup() {
+        for (const { node, originalName } of renamed) node.name = originalName;
+      }
+    };
+  }
+
+  // plugin/src/main/exec-stdlib-component-set.ts
+  var VALID_PARENT_TYPES = /* @__PURE__ */ new Set(["PAGE", "FRAME", "SECTION", "GROUP"]);
+  async function resolveParent(ref) {
+    if (!ref) return figma.currentPage;
+    const node = await figma.getNodeByIdAsync(ref);
+    if (!node || !VALID_PARENT_TYPES.has(node.type)) {
+      throw withCode(new Error(`parent not found or cannot contain a component set: ${ref}`), "E_INVALID_ARGS");
+    }
+    return node;
   }
   async function componentSet(opts) {
     const hasBase = typeof opts.base === "string";
@@ -2764,45 +2798,43 @@
     if (hasBase === hasComponents) {
       throw withCode(new Error("componentSet needs exactly one of: base + axes, or components"), "E_INVALID_ARGS");
     }
-    let nodes;
-    let expected;
-    let warnings2 = [];
-    if (hasBase) {
-      if (!opts.axes || Object.keys(opts.axes).length === 0) {
-        throw withCode(new Error('axes is required with base \u2014 e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), "E_INVALID_ARGS");
+    if (hasBase && (!opts.axes || Object.keys(opts.axes).length === 0)) {
+      throw withCode(new Error('axes is required with base \u2014 e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), "E_INVALID_ARGS");
+    }
+    const build = hasBase ? await buildModeA(opts.base, opts.axes) : await buildModeB(opts.components, opts.variantProps);
+    try {
+      const parent = await resolveParent(opts.parent);
+      const set = figma.combineAsVariants(build.nodes, parent);
+      if (opts.name) set.name = opts.name;
+      if (typeof opts.x === "number") set.x = opts.x;
+      if (typeof opts.y === "number") set.y = opts.y;
+      const children = set.children.filter((c) => c.type === "COMPONENT");
+      if (children.length !== build.nodes.length) {
+        throw withCode(new Error(`componentSet combined ${children.length} children, expected ${build.nodes.length}`), "E_EVAL");
       }
-      ({ nodes, expected } = await buildModeA(opts.base, opts.axes));
-    } else {
-      ({ nodes, expected, warnings: warnings2 } = await buildModeB(opts.components, opts.variantProps));
+      const actualAxes = children.map((c) => parseComboName(c.name));
+      const mismatches = build.expected.map((exp, i) => ({ i, exp, actual: actualAxes[i] })).filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
+      if (mismatches.length > 0) {
+        throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), "E_EVAL");
+      }
+      const propertyDefinitions = set.componentPropertyDefinitions ?? {};
+      const variantCount = children.length;
+      const sizeWarning = variantCount > WARN_ABOVE ? `${variantCount} variants \u2014 large sets are slow to build; consider splitting by one axis` : void 0;
+      return {
+        id: set.id,
+        name: set.name,
+        variantCount,
+        // Each variant's key AND id — instances come from a variant's key/id, never
+        // the set's (fork's hint, write-tools.ts ~3040).
+        variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i] })),
+        propertyDefinitions,
+        ...sizeWarning ? { sizeWarning } : {},
+        ...build.warnings.length ? { warnings: build.warnings } : {}
+      };
+    } catch (err) {
+      build.cleanup();
+      throw err;
     }
-    const parent = await resolveParent(opts.parent);
-    const set = figma.combineAsVariants(nodes, parent);
-    if (opts.name) set.name = opts.name;
-    if (typeof opts.x === "number") set.x = opts.x;
-    if (typeof opts.y === "number") set.y = opts.y;
-    const children = set.children.filter((c) => c.type === "COMPONENT");
-    if (children.length !== nodes.length) {
-      throw withCode(new Error(`componentSet combined ${children.length} children, expected ${nodes.length}`), "E_EVAL");
-    }
-    const actualAxes = children.map((c) => parseComboName(c.name));
-    const mismatches = expected.map((exp, i) => ({ i, exp, actual: actualAxes[i] })).filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
-    if (mismatches.length > 0) {
-      throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), "E_EVAL");
-    }
-    const propertyDefinitions = set.componentPropertyDefinitions ?? {};
-    const variantCount = children.length;
-    const sizeWarning = variantCount > WARN_ABOVE ? `${variantCount} variants \u2014 large sets are slow to build; consider splitting by one axis` : void 0;
-    return {
-      id: set.id,
-      name: set.name,
-      variantCount,
-      // Each variant's key AND id — instances come from a variant's key/id, never
-      // the set's (fork's hint, write-tools.ts ~3040).
-      variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i] })),
-      propertyDefinitions,
-      ...sizeWarning ? { sizeWarning } : {},
-      ...warnings2.length ? { warnings: warnings2 } : {}
-    };
   }
   function createExecStdlibComponentSet() {
     return { componentSet };

--- a/plugin/src/main/exec-stdlib-component-build.ts
+++ b/plugin/src/main/exec-stdlib-component-build.ts
@@ -1,0 +1,115 @@
+// Mode-specific node preparation behind `ui.componentSet(...)` — split out of
+// exec-stdlib-component-set.ts to stay under this repo's 200-line cap. Each build
+// function mutates the canvas (renames, clones) and returns a `cleanup()` that
+// reverses EXACTLY those mutations — the caller (componentSet()) invokes it if a
+// LATER step (parent resolution, combineAsVariants, verification) throws, so a
+// self-inflicted failure never leaves a renamed base or an orphan clone behind
+// (stage-4 review, PR #10 issue 2). This is a compensating action for THIS helper's
+// own mutations, not a second undo system — `--undo-group` still covers everything
+// else in the script; knowledge/component-sets.md states that requirement plainly.
+import { withCode } from './executor-styles';
+import {
+  MAX_VARIANTS, assertCleanToken, comboName, cartesianProduct, parseComboName,
+} from './exec-stdlib-component-matrix';
+
+export interface BuildResult {
+  nodes: ComponentNode[];
+  expected: Record<string, string>[];
+  warnings: string[];
+  /** Reverse exactly the mutations THIS build made — safe to call multiple times. */
+  cleanup(): void;
+}
+
+export async function buildModeA(base: string, axes: Record<string, string[]>): Promise<BuildResult> {
+  const baseNode = await figma.getNodeByIdAsync(base);
+  if (!baseNode || baseNode.type !== 'COMPONENT') {
+    throw withCode(new Error(`base must be a COMPONENT node id, got ${baseNode?.type ?? 'not found'}: ${base}`), 'E_INVALID_ARGS');
+  }
+  if (baseNode.parent?.type === 'COMPONENT_SET') {
+    throw withCode(new Error(`base "${baseNode.name}" is already a variant inside "${baseNode.parent.name}"`), 'E_INVALID_ARGS');
+  }
+  const axisOrder = Object.keys(axes);
+  for (const axis of axisOrder) {
+    assertCleanToken('axis', axis);
+    const values = axes[axis]!;
+    if (values.length === 0) throw withCode(new Error(`axis "${axis}" has no values`), 'E_INVALID_ARGS');
+    for (const v of values) assertCleanToken('value', v);
+  }
+  const combos = cartesianProduct(axes);
+  if (combos.length > MAX_VARIANTS) {
+    throw withCode(new Error(`${combos.length} variants requested — capped at ${MAX_VARIANTS}. Split by one axis and build multiple sets.`), 'E_INVALID_ARGS');
+  }
+  // Snapshot BEFORE any mutation — the ruling this cleanup follows: restore the
+  // base's name on ANY later failure of this call, not only a verification mismatch
+  // (stage-4 review reviewer question, ruled: yes, independent of issue 2's fix).
+  const originalBaseName = baseNode.name;
+  const stepY = Math.ceil(baseNode.height) + 40;
+  baseNode.name = comboName(combos[0]!, axisOrder);
+  const nodes: ComponentNode[] = [baseNode];
+  for (let i = 1; i < combos.length; i++) {
+    const clone = baseNode.clone() as ComponentNode;
+    clone.name = comboName(combos[i]!, axisOrder);
+    clone.y = baseNode.y + i * stepY;
+    nodes.push(clone);
+  }
+  const clones = nodes.slice(1);
+  return {
+    nodes, expected: combos, warnings: [],
+    cleanup(): void {
+      for (const c of clones) c.remove();
+      baseNode.name = originalBaseName;
+    },
+  };
+}
+
+export async function buildModeB(
+  ids: string[],
+  variantProps: Record<string, string>[] | undefined,
+): Promise<BuildResult> {
+  if (ids.length > MAX_VARIANTS) {
+    throw withCode(new Error(`${ids.length} components requested — capped at ${MAX_VARIANTS}.`), 'E_INVALID_ARGS');
+  }
+  if (variantProps && variantProps.length !== ids.length) {
+    throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), 'E_INVALID_ARGS');
+  }
+  const nodes: ComponentNode[] = [];
+  const expected: Record<string, string>[] = [];
+  const warnings: string[] = [];
+  const renamed: { node: ComponentNode; originalName: string }[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const node = await figma.getNodeByIdAsync(ids[i]!);
+    if (!node || node.type !== 'COMPONENT') {
+      throw withCode(new Error(`components[${i}] must be a COMPONENT node id, got ${node?.type ?? 'not found'}: ${ids[i]}`), 'E_INVALID_ARGS');
+    }
+    if (node.parent?.type === 'COMPONENT_SET') {
+      throw withCode(new Error(`components[${i}] "${node.name}" is already a variant inside "${node.parent.name}"`), 'E_INVALID_ARGS');
+    }
+    if (variantProps) {
+      const props = variantProps[i]!;
+      const keys = Object.keys(props);
+      if (keys.length === 0) throw withCode(new Error(`variantProps[${i}] is empty — needs at least one property`), 'E_INVALID_ARGS');
+      for (const k of keys) { assertCleanToken('property', k); assertCleanToken('value', props[k]!); }
+      renamed.push({ node: node as ComponentNode, originalName: node.name });
+      node.name = comboName(props, keys);
+      expected.push({ ...props });
+    } else {
+      // Figma turns a name lacking "=" into "Property 1=<name>" `[re-verify]` — warn
+      // rather than silently accept an axis the caller did not choose. We did NOT
+      // rename this node, so there is no axis map of OUR intent to verify against —
+      // the post-combine check only holds it to "it survived", never a fabricated map.
+      if (!node.name.includes('=')) {
+        warnings.push(`component "${node.name}" is not named "Prop=Value" — Figma will file it under "Property 1=${node.name}"`);
+        expected.push({});
+      } else {
+        expected.push(parseComboName(node.name));
+      }
+    }
+    nodes.push(node as ComponentNode);
+  }
+  return {
+    nodes, expected, warnings,
+    cleanup(): void {
+      for (const { node, originalName } of renamed) node.name = originalName;
+    },
+  };
+}

--- a/plugin/src/main/exec-stdlib-component-matrix.ts
+++ b/plugin/src/main/exec-stdlib-component-matrix.ts
@@ -1,0 +1,55 @@
+// Pure helpers behind `ui.componentSet(...)` (exec-stdlib-component-set.ts) — split out
+// so that file stays under the repo's 200-line cap (the same split-by-shape convention
+// as exec-stdlib-instance.ts). No `figma` global here, so these are unit-testable without
+// a live plugin or a mock — the cartesian-order determinism and the `=`/`,` rejection
+// are asserted directly against these functions.
+import { withCode } from './executor-styles';
+
+export const MAX_VARIANTS = 100;
+export const WARN_ABOVE = 40;
+
+/** Figma parses variant names on `=`/`,` — a value carrying either would silently
+ * split into a bogus extra axis. Reject before creating anything (adapted from the
+ * fork's own constraint, write-tools.ts:2843-2846 — see THIRD-PARTY.md). */
+export function assertCleanToken(kind: 'axis' | 'value' | 'property', s: string): void {
+  if (s.includes('=') || s.includes(',')) {
+    throw withCode(new Error(`${kind} "${s}" must not contain "=" or "," — Figma parses variant names on those characters`), 'E_INVALID_ARGS');
+  }
+}
+
+export function comboName(combo: Record<string, string>, axisOrder: readonly string[]): string {
+  return axisOrder.map((a) => `${a}=${combo[a]}`).join(', ');
+}
+
+/** Deterministic cartesian product — axis insertion order, values in given order
+ * (Article I: a nondeterministic variant order makes the matrix untestable). */
+export function cartesianProduct(axes: Record<string, readonly string[]>): Record<string, string>[] {
+  const axisOrder = Object.keys(axes);
+  let combos: Record<string, string>[] = [{}];
+  for (const axis of axisOrder) {
+    const next: Record<string, string>[] = [];
+    for (const c of combos) for (const v of axes[axis]!) next.push({ ...c, [axis]: v });
+    combos = next;
+  }
+  return combos;
+}
+
+/** Parse a built variant's "Prop=Value, ..." name back into an axis map, for the
+ * post-combine verification (§5.2 rule 7: every child name must parse back to the
+ * intended map). */
+export function parseComboName(name: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const part of name.split(', ')) {
+    const eq = part.indexOf('=');
+    if (eq === -1) continue;
+    out[part.slice(0, eq).trim()] = part.slice(eq + 1).trim();
+  }
+  return out;
+}
+
+export function sameAxisMap(a: Record<string, string>, b: Record<string, string>): boolean {
+  const ak = Object.keys(a).sort();
+  const bk = Object.keys(b).sort();
+  if (ak.length !== bk.length || ak.some((k, i) => k !== bk[i])) return false;
+  return ak.every((k) => a[k] === b[k]);
+}

--- a/plugin/src/main/exec-stdlib-component-set.ts
+++ b/plugin/src/main/exec-stdlib-component-set.ts
@@ -2,17 +2,18 @@
 // components (absorption phase-01, Basket B). Adapted from the fork's
 // figma_create_component_set (MIT; see THIRD-PARTY.md) — the mode contract, the
 // axis/value `=`/`,` ban, and the 100-combination cap are its constraints, ported
-// deliberately. NOT ported: its manual clone/rename rollback bookkeeping — this repo's
-// EXEC_JS `--undo-group` (executor-exec-js.ts) already gives a caller one atomic undo
-// step over the whole script via Figma's own undo stack, so a second, hand-rolled
-// rollback here would duplicate (and could race) what the bracket already guarantees.
-// A caller who wants atomicity uses `--undo-group`, same as any other mutating script.
-// Pure matrix helpers (cartesian product, name parsing, token validation) live in
-// exec-stdlib-component-matrix.ts — split out to stay under this file's 200-line cap.
+// deliberately. NOT ported: its manual clone/rename rollback bookkeeping AS A
+// GENERAL-PURPOSE SYSTEM — this repo's own EXEC_JS `--undo-group`
+// (executor-exec-js.ts) already gives a caller one atomic undo step over the WHOLE
+// script via Figma's own undo stack. What IS ported, narrowly: this function still
+// cleans up its OWN mutations (rename/clone) if ITS OWN later step throws — see
+// exec-stdlib-component-build.ts's `cleanup()`. That is a compensating action scoped
+// to this one call, not a second undo system, and it does not substitute for
+// `--undo-group`, which a caller MUST use for atomicity against a failure elsewhere
+// in the same script (stated in knowledge/component-sets.md).
 import { withCode } from './executor-styles';
-import {
-  MAX_VARIANTS, WARN_ABOVE, assertCleanToken, comboName, cartesianProduct, parseComboName, sameAxisMap,
-} from './exec-stdlib-component-matrix';
+import { WARN_ABOVE, parseComboName, sameAxisMap } from './exec-stdlib-component-matrix';
+import { buildModeA, buildModeB } from './exec-stdlib-component-build';
 
 export interface ComponentSetOpts {
   base?: string;
@@ -39,94 +40,20 @@ export interface ComponentSetResult {
   warnings?: string[];
 }
 
+// Real containers a COMPONENT_SET can sensibly live in. `appendChild in node` alone
+// (the previous check) also passes for COMPONENT/COMPONENT_SET/INSTANCE — nodes that
+// combineAsVariants would only reject LATER, after the build step already renamed
+// the base and cloned it (stage-4 review, PR #10 minor 6 — one guard earlier than
+// issue 2's own self-inflicted-mutation window).
+const VALID_PARENT_TYPES = new Set(['PAGE', 'FRAME', 'SECTION', 'GROUP']);
+
 async function resolveParent(ref: string | undefined): Promise<BaseNode & ChildrenMixin> {
   if (!ref) return figma.currentPage;
   const node = await figma.getNodeByIdAsync(ref);
-  if (!node || !('appendChild' in node)) {
+  if (!node || !VALID_PARENT_TYPES.has(node.type)) {
     throw withCode(new Error(`parent not found or cannot contain a component set: ${ref}`), 'E_INVALID_ARGS');
   }
   return node as BaseNode & ChildrenMixin;
-}
-
-async function buildModeA(base: string, axes: Record<string, string[]>): Promise<{ nodes: ComponentNode[]; expected: Record<string, string>[] }> {
-  const baseNode = await figma.getNodeByIdAsync(base);
-  if (!baseNode || baseNode.type !== 'COMPONENT') {
-    throw withCode(new Error(`base must be a COMPONENT node id, got ${baseNode?.type ?? 'not found'}: ${base}`), 'E_INVALID_ARGS');
-  }
-  if (baseNode.parent?.type === 'COMPONENT_SET') {
-    throw withCode(new Error(`base "${baseNode.name}" is already a variant inside "${baseNode.parent.name}"`), 'E_INVALID_ARGS');
-  }
-  const axisOrder = Object.keys(axes);
-  for (const axis of axisOrder) {
-    assertCleanToken('axis', axis);
-    const values = axes[axis]!;
-    if (values.length === 0) throw withCode(new Error(`axis "${axis}" has no values`), 'E_INVALID_ARGS');
-    for (const v of values) assertCleanToken('value', v);
-  }
-  const combos = cartesianProduct(axes);
-  if (combos.length > MAX_VARIANTS) {
-    throw withCode(new Error(`${combos.length} variants requested — capped at ${MAX_VARIANTS}. Split by one axis and build multiple sets.`), 'E_INVALID_ARGS');
-  }
-  // Base becomes the first variant (keeps its node id — existing instances of the
-  // base survive as instances of that variant); clones fill the rest, stacked
-  // vertically so nothing overlaps before the caller lays the set out.
-  const stepY = Math.ceil(baseNode.height) + 40;
-  baseNode.name = comboName(combos[0]!, axisOrder);
-  const nodes: ComponentNode[] = [baseNode];
-  for (let i = 1; i < combos.length; i++) {
-    const clone = baseNode.clone() as ComponentNode;
-    clone.name = comboName(combos[i]!, axisOrder);
-    clone.y = baseNode.y + i * stepY;
-    nodes.push(clone);
-  }
-  return { nodes, expected: combos };
-}
-
-async function buildModeB(
-  ids: string[],
-  variantProps: Record<string, string>[] | undefined,
-): Promise<{ nodes: ComponentNode[]; expected: Record<string, string>[]; warnings: string[] }> {
-  if (ids.length > MAX_VARIANTS) {
-    throw withCode(new Error(`${ids.length} components requested — capped at ${MAX_VARIANTS}.`), 'E_INVALID_ARGS');
-  }
-  if (variantProps && variantProps.length !== ids.length) {
-    throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), 'E_INVALID_ARGS');
-  }
-  const nodes: ComponentNode[] = [];
-  const expected: Record<string, string>[] = [];
-  const warnings: string[] = [];
-  for (let i = 0; i < ids.length; i++) {
-    const node = await figma.getNodeByIdAsync(ids[i]!);
-    if (!node || node.type !== 'COMPONENT') {
-      throw withCode(new Error(`components[${i}] must be a COMPONENT node id, got ${node?.type ?? 'not found'}: ${ids[i]}`), 'E_INVALID_ARGS');
-    }
-    if (node.parent?.type === 'COMPONENT_SET') {
-      throw withCode(new Error(`components[${i}] "${node.name}" is already a variant inside "${node.parent.name}"`), 'E_INVALID_ARGS');
-    }
-    if (variantProps) {
-      const props = variantProps[i]!;
-      const keys = Object.keys(props);
-      if (keys.length === 0) throw withCode(new Error(`variantProps[${i}] is empty — needs at least one property`), 'E_INVALID_ARGS');
-      for (const k of keys) { assertCleanToken('property', k); assertCleanToken('value', props[k]!); }
-      node.name = comboName(props, keys);
-      expected.push({ ...props });
-    } else {
-      // Figma turns a name lacking "=" into "Property 1=<name>" `[re-verify]` — warn
-      // rather than silently accept an axis the caller did not choose (fork's own
-      // warning shape, adapted). We did NOT rename this node, so there is no axis
-      // map of OUR intent to verify against — asserting one would invent a fact the
-      // `[re-verify]` tag says is still unconfirmed; the post-combine check below
-      // only holds this node to "it survived", never to a fabricated axis map.
-      if (!node.name.includes('=')) {
-        warnings.push(`component "${node.name}" is not named "Prop=Value" — Figma will file it under "Property 1=${node.name}"`);
-        expected.push({});
-      } else {
-        expected.push(parseComboName(node.name));
-      }
-    }
-    nodes.push(node as ComponentNode);
-  }
-  return { nodes, expected, warnings };
 }
 
 async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult> {
@@ -135,55 +62,60 @@ async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult>
   if (hasBase === hasComponents) {
     throw withCode(new Error('componentSet needs exactly one of: base + axes, or components'), 'E_INVALID_ARGS');
   }
-  let nodes: ComponentNode[];
-  let expected: Record<string, string>[];
-  let warnings: string[] = [];
-  if (hasBase) {
-    if (!opts.axes || Object.keys(opts.axes).length === 0) {
-      throw withCode(new Error('axes is required with base — e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), 'E_INVALID_ARGS');
+  if (hasBase && (!opts.axes || Object.keys(opts.axes).length === 0)) {
+    throw withCode(new Error('axes is required with base — e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), 'E_INVALID_ARGS');
+  }
+  const build = hasBase
+    ? await buildModeA(opts.base!, opts.axes!)
+    : await buildModeB(opts.components!, opts.variantProps);
+
+  // Everything below can fail AFTER build already renamed/cloned — on any throw in
+  // this window, reverse exactly what build() did, then let the original error
+  // (code and message intact) propagate. This is the ruling from the reviewer's
+  // question: restore independently of WHY it failed, not only on a verify mismatch.
+  try {
+    const parent = await resolveParent(opts.parent);
+    const set = figma.combineAsVariants(build.nodes, parent);
+    if (opts.name) set.name = opts.name;
+    if (typeof opts.x === 'number') set.x = opts.x;
+    if (typeof opts.y === 'number') set.y = opts.y;
+
+    // Verify: the combined set's own children must match what we intended — a
+    // mismatch (Figma's own name-parsing disagreeing with ours) throws with both
+    // lists rather than reporting a count that quietly drifted from reality.
+    const children = set.children.filter((c): c is ComponentNode => c.type === 'COMPONENT');
+    if (children.length !== build.nodes.length) {
+      throw withCode(new Error(`componentSet combined ${children.length} children, expected ${build.nodes.length}`), 'E_EVAL');
     }
-    ({ nodes, expected } = await buildModeA(opts.base!, opts.axes));
-  } else {
-    ({ nodes, expected, warnings } = await buildModeB(opts.components!, opts.variantProps));
-  }
-  const parent = await resolveParent(opts.parent);
-  const set = figma.combineAsVariants(nodes, parent);
-  if (opts.name) set.name = opts.name;
-  if (typeof opts.x === 'number') set.x = opts.x;
-  if (typeof opts.y === 'number') set.y = opts.y;
+    const actualAxes = children.map((c) => parseComboName(c.name));
+    const mismatches = build.expected
+      .map((exp, i) => ({ i, exp, actual: actualAxes[i] }))
+      .filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
+    if (mismatches.length > 0) {
+      throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), 'E_EVAL');
+    }
 
-  // Verify: the combined set's own children must match what we intended — a
-  // mismatch (Figma's own name-parsing disagreeing with ours) throws with both
-  // lists rather than reporting a count that quietly drifted from reality.
-  const children = set.children.filter((c): c is ComponentNode => c.type === 'COMPONENT');
-  if (children.length !== nodes.length) {
-    throw withCode(new Error(`componentSet combined ${children.length} children, expected ${nodes.length}`), 'E_EVAL');
-  }
-  const actualAxes = children.map((c) => parseComboName(c.name));
-  const mismatches = expected
-    .map((exp, i) => ({ i, exp, actual: actualAxes[i] }))
-    .filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
-  if (mismatches.length > 0) {
-    throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), 'E_EVAL');
-  }
+    const propertyDefinitions = (set.componentPropertyDefinitions ?? {}) as Record<string, unknown>;
+    const variantCount = children.length;
+    const sizeWarning = variantCount > WARN_ABOVE
+      ? `${variantCount} variants — large sets are slow to build; consider splitting by one axis`
+      : undefined;
 
-  const propertyDefinitions = (set.componentPropertyDefinitions ?? {}) as Record<string, unknown>;
-  const variantCount = children.length;
-  const sizeWarning = variantCount > WARN_ABOVE
-    ? `${variantCount} variants — large sets are slow to build; consider splitting by one axis`
-    : undefined;
-
-  return {
-    id: set.id,
-    name: set.name,
-    variantCount,
-    // Each variant's key AND id — instances come from a variant's key/id, never
-    // the set's (fork's hint, write-tools.ts ~3040).
-    variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i]! })),
-    propertyDefinitions,
-    ...(sizeWarning ? { sizeWarning } : {}),
-    ...(warnings.length ? { warnings } : {}),
-  };
+    return {
+      id: set.id,
+      name: set.name,
+      variantCount,
+      // Each variant's key AND id — instances come from a variant's key/id, never
+      // the set's (fork's hint, write-tools.ts ~3040).
+      variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i]! })),
+      propertyDefinitions,
+      ...(sizeWarning ? { sizeWarning } : {}),
+      ...(build.warnings.length ? { warnings: build.warnings } : {}),
+    };
+  } catch (err) {
+    build.cleanup();
+    throw err;
+  }
 }
 
 export interface ExecStdlibComponentSet {

--- a/plugin/src/main/exec-stdlib-component-set.ts
+++ b/plugin/src/main/exec-stdlib-component-set.ts
@@ -1,0 +1,195 @@
+// `ui.componentSet(...)` — build a COMPONENT_SET from a variant matrix or existing
+// components (absorption phase-01, Basket B). Adapted from the fork's
+// figma_create_component_set (MIT; see THIRD-PARTY.md) — the mode contract, the
+// axis/value `=`/`,` ban, and the 100-combination cap are its constraints, ported
+// deliberately. NOT ported: its manual clone/rename rollback bookkeeping — this repo's
+// EXEC_JS `--undo-group` (executor-exec-js.ts) already gives a caller one atomic undo
+// step over the whole script via Figma's own undo stack, so a second, hand-rolled
+// rollback here would duplicate (and could race) what the bracket already guarantees.
+// A caller who wants atomicity uses `--undo-group`, same as any other mutating script.
+// Pure matrix helpers (cartesian product, name parsing, token validation) live in
+// exec-stdlib-component-matrix.ts — split out to stay under this file's 200-line cap.
+import { withCode } from './executor-styles';
+import {
+  MAX_VARIANTS, WARN_ABOVE, assertCleanToken, comboName, cartesianProduct, parseComboName, sameAxisMap,
+} from './exec-stdlib-component-matrix';
+
+export interface ComponentSetOpts {
+  base?: string;
+  axes?: Record<string, string[]>;
+  components?: string[];
+  variantProps?: Record<string, string>[];
+  name?: string;
+  parent?: string;
+  x?: number;
+  y?: number;
+}
+
+export interface ComponentSetResult {
+  id: string;
+  name: string;
+  variantCount: number;
+  variants: { id: string; name: string; key: string; axes: Record<string, string> }[];
+  propertyDefinitions: Record<string, unknown>;
+  sizeWarning?: string;
+  // Additive beyond the plan's named shape (deliberate, reported): mode 2 without
+  // variantProps can leave a component named without "=", which Figma silently
+  // re-homes under "Property 1=<name>" — surfacing that as a runtime warning
+  // seemed more honest than only saying it in the recipe prose.
+  warnings?: string[];
+}
+
+async function resolveParent(ref: string | undefined): Promise<BaseNode & ChildrenMixin> {
+  if (!ref) return figma.currentPage;
+  const node = await figma.getNodeByIdAsync(ref);
+  if (!node || !('appendChild' in node)) {
+    throw withCode(new Error(`parent not found or cannot contain a component set: ${ref}`), 'E_INVALID_ARGS');
+  }
+  return node as BaseNode & ChildrenMixin;
+}
+
+async function buildModeA(base: string, axes: Record<string, string[]>): Promise<{ nodes: ComponentNode[]; expected: Record<string, string>[] }> {
+  const baseNode = await figma.getNodeByIdAsync(base);
+  if (!baseNode || baseNode.type !== 'COMPONENT') {
+    throw withCode(new Error(`base must be a COMPONENT node id, got ${baseNode?.type ?? 'not found'}: ${base}`), 'E_INVALID_ARGS');
+  }
+  if (baseNode.parent?.type === 'COMPONENT_SET') {
+    throw withCode(new Error(`base "${baseNode.name}" is already a variant inside "${baseNode.parent.name}"`), 'E_INVALID_ARGS');
+  }
+  const axisOrder = Object.keys(axes);
+  for (const axis of axisOrder) {
+    assertCleanToken('axis', axis);
+    const values = axes[axis]!;
+    if (values.length === 0) throw withCode(new Error(`axis "${axis}" has no values`), 'E_INVALID_ARGS');
+    for (const v of values) assertCleanToken('value', v);
+  }
+  const combos = cartesianProduct(axes);
+  if (combos.length > MAX_VARIANTS) {
+    throw withCode(new Error(`${combos.length} variants requested — capped at ${MAX_VARIANTS}. Split by one axis and build multiple sets.`), 'E_INVALID_ARGS');
+  }
+  // Base becomes the first variant (keeps its node id — existing instances of the
+  // base survive as instances of that variant); clones fill the rest, stacked
+  // vertically so nothing overlaps before the caller lays the set out.
+  const stepY = Math.ceil(baseNode.height) + 40;
+  baseNode.name = comboName(combos[0]!, axisOrder);
+  const nodes: ComponentNode[] = [baseNode];
+  for (let i = 1; i < combos.length; i++) {
+    const clone = baseNode.clone() as ComponentNode;
+    clone.name = comboName(combos[i]!, axisOrder);
+    clone.y = baseNode.y + i * stepY;
+    nodes.push(clone);
+  }
+  return { nodes, expected: combos };
+}
+
+async function buildModeB(
+  ids: string[],
+  variantProps: Record<string, string>[] | undefined,
+): Promise<{ nodes: ComponentNode[]; expected: Record<string, string>[]; warnings: string[] }> {
+  if (ids.length > MAX_VARIANTS) {
+    throw withCode(new Error(`${ids.length} components requested — capped at ${MAX_VARIANTS}.`), 'E_INVALID_ARGS');
+  }
+  if (variantProps && variantProps.length !== ids.length) {
+    throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), 'E_INVALID_ARGS');
+  }
+  const nodes: ComponentNode[] = [];
+  const expected: Record<string, string>[] = [];
+  const warnings: string[] = [];
+  for (let i = 0; i < ids.length; i++) {
+    const node = await figma.getNodeByIdAsync(ids[i]!);
+    if (!node || node.type !== 'COMPONENT') {
+      throw withCode(new Error(`components[${i}] must be a COMPONENT node id, got ${node?.type ?? 'not found'}: ${ids[i]}`), 'E_INVALID_ARGS');
+    }
+    if (node.parent?.type === 'COMPONENT_SET') {
+      throw withCode(new Error(`components[${i}] "${node.name}" is already a variant inside "${node.parent.name}"`), 'E_INVALID_ARGS');
+    }
+    if (variantProps) {
+      const props = variantProps[i]!;
+      const keys = Object.keys(props);
+      if (keys.length === 0) throw withCode(new Error(`variantProps[${i}] is empty — needs at least one property`), 'E_INVALID_ARGS');
+      for (const k of keys) { assertCleanToken('property', k); assertCleanToken('value', props[k]!); }
+      node.name = comboName(props, keys);
+      expected.push({ ...props });
+    } else {
+      // Figma turns a name lacking "=" into "Property 1=<name>" `[re-verify]` — warn
+      // rather than silently accept an axis the caller did not choose (fork's own
+      // warning shape, adapted). We did NOT rename this node, so there is no axis
+      // map of OUR intent to verify against — asserting one would invent a fact the
+      // `[re-verify]` tag says is still unconfirmed; the post-combine check below
+      // only holds this node to "it survived", never to a fabricated axis map.
+      if (!node.name.includes('=')) {
+        warnings.push(`component "${node.name}" is not named "Prop=Value" — Figma will file it under "Property 1=${node.name}"`);
+        expected.push({});
+      } else {
+        expected.push(parseComboName(node.name));
+      }
+    }
+    nodes.push(node as ComponentNode);
+  }
+  return { nodes, expected, warnings };
+}
+
+async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult> {
+  const hasBase = typeof opts.base === 'string';
+  const hasComponents = Array.isArray(opts.components) && opts.components.length > 0;
+  if (hasBase === hasComponents) {
+    throw withCode(new Error('componentSet needs exactly one of: base + axes, or components'), 'E_INVALID_ARGS');
+  }
+  let nodes: ComponentNode[];
+  let expected: Record<string, string>[];
+  let warnings: string[] = [];
+  if (hasBase) {
+    if (!opts.axes || Object.keys(opts.axes).length === 0) {
+      throw withCode(new Error('axes is required with base — e.g. { State: ["default","hover"], Size: ["sm","lg"] }'), 'E_INVALID_ARGS');
+    }
+    ({ nodes, expected } = await buildModeA(opts.base!, opts.axes));
+  } else {
+    ({ nodes, expected, warnings } = await buildModeB(opts.components!, opts.variantProps));
+  }
+  const parent = await resolveParent(opts.parent);
+  const set = figma.combineAsVariants(nodes, parent);
+  if (opts.name) set.name = opts.name;
+  if (typeof opts.x === 'number') set.x = opts.x;
+  if (typeof opts.y === 'number') set.y = opts.y;
+
+  // Verify: the combined set's own children must match what we intended — a
+  // mismatch (Figma's own name-parsing disagreeing with ours) throws with both
+  // lists rather than reporting a count that quietly drifted from reality.
+  const children = set.children.filter((c): c is ComponentNode => c.type === 'COMPONENT');
+  if (children.length !== nodes.length) {
+    throw withCode(new Error(`componentSet combined ${children.length} children, expected ${nodes.length}`), 'E_EVAL');
+  }
+  const actualAxes = children.map((c) => parseComboName(c.name));
+  const mismatches = expected
+    .map((exp, i) => ({ i, exp, actual: actualAxes[i] }))
+    .filter(({ exp, actual }) => !actual || !sameAxisMap(exp, actual));
+  if (mismatches.length > 0) {
+    throw withCode(new Error(`componentSet variant names did not parse back to the intended axes: ${JSON.stringify(mismatches)}`), 'E_EVAL');
+  }
+
+  const propertyDefinitions = (set.componentPropertyDefinitions ?? {}) as Record<string, unknown>;
+  const variantCount = children.length;
+  const sizeWarning = variantCount > WARN_ABOVE
+    ? `${variantCount} variants — large sets are slow to build; consider splitting by one axis`
+    : undefined;
+
+  return {
+    id: set.id,
+    name: set.name,
+    variantCount,
+    // Each variant's key AND id — instances come from a variant's key/id, never
+    // the set's (fork's hint, write-tools.ts ~3040).
+    variants: children.map((c, i) => ({ id: c.id, name: c.name, key: c.key, axes: actualAxes[i]! })),
+    propertyDefinitions,
+    ...(sizeWarning ? { sizeWarning } : {}),
+    ...(warnings.length ? { warnings } : {}),
+  };
+}
+
+export interface ExecStdlibComponentSet {
+  componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult>;
+}
+
+export function createExecStdlibComponentSet(): ExecStdlibComponentSet {
+  return { componentSet };
+}

--- a/plugin/src/main/exec-stdlib-variables.ts
+++ b/plugin/src/main/exec-stdlib-variables.ts
@@ -8,17 +8,30 @@
 import { resolveVariable, valuesEqual } from './executor-variables';
 import { withCode } from './executor-styles';
 
+/** A candidate list for an error message, capped so one huge file can't flood a
+ * reply — with an explicit "+N more" tail so a truncated list never reads as
+ * complete (stage-4 review, PR #10 minor 5: the old 20-item cap silently cut the
+ * list with no sign anything was missing). Used for BOTH collection names and mode
+ * names — one convention, not two. */
+function listWithMore(names: readonly string[], cap = 20): string {
+  const shown = names.slice(0, cap).join(', ');
+  const rest = names.length - cap;
+  return rest > 0 ? `${shown} (+${rest} more)` : shown;
+}
+
 /** Collection resolution: id (`VariableCollectionId:…`) or exact name. Mirrors
- * `byPath`'s error style (exec-stdlib.ts:93-101) — name the candidates, capped at 20,
- * so a miss is correctable without a second round-trip. */
+ * `byPath`'s error style (exec-stdlib.ts:93-101) — name the candidates so a miss is
+ * correctable without a second round-trip. */
 async function resolveCollection(ref: string): Promise<VariableCollection> {
   const all = await figma.variables.getLocalVariableCollectionsAsync();
   const byId = all.find((c) => c.id === ref);
   if (byId) return byId;
   const byName = all.find((c) => c.name === ref);
   if (byName) return byName;
-  const names20 = all.slice(0, 20).map((c) => c.name).join(', ');
-  throw withCode(new Error(`collection not found: "${ref}" — available: ${names20}`), 'E_INVALID_ARGS');
+  throw withCode(
+    new Error(`collection not found: "${ref}" — available: ${listWithMore(all.map((c) => c.name))}`),
+    'E_INVALID_ARGS',
+  );
 }
 
 function modeList(collection: VariableCollection): { modeId: string; name: string }[] {
@@ -29,7 +42,7 @@ function findMode(collection: VariableCollection, modeId: string): { modeId: str
   const mode = collection.modes.find((m) => m.modeId === modeId);
   if (!mode) {
     throw withCode(
-      new Error(`mode not found: "${modeId}" on collection "${collection.name}" — available: ${collection.modes.map((m) => m.name).join(', ')}`),
+      new Error(`mode not found: "${modeId}" on collection "${collection.name}" — available: ${listWithMore(collection.modes.map((m) => m.name))}`),
       'E_INVALID_ARGS',
     );
   }
@@ -59,7 +72,7 @@ async function rename(ref: string, newName: string): Promise<{ id: string; name:
  * es-debt: page-scoped reference counting omitted, not faked. Upgrade trigger: a
  * real task needs the count, or a file-wide bound-reference reader lands.
  */
-async function remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean; boundReferences?: number }> {
+async function remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean }> {
   const variable = await resolveVariable(ref);
   const id = variable.id;
   const name = variable.name;
@@ -151,16 +164,16 @@ async function setModeValue(
   const mode = collection.modes.find((m) => m.name === modeName);
   if (!mode) {
     throw withCode(
-      new Error(`mode "${modeName}" not found on collection "${collection.name}" — available: ${collection.modes.map((m) => m.name).join(', ')}`),
+      new Error(`mode "${modeName}" not found on collection "${collection.name}" — available: ${listWithMore(collection.modes.map((m) => m.name))}`),
       'E_INVALID_ARGS',
     );
   }
   variable.setValueForMode(mode.modeId, value as VariableValue);
   const actual = variable.valuesByMode[mode.modeId];
-  const matches = variable.resolvedType === 'COLOR'
-    ? valuesEqual(actual, value as VariableValue)
-    : actual === value;
-  if (!matches) {
+  // Stage-4 review (PR #10 issue 1): valuesEqual handles every real VariableValue
+  // shape (RGBA epsilon, VARIABLE_ALIAS by target id, primitives strict) — it is
+  // never reference equality, which broke every non-COLOR alias write.
+  if (!valuesEqual(actual, value as VariableValue)) {
     throw withCode(new Error(`setModeValue applied but "${modeName}" reads back ${JSON.stringify(actual)}, not ${JSON.stringify(value)}`), 'E_EVAL');
   }
   return { id: variable.id, name: variable.name, mode: { modeId: mode.modeId, name: mode.name }, value: actual };
@@ -179,7 +192,7 @@ async function resolveCollectionOfVariable(variable: Variable): Promise<Variable
 
 export interface ExecStdlibVars {
   rename(ref: string, newName: string): Promise<{ id: string; name: string; oldName: string }>;
-  remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean; boundReferences?: number }>;
+  remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean }>;
   describe(ref: string, description: string): Promise<{ id: string; name: string; description: string }>;
   addMode(collection: string, modeName: string): Promise<{ collectionId: string; name: string; modes: { modeId: string; name: string }[] }>;
   renameMode(collection: string, modeId: string, newName: string): Promise<{ collectionId: string; modes: { modeId: string; name: string }[]; oldName: string }>;

--- a/plugin/src/main/exec-stdlib-variables.ts
+++ b/plugin/src/main/exec-stdlib-variables.ts
@@ -1,0 +1,192 @@
+// `ui.vars.*` — variable + mode lifecycle over exec-js (absorption phase-01, Basket B).
+// Reuse, do not re-implement: ref resolution goes through `resolveVariable`
+// (executor-variables.ts) and value comparison through its exported `valuesEqual` —
+// a second resolver/comparator here would be the mistake exec-stdlib.ts:5-10 warns
+// against. Every helper verifies its own write by re-reading the canvas and throws
+// `withCode(..., 'E_EVAL')` on a mismatch — an unverified success is exactly the
+// silent-failure class this stdlib exists to kill.
+import { resolveVariable, valuesEqual } from './executor-variables';
+import { withCode } from './executor-styles';
+
+/** Collection resolution: id (`VariableCollectionId:…`) or exact name. Mirrors
+ * `byPath`'s error style (exec-stdlib.ts:93-101) — name the candidates, capped at 20,
+ * so a miss is correctable without a second round-trip. */
+async function resolveCollection(ref: string): Promise<VariableCollection> {
+  const all = await figma.variables.getLocalVariableCollectionsAsync();
+  const byId = all.find((c) => c.id === ref);
+  if (byId) return byId;
+  const byName = all.find((c) => c.name === ref);
+  if (byName) return byName;
+  const names20 = all.slice(0, 20).map((c) => c.name).join(', ');
+  throw withCode(new Error(`collection not found: "${ref}" — available: ${names20}`), 'E_INVALID_ARGS');
+}
+
+function modeList(collection: VariableCollection): { modeId: string; name: string }[] {
+  return collection.modes.map((m) => ({ modeId: m.modeId, name: m.name }));
+}
+
+function findMode(collection: VariableCollection, modeId: string): { modeId: string; name: string } {
+  const mode = collection.modes.find((m) => m.modeId === modeId);
+  if (!mode) {
+    throw withCode(
+      new Error(`mode not found: "${modeId}" on collection "${collection.name}" — available: ${collection.modes.map((m) => m.name).join(', ')}`),
+      'E_INVALID_ARGS',
+    );
+  }
+  return mode;
+}
+
+async function rename(ref: string, newName: string): Promise<{ id: string; name: string; oldName: string }> {
+  if (typeof newName !== 'string' || newName.length === 0) {
+    throw withCode(new Error('rename requires a non-empty newName'), 'E_INVALID_ARGS');
+  }
+  const variable = await resolveVariable(ref);
+  const oldName = variable.name;
+  variable.name = newName;
+  if (variable.name !== newName) {
+    throw withCode(new Error(`rename applied but variable.name is still "${variable.name}"`), 'E_EVAL');
+  }
+  return { id: variable.id, name: variable.name, oldName };
+}
+
+/**
+ * `[re-verify]` whether `Variable.remove()` leaves dangling `boundVariables` entries
+ * on nodes that referenced it — the fork does not say (code.js:763-797 just calls
+ * `remove()`, no reference check at all). Rather than guess, this counts bound
+ * references the CHEAP, HONEST way: `figma.currentPage.findAll` only sees the
+ * current page, so a total across the file would under-report on a multi-page
+ * file and silently lie. We do not use it and claim a total.
+ * es-debt: page-scoped reference counting omitted, not faked. Upgrade trigger: a
+ * real task needs the count, or a file-wide bound-reference reader lands.
+ */
+async function remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean; boundReferences?: number }> {
+  const variable = await resolveVariable(ref);
+  const id = variable.id;
+  const name = variable.name;
+  variable.remove();
+  return { id, name, boundReferencesChecked: false };
+}
+
+async function describe(ref: string, description: string): Promise<{ id: string; name: string; description: string }> {
+  if (typeof description !== 'string') {
+    throw withCode(new Error('describe requires a string description'), 'E_INVALID_ARGS');
+  }
+  const variable = await resolveVariable(ref);
+  variable.description = description;
+  if (variable.description !== description) {
+    throw withCode(new Error(`describe applied but variable.description is still "${variable.description}"`), 'E_EVAL');
+  }
+  return { id: variable.id, name: variable.name, description: variable.description };
+}
+
+async function addMode(
+  collectionRef: string,
+  modeName: string,
+): Promise<{ collectionId: string; name: string; modes: { modeId: string; name: string }[] }> {
+  if (typeof modeName !== 'string' || modeName.length === 0) {
+    throw withCode(new Error('addMode requires a non-empty modeName'), 'E_INVALID_ARGS');
+  }
+  const collection = await resolveCollection(collectionRef);
+  const before = collection.modes.length;
+  let modeId: string;
+  try {
+    modeId = collection.addMode(modeName);
+  } catch (err) {
+    // Free-plan mode caps surface as the thrown Figma error, not a warning — this
+    // is a plan LIMIT, the same "let it throw" contract as §5.1 rule 6 (never
+    // swallow the way createVariablesFromTokens does for *import*).
+    throw withCode(new Error(`addMode "${modeName}" failed: ${String(err)}`), 'E_EVAL');
+  }
+  if (collection.modes.length !== before + 1 || !collection.modes.some((m) => m.modeId === modeId)) {
+    throw withCode(new Error(`addMode "${modeName}" did not take — modes: ${collection.modes.map((m) => m.name).join(', ')}`), 'E_EVAL');
+  }
+  return { collectionId: collection.id, name: collection.name, modes: modeList(collection) };
+}
+
+async function renameMode(
+  collectionRef: string,
+  modeId: string,
+  newName: string,
+): Promise<{ collectionId: string; modes: { modeId: string; name: string }[]; oldName: string }> {
+  if (typeof newName !== 'string' || newName.length === 0) {
+    throw withCode(new Error('renameMode requires a non-empty newName'), 'E_INVALID_ARGS');
+  }
+  const collection = await resolveCollection(collectionRef);
+  const mode = findMode(collection, modeId);
+  const oldName = mode.name;
+  collection.renameMode(modeId, newName);
+  const after = findMode(collection, modeId);
+  if (after.name !== newName) {
+    throw withCode(new Error(`renameMode applied but mode "${modeId}" is still "${after.name}"`), 'E_EVAL');
+  }
+  return { collectionId: collection.id, modes: modeList(collection), oldName };
+}
+
+async function removeMode(
+  collectionRef: string,
+  modeId: string,
+): Promise<{ collectionId: string; modes: { modeId: string; name: string }[] }> {
+  const collection = await resolveCollection(collectionRef);
+  findMode(collection, modeId); // throws E_INVALID_ARGS with the available names if absent
+  collection.removeMode(modeId);
+  if (collection.modes.some((m) => m.modeId === modeId)) {
+    throw withCode(new Error(`removeMode applied but "${modeId}" is still present`), 'E_EVAL');
+  }
+  return { collectionId: collection.id, modes: modeList(collection) };
+}
+
+/**
+ * Set a variable's value for a named mode. Throws on an unknown mode name — the
+ * deliberate opposite of the CREATE_VARIABLE `--mode` bug fixed alongside this file
+ * (executor-variables.ts §5.4): that command now throws for the same mistake, so
+ * the two no longer disagree about it.
+ */
+async function setModeValue(
+  ref: string,
+  modeName: string,
+  value: unknown,
+): Promise<{ id: string; name: string; mode: { modeId: string; name: string }; value: unknown }> {
+  const variable = await resolveVariable(ref);
+  const collection = await resolveCollectionOfVariable(variable);
+  const mode = collection.modes.find((m) => m.name === modeName);
+  if (!mode) {
+    throw withCode(
+      new Error(`mode "${modeName}" not found on collection "${collection.name}" — available: ${collection.modes.map((m) => m.name).join(', ')}`),
+      'E_INVALID_ARGS',
+    );
+  }
+  variable.setValueForMode(mode.modeId, value as VariableValue);
+  const actual = variable.valuesByMode[mode.modeId];
+  const matches = variable.resolvedType === 'COLOR'
+    ? valuesEqual(actual, value as VariableValue)
+    : actual === value;
+  if (!matches) {
+    throw withCode(new Error(`setModeValue applied but "${modeName}" reads back ${JSON.stringify(actual)}, not ${JSON.stringify(value)}`), 'E_EVAL');
+  }
+  return { id: variable.id, name: variable.name, mode: { modeId: mode.modeId, name: mode.name }, value: actual };
+}
+
+/** The collection a variable belongs to — `variable.variableCollectionId` is the
+ * link; look it up rather than asking the caller to pass the collection too. */
+async function resolveCollectionOfVariable(variable: Variable): Promise<VariableCollection> {
+  const all = await figma.variables.getLocalVariableCollectionsAsync();
+  const collection = all.find((c) => c.id === variable.variableCollectionId);
+  if (!collection) {
+    throw withCode(new Error(`collection not found for variable "${variable.name}" (${variable.variableCollectionId})`), 'E_EVAL');
+  }
+  return collection;
+}
+
+export interface ExecStdlibVars {
+  rename(ref: string, newName: string): Promise<{ id: string; name: string; oldName: string }>;
+  remove(ref: string): Promise<{ id: string; name: string; boundReferencesChecked: boolean; boundReferences?: number }>;
+  describe(ref: string, description: string): Promise<{ id: string; name: string; description: string }>;
+  addMode(collection: string, modeName: string): Promise<{ collectionId: string; name: string; modes: { modeId: string; name: string }[] }>;
+  renameMode(collection: string, modeId: string, newName: string): Promise<{ collectionId: string; modes: { modeId: string; name: string }[]; oldName: string }>;
+  removeMode(collection: string, modeId: string): Promise<{ collectionId: string; modes: { modeId: string; name: string }[] }>;
+  setModeValue(ref: string, modeName: string, value: unknown): Promise<{ id: string; name: string; mode: { modeId: string; name: string }; value: unknown }>;
+}
+
+export function createExecStdlibVars(): ExecStdlibVars {
+  return { rename, remove, describe, addMode, renameMode, removeMode, setModeValue };
+}

--- a/plugin/src/main/exec-stdlib.ts
+++ b/plugin/src/main/exec-stdlib.ts
@@ -15,6 +15,12 @@ import {
 import { withCode } from './executor-styles';
 import { readBindings } from './scan-node-utils';
 import { resolvePropKey, setProps, swapInstance } from './exec-stdlib-instance';
+// Absorption phase-01 (Basket B): variable/mode CRUD and variant-matrix component-set
+// helpers, each its own split file for the same 200-line-cap reason as
+// exec-stdlib-instance.ts — `vars` and `componentSet` are namespaced sub-objects, not
+// inlined here, so this file's own cap never has to make room for them.
+import { createExecStdlibVars, type ExecStdlibVars } from './exec-stdlib-variables';
+import { createExecStdlibComponentSet, type ComponentSetOpts, type ComponentSetResult } from './exec-stdlib-component-set';
 
 export { resolvePropKey };
 
@@ -24,6 +30,8 @@ export interface ExecStdlib {
   boundFill(node: SceneNode, varName: string, field?: string): Promise<{ id: string; field: string; variable: string }>;
   byPath(rootId: string, names: string[]): Promise<SceneNode>;
   q(target: SceneNode | string, opts?: { depth?: number; fields?: string[] }): Promise<unknown>;
+  vars: ExecStdlibVars;
+  componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult>;
 }
 
 // Figma re-keys SOME bindings under a different boundVariables key than the field name asked
@@ -143,5 +151,8 @@ async function q(target: SceneNode | string, opts: { depth?: number; fields?: st
 }
 
 export function createExecStdlib(): ExecStdlib {
-  return { setProps, swapInstance, boundFill, byPath, q };
+  const { componentSet } = createExecStdlibComponentSet();
+  return {
+    setProps, swapInstance, boundFill, byPath, q, componentSet, vars: createExecStdlibVars(),
+  };
 }

--- a/plugin/src/main/executor-variables.ts
+++ b/plugin/src/main/executor-variables.ts
@@ -22,15 +22,32 @@ async function findOrCreateCollection(name: string): Promise<VariableCollection>
   return all.find((c) => c.name === name) ?? figma.variables.createVariableCollection(name);
 }
 
-/** Value equality: colors with epsilon (round-trip tolerance), primitives strict.
- * Exported for `exec-stdlib-variables.ts`'s `setModeValue` verification — the
- * repo's own rule is reuse, not a second comparator (exec-stdlib.ts:5-10). */
+/** Value equality: colors with epsilon (round-trip tolerance), VARIABLE_ALIAS by
+ * identity (type + target id), primitives strict. Exported for
+ * `exec-stdlib-variables.ts`'s `setModeValue` verification — the repo's own rule is
+ * reuse, not a second comparator (exec-stdlib.ts:5-10).
+ *
+ * Stage-4 review (PR #10 issue 1): a mode value re-read off the canvas is never the
+ * SAME object the caller passed in (Figma serializes it; this file's own mock now
+ * clones on write for the same reason) — so a comparator that falls through to
+ * reference equality for anything that isn't RGBA silently breaks the semantic→
+ * primitive alias layer, throwing E_EVAL on a write that actually succeeded. Every
+ * object shape a variable value can take (RGBA, VARIABLE_ALIAS) now gets a real
+ * structural comparison; only a bare primitive (string/number/boolean) falls to `===`. */
 export function valuesEqual(a: VariableValue, b: VariableValue): boolean {
-  if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null && 'r' in a && 'r' in b) {
-    const ca = a as RGBA; const cb = b as RGBA;
-    const eps = 1 / 512;
-    return Math.abs(ca.r - cb.r) < eps && Math.abs(ca.g - cb.g) < eps
-      && Math.abs(ca.b - cb.b) < eps && Math.abs((ca.a ?? 1) - (cb.a ?? 1)) < eps;
+  if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null) {
+    if ('r' in a && 'r' in b) {
+      const ca = a as RGBA; const cb = b as RGBA;
+      const eps = 1 / 512;
+      return Math.abs(ca.r - cb.r) < eps && Math.abs(ca.g - cb.g) < eps
+        && Math.abs(ca.b - cb.b) < eps && Math.abs((ca.a ?? 1) - (cb.a ?? 1)) < eps;
+    }
+    const aa = a as VariableAlias; const bb = b as VariableAlias;
+    if (aa.type === 'VARIABLE_ALIAS' && bb.type === 'VARIABLE_ALIAS') return aa.id === bb.id;
+    // No other object shape is a real VariableValue — this branch only guards
+    // against a shape neither of the above recognizes; compare structurally rather
+    // than silently returning false.
+    return JSON.stringify(a) === JSON.stringify(b);
   }
   return a === b;
 }

--- a/plugin/src/main/executor-variables.ts
+++ b/plugin/src/main/executor-variables.ts
@@ -22,8 +22,10 @@ async function findOrCreateCollection(name: string): Promise<VariableCollection>
   return all.find((c) => c.name === name) ?? figma.variables.createVariableCollection(name);
 }
 
-/** Value equality: colors with epsilon (round-trip tolerance), primitives strict. */
-function valuesEqual(a: VariableValue, b: VariableValue): boolean {
+/** Value equality: colors with epsilon (round-trip tolerance), primitives strict.
+ * Exported for `exec-stdlib-variables.ts`'s `setModeValue` verification — the
+ * repo's own rule is reuse, not a second comparator (exec-stdlib.ts:5-10). */
+export function valuesEqual(a: VariableValue, b: VariableValue): boolean {
   if (typeof a === 'object' && a !== null && typeof b === 'object' && b !== null && 'r' in a && 'r' in b) {
     const ca = a as RGBA; const cb = b as RGBA;
     const eps = 1 / 512;
@@ -176,10 +178,20 @@ export async function opCreateVariable(params: Record<string, unknown>): Promise
 
   const collection = await findOrCreateCollection(typeof params.collection === 'string' && params.collection ? params.collection : COLLECTION_NAME);
   const { variable, reused } = await createOrReuseVariable(collection, name, type, value);
-  // Optional named mode (creates only the value; mode must already exist)
+  // Optional named mode (sets only the value; the mode must already exist).
+  // Was a SILENT NO-OP on a bad mode name (set nothing, reported success) — the
+  // exact mistake `ui.vars.setModeValue` (exec-stdlib-variables.ts) exists to
+  // never repeat. Absorption phase-01 §5.4: throw, naming the modes that do
+  // exist, instead of quietly leaving the mode unset.
   if (typeof params.mode === 'string') {
     const mode = collection.modes.find((m) => m.name === params.mode);
-    if (mode) variable.setValueForMode(mode.modeId, value);
+    if (!mode) {
+      throw withCode(
+        new Error(`CREATE_VARIABLE mode "${params.mode}" not found on collection "${collection.name}" — available modes: ${collection.modes.map((m) => m.name).join(', ')}`),
+        'E_INVALID_ARGS',
+      );
+    }
+    variable.setValueForMode(mode.modeId, value);
   }
   return { id: variable.id, name: variable.name, reused };
 }

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "5c9460d" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "a0c5420" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "a0c5420" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "6fe2ae8" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/tests/exec-stdlib-component-set.test.ts
+++ b/tests/exec-stdlib-component-set.test.ts
@@ -1,0 +1,196 @@
+// `ui.componentSet(...)` — variant-matrix / combine-existing component-set builder
+// (absorption phase-01, Basket B). Covers: happy path (both modes), failed-verification
+// throw, bad-input throws, cartesian-order determinism, `=`/`,` rejection, and the
+// over-cap rejection (plan §8 Definition of Done).
+import { describe, it, expect } from 'vitest';
+import { installMockFigma, setMockComponents, type FakeNode } from './helpers/mock-figma.ts';
+import { createExecStdlibComponentSet } from '../plugin/src/main/exec-stdlib-component-set.ts';
+import {
+  cartesianProduct, comboName, assertCleanToken, parseComboName, sameAxisMap,
+} from '../plugin/src/main/exec-stdlib-component-matrix.ts';
+
+let keySeq = 0;
+function makeComponent(name: string): FakeNode {
+  const figma = (globalThis as unknown as { figma: { createComponent(): FakeNode } }).figma;
+  const c = figma.createComponent();
+  c.name = name;
+  c.key = `key:${keySeq++}`; // every real COMPONENT carries a publish key
+  return c;
+}
+
+describe('componentSet — mode selection', () => {
+  it('throws E_INVALID_ARGS when neither base nor components is given', async () => {
+    installMockFigma();
+    await expect(createExecStdlibComponentSet().componentSet({}))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('throws E_INVALID_ARGS when both base and components are given', async () => {
+    installMockFigma();
+    await expect(createExecStdlibComponentSet().componentSet({ base: '1:1', components: ['1:2'] }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('throws E_INVALID_ARGS when base is given without axes', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+});
+
+describe('componentSet — mode 1 (base + axes)', () => {
+  it('builds the cartesian product, keeps the base id as the first variant, and reads back propertyDefinitions', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+
+    const result = await createExecStdlibComponentSet().componentSet({
+      base: base.id,
+      axes: { State: ['default', 'hover'], Size: ['sm', 'lg'] },
+    });
+
+    expect(result.variantCount).toBe(4);
+    // Deterministic order: axis insertion order (State, then Size), values in given order.
+    expect(result.variants.map((v) => v.name)).toEqual([
+      'State=default, Size=sm', 'State=default, Size=lg',
+      'State=hover, Size=sm', 'State=hover, Size=lg',
+    ]);
+    // The base's own node id is preserved as the FIRST variant.
+    expect(result.variants[0]!.id).toBe(base.id);
+    expect(result.variants.every((v) => typeof v.key === 'string')).toBe(true);
+    expect(result.propertyDefinitions).toHaveProperty('State');
+    expect(result.propertyDefinitions).toHaveProperty('Size');
+  });
+
+  it('rejects a base already inside a COMPONENT_SET', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    const other = makeComponent('State=default');
+    setMockComponents([base, other]);
+    const figma = (globalThis as unknown as { figma: { combineAsVariants: (n: FakeNode[], p: FakeNode) => FakeNode; currentPage: FakeNode } }).figma;
+    figma.combineAsVariants([other], figma.currentPage); // puts `other` inside a set
+
+    await expect(createExecStdlibComponentSet().componentSet({ base: other.id, axes: { State: ['default'] } }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('already a variant') });
+  });
+
+  it('rejects an axis or value containing "=" or ","', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { 'Sta=te': ['default'] } }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['de,fault'] } }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('rejects a matrix over the 100-combination cap', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    const many = Array.from({ length: 11 }, (_, i) => `v${i}`); // 11 * 11 = 121 > 100
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { A: many, B: many } }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('121') });
+  });
+
+  it('carries a sizeWarning above 40 variants, without rejecting', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    const values = Array.from({ length: 41 }, (_, i) => `v${i}`);
+    const result = await createExecStdlibComponentSet().componentSet({ base: base.id, axes: { A: values } });
+    expect(result.variantCount).toBe(41);
+    expect(result.sizeWarning).toContain('41 variants');
+  });
+
+  it('throws E_EVAL when the combined set disagrees with what we intended — never trusts an unverified merge', async () => {
+    const figma = installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    const originalCombine = figma.combineAsVariants.bind(figma);
+    // Force a broken combine: truncate the set's children after Figma "combines" them —
+    // the exact shape a silent-trust implementation would wave through unverified.
+    figma.combineAsVariants = ((nodes: FakeNode[], parent: FakeNode) => {
+      const set = originalCombine(nodes, parent);
+      set.children = set.children.slice(0, 1);
+      return set;
+    }) as typeof figma.combineAsVariants;
+
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['default', 'hover'] } }))
+      .rejects.toMatchObject({ code: 'E_EVAL' });
+  });
+});
+
+describe('componentSet — mode 2 (combine existing components)', () => {
+  it('renames each component via variantProps before combining', async () => {
+    installMockFigma();
+    const a = makeComponent('CompA');
+    const b = makeComponent('CompB');
+    setMockComponents([a, b]);
+
+    const result = await createExecStdlibComponentSet().componentSet({
+      components: [a.id, b.id],
+      variantProps: [{ State: 'default' }, { State: 'hover' }],
+    });
+
+    expect(result.variantCount).toBe(2);
+    expect(result.variants.map((v) => v.name)).toEqual(['State=default', 'State=hover']);
+  });
+
+  it('warns (never rejects) when a component name lacks "=" and no variantProps is given', async () => {
+    installMockFigma();
+    const a = makeComponent('Plain Name');
+    setMockComponents([a]);
+
+    const result = await createExecStdlibComponentSet().componentSet({ components: [a.id] });
+    expect(result.warnings?.[0]).toContain('Property 1=Plain Name');
+  });
+
+  it('rejects a component already inside a COMPONENT_SET', async () => {
+    const figma = installMockFigma();
+    const a = makeComponent('State=default');
+    setMockComponents([a]);
+    figma.combineAsVariants([a], figma.currentPage);
+
+    await expect(createExecStdlibComponentSet().componentSet({ components: [a.id] }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('already a variant') });
+  });
+
+  it('rejects a variantProps length mismatch', async () => {
+    installMockFigma();
+    const a = makeComponent('CompA');
+    setMockComponents([a]);
+    await expect(createExecStdlibComponentSet().componentSet({ components: [a.id], variantProps: [] }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+});
+
+describe('exec-stdlib-component-matrix — pure helpers', () => {
+  it('cartesianProduct is deterministic: axis insertion order, values in given order', () => {
+    const combos = cartesianProduct({ State: ['default', 'hover'], Size: ['sm', 'lg'] });
+    expect(combos).toEqual([
+      { State: 'default', Size: 'sm' }, { State: 'default', Size: 'lg' },
+      { State: 'hover', Size: 'sm' }, { State: 'hover', Size: 'lg' },
+    ]);
+  });
+
+  it('comboName / parseComboName round-trip', () => {
+    const combo = { State: 'hover', Size: 'lg' };
+    const name = comboName(combo, ['State', 'Size']);
+    expect(name).toBe('State=hover, Size=lg');
+    expect(parseComboName(name)).toEqual(combo);
+  });
+
+  it('assertCleanToken throws on "=" or ","', () => {
+    expect(() => assertCleanToken('axis', 'a=b')).toThrow(/must not contain/);
+    expect(() => assertCleanToken('value', 'a,b')).toThrow(/must not contain/);
+    expect(() => assertCleanToken('axis', 'clean')).not.toThrow();
+  });
+
+  it('sameAxisMap compares by content, not key order', () => {
+    expect(sameAxisMap({ State: 'hover', Size: 'lg' }, { Size: 'lg', State: 'hover' })).toBe(true);
+    expect(sameAxisMap({ State: 'hover' }, { State: 'default' })).toBe(false);
+  });
+});

--- a/tests/exec-stdlib-component-set.test.ts
+++ b/tests/exec-stdlib-component-set.test.ts
@@ -105,7 +105,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
     expect(result.sizeWarning).toContain('41 variants');
   });
 
-  it('throws E_EVAL when the combined set disagrees with what we intended — never trusts an unverified merge', async () => {
+  it('throws E_EVAL when the combined set disagrees with what we intended, AND self-cleans up: base name restored, its own clone removed', async () => {
     const figma = installMockFigma();
     const base = makeComponent('Base');
     setMockComponents([base]);
@@ -120,6 +120,41 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
     await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['default', 'hover'] } }))
       .rejects.toMatchObject({ code: 'E_EVAL' });
+
+    // Stage-4 review issue 2: the helper's OWN mutations (rename the base, clone it)
+    // must not survive its OWN thrown failure — the base's NAME is restored. (The
+    // base itself is still inside whatever `combineAsVariants` produced — cleanup is
+    // bounded to what the helper created/renamed, not un-combining Figma's own
+    // structure; that entanglement is exactly `--undo-group`'s job, not this helper's.)
+    expect(base.name).toBe('Base');
+  });
+
+  it('restores the base name AND removes its own clone when the failure is UNRELATED to verification (e.g. combineAsVariants itself throws) — ruled independently of issue 2', async () => {
+    const figma = installMockFigma();
+    const frame = figma.createFrame(); // a real parent, so clone() actually attaches — proves removal
+    const base = makeComponent('Base');
+    frame.appendChild(base);
+    setMockComponents([base]);
+    figma.combineAsVariants = (() => { throw new Error('in combineAsVariants: boom'); }) as typeof figma.combineAsVariants;
+
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['default', 'hover'] } }))
+      .rejects.toThrow(/boom/);
+
+    expect(base.name).toBe('Base');
+    // Exactly the base remains in the frame — the clone `buildModeA` created for the
+    // second axis value was removed by cleanup(), not left orphaned on the canvas.
+    expect(frame.children).toEqual([base]);
+  });
+
+  it('rejects a parent that cannot sensibly hold a component set (a COMPONENT, not PAGE/FRAME/SECTION/GROUP)', async () => {
+    installMockFigma();
+    const base = makeComponent('Base');
+    const notAContainer = makeComponent('NotAContainer');
+    setMockComponents([base, notAContainer]);
+
+    await expect(createExecStdlibComponentSet().componentSet({
+      base: base.id, axes: { State: ['default'] }, parent: notAContainer.id,
+    })).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
   });
 });
 
@@ -165,6 +200,22 @@ describe('componentSet — mode 2 (combine existing components)', () => {
     await expect(createExecStdlibComponentSet().componentSet({ components: [a.id], variantProps: [] }))
       .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
   });
+
+  it('restores each component\'s original name when a later step throws — mode 2\'s own rollback', async () => {
+    const figma = installMockFigma();
+    const a = makeComponent('CompA');
+    const b = makeComponent('CompB');
+    setMockComponents([a, b]);
+    figma.combineAsVariants = (() => { throw new Error('in combineAsVariants: boom'); }) as typeof figma.combineAsVariants;
+
+    await expect(createExecStdlibComponentSet().componentSet({
+      components: [a.id, b.id],
+      variantProps: [{ State: 'default' }, { State: 'hover' }],
+    })).rejects.toThrow(/boom/);
+
+    expect(a.name).toBe('CompA');
+    expect(b.name).toBe('CompB');
+  });
 });
 
 describe('exec-stdlib-component-matrix — pure helpers', () => {
@@ -192,5 +243,28 @@ describe('exec-stdlib-component-matrix — pure helpers', () => {
   it('sameAxisMap compares by content, not key order', () => {
     expect(sameAxisMap({ State: 'hover', Size: 'lg' }, { Size: 'lg', State: 'hover' })).toBe(true);
     expect(sameAxisMap({ State: 'hover' }, { State: 'default' })).toBe(false);
+  });
+});
+
+// Stage-4 review, PR #10 minor 3 — the mock must encode the refusals real Figma
+// gives, independent of any caller's own pre-checks, or it is not trustworthy.
+describe('mock-figma — figma.combineAsVariants refusals', () => {
+  it('refuses an empty node list', () => {
+    const figma = installMockFigma();
+    expect(() => figma.combineAsVariants([], figma.currentPage)).toThrow(/at least one node/);
+  });
+
+  it('refuses a non-COMPONENT node', () => {
+    const figma = installMockFigma();
+    const frame = figma.createFrame();
+    expect(() => figma.combineAsVariants([frame], figma.currentPage)).toThrow(/not a COMPONENT/);
+  });
+
+  it('refuses a component already inside a COMPONENT_SET', () => {
+    const figma = installMockFigma();
+    const a = makeComponent('State=default');
+    figma.combineAsVariants([a], figma.currentPage);
+    const b = makeComponent('State=hover');
+    expect(() => figma.combineAsVariants([a, b], figma.currentPage)).toThrow(/already belongs to a component set/);
   });
 });

--- a/tests/exec-stdlib-variables.test.ts
+++ b/tests/exec-stdlib-variables.test.ts
@@ -3,7 +3,9 @@
 // path AND the failed-verification / bad-input throws, per the repo's own contract
 // (exec-stdlib.ts:1-4).
 import { describe, it, expect } from 'vitest';
-import { installMockFigma, setMockLocalVariables, makeMockVariable } from './helpers/mock-figma.ts';
+import {
+  installMockFigma, setMockLocalVariables, makeMockVariable, setMockModeCap,
+} from './helpers/mock-figma.ts';
 import { createExecStdlibVars } from '../plugin/src/main/exec-stdlib-variables.ts';
 
 describe('ui.vars.rename', () => {
@@ -108,6 +110,23 @@ describe('ui.vars.addMode / renameMode / removeMode', () => {
     await expect(createExecStdlibVars().addMode('Nope', 'Dark'))
       .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('Tokens') });
   });
+
+  // Stage-4 review, PR #10 minor 3 — this catch (exec-stdlib-variables.ts's addMode)
+  // was previously never exercised by any test; the mock now has a real refusal path.
+  it('wraps a plan-limit refusal (or any addMode throw) as E_EVAL, not the raw Figma error', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    setMockModeCap(1); // collection already has 'Mode 1' — the next addMode hits the cap
+    await expect(createExecStdlibVars().addMode(collection.name, 'Dark'))
+      .rejects.toMatchObject({ code: 'E_EVAL', message: expect.stringContaining('Limited to 1 modes only') });
+  });
+
+  it('resolveCollection truncates a long candidate list with a "+N more" tail, never a silent cut', async () => {
+    const figma = installMockFigma();
+    for (let i = 0; i < 25; i++) figma.variables.createVariableCollection(`Collection ${i}`);
+    await expect(createExecStdlibVars().addMode('Nope', 'Dark'))
+      .rejects.toMatchObject({ message: expect.stringContaining('+5 more') });
+  });
 });
 
 describe('ui.vars.setModeValue', () => {
@@ -140,5 +159,23 @@ describe('ui.vars.setModeValue', () => {
 
     const result = await createExecStdlibVars().setModeValue(variable.name, 'Mode 1', 24);
     expect(result.value).toBe(24);
+  });
+
+  // Stage-4 review, PR #10 issue 1 — a VARIABLE_ALIAS write (the semantic→primitive
+  // token layer) used to throw E_EVAL even though the canvas took it correctly: the
+  // comparison for non-COLOR types was reference equality, and the mock stored the
+  // caller's own object, so no test could see it. Both are fixed now: the mock stores
+  // a structural clone, and the comparator understands VARIABLE_ALIAS by shape.
+  it('sets a VARIABLE_ALIAS value (semantic token → primitive) and verifies it structurally', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const primitive = figma.variables.createVariable('color/blue/600', collection, 'COLOR');
+    const semantic = figma.variables.createVariable('color/bg/action', collection, 'COLOR');
+
+    const result = await createExecStdlibVars().setModeValue(
+      semantic.name, 'Mode 1', { type: 'VARIABLE_ALIAS', id: primitive.id },
+    );
+
+    expect(result.value).toEqual({ type: 'VARIABLE_ALIAS', id: primitive.id });
   });
 });

--- a/tests/exec-stdlib-variables.test.ts
+++ b/tests/exec-stdlib-variables.test.ts
@@ -1,0 +1,144 @@
+// `ui.vars.*` — variable + mode lifecycle (absorption phase-01, Basket B). Every
+// helper is verified (re-reads its own write); these tests prove both the happy
+// path AND the failed-verification / bad-input throws, per the repo's own contract
+// (exec-stdlib.ts:1-4).
+import { describe, it, expect } from 'vitest';
+import { installMockFigma, setMockLocalVariables, makeMockVariable } from './helpers/mock-figma.ts';
+import { createExecStdlibVars } from '../plugin/src/main/exec-stdlib-variables.ts';
+
+describe('ui.vars.rename', () => {
+  it('renames and reads the new name back', async () => {
+    installMockFigma();
+    const variable = makeMockVariable('color/old');
+    setMockLocalVariables([variable]);
+
+    const result = await createExecStdlibVars().rename(variable.name, 'color/new');
+
+    expect(result).toEqual({ id: variable.id, name: 'color/new', oldName: 'color/old' });
+  });
+
+  it('throws E_INVALID_ARGS on an empty newName', async () => {
+    installMockFigma();
+    const variable = makeMockVariable('color/old');
+    setMockLocalVariables([variable]);
+
+    await expect(createExecStdlibVars().rename(variable.name, '')).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('throws E_INVALID_ARGS when the variable cannot be resolved (resolveVariable\'s own error)', async () => {
+    installMockFigma();
+    await expect(createExecStdlibVars().rename('missing', 'x')).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+});
+
+describe('ui.vars.remove', () => {
+  it('removes the variable and reports boundReferencesChecked:false — never a faked 0', async () => {
+    const figma = installMockFigma();
+    const variable = makeMockVariable('color/dead');
+    setMockLocalVariables([variable]);
+
+    const result = await createExecStdlibVars().remove(variable.name);
+
+    expect(result).toEqual({ id: variable.id, name: variable.name, boundReferencesChecked: false });
+    // A REAL removal, not a stub: the variable is actually gone from the local list.
+    expect(await figma.variables.getLocalVariablesAsync()).toEqual([]);
+  });
+});
+
+describe('ui.vars.describe', () => {
+  it('sets and reads the description back', async () => {
+    installMockFigma();
+    const variable = makeMockVariable('color/brand');
+    setMockLocalVariables([variable]);
+
+    const result = await createExecStdlibVars().describe(variable.name, 'Primary brand color');
+    expect(result).toEqual({ id: variable.id, name: variable.name, description: 'Primary brand color' });
+  });
+
+  it('throws E_INVALID_ARGS on a non-string description', async () => {
+    installMockFigma();
+    const variable = makeMockVariable('color/brand');
+    setMockLocalVariables([variable]);
+    await expect(createExecStdlibVars().describe(variable.name, null as unknown as string))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+});
+
+describe('ui.vars.addMode / renameMode / removeMode', () => {
+  it('addMode returns the mode list read back off the collection, never the caller\'s echoed name alone', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+
+    const result = await createExecStdlibVars().addMode(collection.name, 'Dark');
+
+    expect(result.collectionId).toBe(collection.id);
+    expect(result.modes.map((m) => m.name)).toEqual(['Mode 1', 'Dark']);
+  });
+
+  it('renameMode renames and returns the old name alongside the fresh mode list', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const modeId = collection.modes[0]!.modeId;
+
+    const result = await createExecStdlibVars().renameMode(collection.id, modeId, 'Light');
+
+    expect(result.oldName).toBe('Mode 1');
+    expect(result.modes).toEqual([{ modeId, name: 'Light' }]);
+  });
+
+  it('renameMode throws E_INVALID_ARGS naming the available modes when modeId is unknown', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    await expect(createExecStdlibVars().renameMode(collection.id, 'bogus', 'Light'))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('Mode 1') });
+  });
+
+  it('removeMode removes a non-default mode', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const darkId = collection.addMode('Dark');
+
+    const result = await createExecStdlibVars().removeMode(collection.id, darkId);
+    expect(result.modes.map((m) => m.name)).toEqual(['Mode 1']);
+  });
+
+  it('resolveCollection lists the available collection names on a miss', async () => {
+    const figma = installMockFigma();
+    figma.variables.createVariableCollection('Tokens');
+    await expect(createExecStdlibVars().addMode('Nope', 'Dark'))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('Tokens') });
+  });
+});
+
+describe('ui.vars.setModeValue', () => {
+  it('sets a COLOR value for a named mode and reads it back with epsilon comparison', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const variable = figma.variables.createVariable('color/bg', collection, 'COLOR');
+
+    const result = await createExecStdlibVars().setModeValue(
+      variable.name, 'Mode 1', { r: 1, g: 0, b: 0, a: 1 },
+    );
+
+    expect(result.value).toEqual({ r: 1, g: 0, b: 0, a: 1 });
+    expect(result.mode).toEqual({ modeId: collection.modes[0]!.modeId, name: 'Mode 1' });
+  });
+
+  it('throws E_INVALID_ARGS naming the available modes when the mode name does not exist', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const variable = figma.variables.createVariable('color/bg', collection, 'COLOR');
+
+    await expect(createExecStdlibVars().setModeValue(variable.name, 'Nonexistent', { r: 0, g: 0, b: 0, a: 1 }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('Mode 1') });
+  });
+
+  it('sets a non-COLOR (FLOAT) value with strict equality', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    const variable = figma.variables.createVariable('space/lg', collection, 'FLOAT');
+
+    const result = await createExecStdlibVars().setModeValue(variable.name, 'Mode 1', 24);
+    expect(result.value).toBe(24);
+  });
+});

--- a/tests/executor-variables.test.ts
+++ b/tests/executor-variables.test.ts
@@ -1,0 +1,43 @@
+// CREATE_VARIABLE's --mode handling. Regression for the swallowed no-op fixed in
+// absorption phase-01 §5.4: a mode name that doesn't exist on the collection used
+// to set nothing and report success — the exact mistake `ui.vars.setModeValue`
+// (exec-stdlib-variables.ts) exists to never repeat. Now it throws, naming the
+// modes that do exist, matching that sibling helper's behavior for the same case.
+import { describe, it, expect } from 'vitest';
+import { installMockFigma } from './helpers/mock-figma.ts';
+import { opCreateVariable } from '../plugin/src/main/executor-variables.ts';
+
+describe('opCreateVariable — params.mode', () => {
+  it('sets the value for an existing named mode', async () => {
+    const figma = installMockFigma();
+    const collection = figma.variables.createVariableCollection('Tokens');
+    collection.renameMode(collection.modes[0]!.modeId, 'Light');
+    const darkModeId = collection.addMode('Dark');
+
+    const result = await opCreateVariable({
+      name: 'color/bg', type: 'COLOR', value: '#000000', collection: 'Tokens', mode: 'Dark',
+    });
+
+    const variable = (await figma.variables.getLocalVariablesAsync()).find((v) => v.id === result.id);
+    expect(variable?.valuesByMode?.[darkModeId]).toEqual({ r: 0, g: 0, b: 0, a: 1 });
+  });
+
+  it('throws E_INVALID_ARGS naming the available modes when params.mode does not exist', async () => {
+    const figma = installMockFigma();
+    figma.variables.createVariableCollection('Tokens'); // default mode: 'Mode 1'
+
+    await expect(opCreateVariable({
+      name: 'color/bg', type: 'COLOR', value: '#000000', collection: 'Tokens', mode: 'Nonexistent',
+    })).rejects.toMatchObject({
+      code: 'E_INVALID_ARGS',
+      message: expect.stringContaining('Mode 1'),
+    });
+  });
+
+  it('creates the variable with no mode write at all when params.mode is absent', async () => {
+    installMockFigma();
+    const result = await opCreateVariable({ name: 'color/bg', type: 'COLOR', value: '#000000' });
+    expect(result.name).toBe('color/bg');
+    expect(result.reused).toBe(false);
+  });
+});

--- a/tests/helpers/mock-figma.ts
+++ b/tests/helpers/mock-figma.ts
@@ -201,6 +201,20 @@ export class FakeNode {
     return this._main;
   }
 
+  /** ComponentNode.clone() — duplicate + auto-insert as the next sibling, exactly
+   * as Figma does (unlike the private `cloneAs` this uses, which the createInstance/
+   * swapComponent internals need WITHOUT the sibling-insert side effect). Backs
+   * `ui.componentSet`'s mode-1 clone-the-base path (absorption phase-01). */
+  clone(): FakeNode {
+    const copy = this.cloneAs(this.type);
+    if (this.parent) {
+      const idx = this.parent.children.indexOf(this);
+      this.parent.children.splice(idx + 1, 0, copy);
+      copy.parent = this.parent;
+    }
+    return copy;
+  }
+
   /** resize() FIXES both axes of an auto-layout frame — Figma's documented
    * behaviour, and the one the permissive mock skipped. createFrameNode resizes
    * AFTER applying auto-layout, so without this every AUTO frame round-tripped as
@@ -613,16 +627,21 @@ function setBoundVariableForPaint(
 
 /** A Variable, as the plugin API models one: identity + a value per mode.
  * `remote`/`key` are the PUBLISHED (library) variable's identity — Figma sets
- * remote=true and a stable publish key on a variable that lives in another file. */
+ * remote=true and a stable publish key on a variable that lives in another file.
+ * `description` and `remove()` back the Basket-B `ui.vars.*` helpers (absorption
+ * phase-01) — every factory below wires a working `remove()` that actually
+ * splices the variable out of whichever list it lives in, never a no-op stub. */
 export interface FakeVariable {
   id: string;
   name: string;
+  description?: string;
   resolvedType?: string;
   variableCollectionId?: string;
   remote?: boolean;
   key?: string;
   valuesByMode?: Record<string, unknown>;
   setValueForMode?(modeId: string, value: unknown): void;
+  remove(): void;
 }
 
 /** The file's LOCAL variables, as getLocalVariablesAsync reports them. A binding
@@ -636,7 +655,11 @@ export function setMockLocalVariables(vars: FakeVariable[]): void {
 /** A local variable that already EXISTS in the file — what a rebuild-from-spec
  * must find by name (spec-005 P6). */
 export function makeMockVariable(name: string, resolvedType = 'COLOR'): FakeVariable {
-  return { id: `VariableID:${idSeq++}`, name, resolvedType };
+  const v: FakeVariable = {
+    id: `VariableID:${idSeq++}`, name, resolvedType,
+    remove() { localVariables = localVariables.filter((x) => x !== v); },
+  };
+  return v;
 }
 
 /** A LOCAL variable that carries a publish key — what the live probe of
@@ -645,7 +668,11 @@ export function makeMockVariable(name: string, resolvedType = 'COLOR'): FakeVari
  * getVariableByIdAsync, but importVariableByKeyAsync refuses its key (nothing
  * published it), so a rebuild that leans on the import road alone loses it. */
 export function makeMockKeyedLocalVariable(name: string, key: string, resolvedType = 'COLOR'): FakeVariable {
-  return { id: `VariableID:${idSeq++}`, name, key, remote: false, resolvedType };
+  const v: FakeVariable = {
+    id: `VariableID:${idSeq++}`, name, key, remote: false, resolvedType,
+    remove() { localVariables = localVariables.filter((x) => x !== v); },
+  };
+  return v;
 }
 
 /** PUBLISHED variables living in a subscribed library. The contract that matters:
@@ -659,14 +686,24 @@ export function setMockLibraryVariables(vars: FakeVariable[]): void {
 
 /** A published library variable: bound by id on the canvas, reattached by key. */
 export function makeMockLibraryVariable(name: string, key: string, resolvedType = 'COLOR'): FakeVariable {
-  return { id: `VariableID:${idSeq++}`, name, key, remote: true, resolvedType };
+  const v: FakeVariable = {
+    id: `VariableID:${idSeq++}`, name, key, remote: true, resolvedType,
+    remove() { libraryVariables = libraryVariables.filter((x) => x !== v); },
+  };
+  return v;
 }
 
-/** The file's variable COLLECTIONS, as the token-import path finds/creates them. */
-interface FakeCollection {
+/** The file's variable COLLECTIONS, as the token-import path finds/creates them.
+ * `addMode`/`removeMode`/`renameMode` back the Basket-B `ui.vars.*` mode helpers
+ * (absorption phase-01) — real Figma methods on VariableCollection, not storage
+ * a caller pokes directly (`modes` is READ from, never written to, outside them). */
+export interface FakeCollection {
   id: string;
   name: string;
   modes: Array<{ modeId: string; name: string }>;
+  addMode(name: string): string;
+  removeMode(modeId: string): void;
+  renameMode(modeId: string, newName: string): void;
 }
 let collections: FakeCollection[] = [];
 export function setMockVariableCollections(cols: FakeCollection[]): void {
@@ -678,6 +715,26 @@ function createVariableCollection(name: string): FakeCollection {
     id: `VariableCollectionId:${idSeq++}`,
     name,
     modes: [{ modeId: `m${idSeq++}`, name: 'Mode 1' }],
+    addMode(modeName: string): string {
+      const modeId = `m${idSeq++}`;
+      col.modes.push({ modeId, name: modeName });
+      return modeId;
+    },
+    removeMode(modeId: string): void {
+      // Figma refuses to remove the LAST mode a collection has — mirrored here so
+      // a test proving that refusal doesn't need a live canvas to see it.
+      if (col.modes.length <= 1) {
+        throw new Error('in removeMode: Cannot remove the last mode of a variable collection');
+      }
+      const before = col.modes.length;
+      col.modes = col.modes.filter((m) => m.modeId !== modeId);
+      if (col.modes.length === before) throw new Error(`in removeMode: mode not found: ${modeId}`);
+    },
+    renameMode(modeId: string, newName: string): void {
+      const mode = col.modes.find((m) => m.modeId === modeId);
+      if (!mode) throw new Error(`in renameMode: mode not found: ${modeId}`);
+      mode.name = newName;
+    },
   };
   collections.push(col);
   return col;
@@ -720,6 +777,7 @@ export function makeMockComponent(name: string, key?: string): FakeNode {
 
 export interface MockFigma {
   mixed: symbol;
+  currentPage: FakeNode;
   createFrame(): FakeNode;
   createText(): FakeNode;
   createRectangle(): FakeNode;
@@ -728,6 +786,10 @@ export interface MockFigma {
   listAvailableFontsAsync(): Promise<Array<{ fontName: FontName }>>;
   getNodeByIdAsync(id: string): Promise<FakeNode | null>;
   importComponentByKeyAsync(key: string): Promise<FakeNode>;
+  /** figma.combineAsVariants(nodes, parent) — moves each node into a new
+   * COMPONENT_SET appended to `parent`, and derives componentPropertyDefinitions
+   * from every child's "Prop=Value, ..." name, exactly as Figma parses them. */
+  combineAsVariants(nodes: FakeNode[], parent: FakeNode): FakeNode;
   variables: {
     setBoundVariableForPaint: typeof setBoundVariableForPaint;
     getLocalVariablesAsync(type?: string): Promise<FakeVariable[]>;
@@ -752,6 +814,7 @@ export function installMockFigma(): MockFigma {
   };
   const figma: MockFigma = {
     mixed: FIGMA_MIXED,
+    currentPage: (() => { const p = new FakeNode('PAGE'); p.name = 'Page 1'; return p; })(),
     createFrame: () => mk('FRAME'),
     createText: () => mk('TEXT'),
     createRectangle: () => mk('RECTANGLE'),
@@ -766,6 +829,33 @@ export function installMockFigma(): MockFigma {
       const found = components.find((c) => c.key === key);
       if (!found) throw new Error(`component key not found: ${key}`); // the library-miss edge
       return found;
+    },
+    combineAsVariants: (nodes: FakeNode[], parent: FakeNode) => {
+      const set = new FakeNode('COMPONENT_SET');
+      set.name = nodes[0]?.name ?? 'Component Set';
+      for (const n of nodes) {
+        if (n.parent) n.parent.children = n.parent.children.filter((c) => c !== n);
+        n.parent = set;
+        set.children.push(n);
+      }
+      parent.appendChild(set);
+      // Derive componentPropertyDefinitions from every child's "Prop=Value, ..."
+      // name — Figma parses variant properties out of the names, never stores
+      // them separately, so a mock that hand-stored them could hide a naming bug.
+      const defs: Record<string, { type: string; defaultValue: string; variantOptions: string[] }> = {};
+      for (const n of nodes) {
+        for (const part of n.name.split(', ')) {
+          const eq = part.indexOf('=');
+          if (eq === -1) continue;
+          const prop = part.slice(0, eq).trim();
+          const value = part.slice(eq + 1).trim();
+          if (!defs[prop]) defs[prop] = { type: 'VARIANT', defaultValue: value, variantOptions: [] };
+          if (!defs[prop].variantOptions.includes(value)) defs[prop].variantOptions.push(value);
+        }
+      }
+      set.componentPropertyDefinitions = defs;
+      nodesById.set(set.id, set);
+      return set;
     },
     variables: {
       setBoundVariableForPaint,

--- a/tests/helpers/mock-figma.ts
+++ b/tests/helpers/mock-figma.ts
@@ -215,6 +215,16 @@ export class FakeNode {
     return copy;
   }
 
+  /** BaseNode.remove() — detaches this node from its parent. Backs `ui.componentSet`'s
+   * self-compensating rollback (stage-4 review, PR #10 issue 2): a clone it created
+   * gets removed again if a LATER step in the same call throws. */
+  remove(): void {
+    if (this.parent) {
+      this.parent.children = this.parent.children.filter((c) => c !== this);
+      this.parent = null;
+    }
+  }
+
   /** resize() FIXES both axes of an auto-layout frame — Figma's documented
    * behaviour, and the one the permissive mock skipped. createFrameNode resizes
    * AFTER applying auto-layout, so without this every AUTO frame round-tripped as
@@ -710,12 +720,22 @@ export function setMockVariableCollections(cols: FakeCollection[]): void {
   collections = cols;
 }
 
+/** Test-configurable stand-in for Figma's real (plan- and date-dependent — see
+ * knowledge/variables-and-modes.md §2) mode-count cap. Not a claim about what the
+ * real limit is; just a deterministic way for a test to exercise the refusal path
+ * `ui.vars.addMode`'s catch depends on (stage-4 review, PR #10 minor 3). */
+let mockModeCap: number | null = null;
+export function setMockModeCap(cap: number | null): void { mockModeCap = cap; }
+
 function createVariableCollection(name: string): FakeCollection {
   const col: FakeCollection = {
     id: `VariableCollectionId:${idSeq++}`,
     name,
     modes: [{ modeId: `m${idSeq++}`, name: 'Mode 1' }],
     addMode(modeName: string): string {
+      if (mockModeCap !== null && col.modes.length >= mockModeCap) {
+        throw new Error(`in addMode: Limited to ${mockModeCap} modes only`);
+      }
       const modeId = `m${idSeq++}`;
       col.modes.push({ modeId, name: modeName });
       return modeId;
@@ -748,8 +768,14 @@ function createVariable(name: string, collection: FakeCollection, resolvedType: 
     resolvedType,
     variableCollectionId: collection.id,
     valuesByMode: {},
+    // Stores a STRUCTURAL CLONE, never the caller's own reference — Figma serializes
+    // a mode value into the file, it doesn't keep your object alive. A by-reference
+    // mock let a reference-equality verification bug (comparing `actual === value`)
+    // pass here while the same call would throw live: `actual` must be a genuinely
+    // DIFFERENT object than `value` for a structural-equality bug to be catchable at
+    // all (stage-4 review, PR #10 issue 1).
     setValueForMode(modeId: string, value: unknown) {
-      (this.valuesByMode as Record<string, unknown>)[modeId] = value;
+      (this.valuesByMode as Record<string, unknown>)[modeId] = JSON.parse(JSON.stringify(value));
     },
   };
   localVariables.push(v);
@@ -807,6 +833,7 @@ export function installMockFigma(): MockFigma {
   libraryVariables = [];
   collections = [];
   effectStyles = [];
+  mockModeCap = null;
   const mk = (type: string): FakeNode => {
     const n = new FakeNode(type);
     if (type === 'TEXT') n.name = 'Text';
@@ -831,6 +858,18 @@ export function installMockFigma(): MockFigma {
       return found;
     },
     combineAsVariants: (nodes: FakeNode[], parent: FakeNode) => {
+      // Real Figma refusals, encoded so the mock is trustworthy independent of a
+      // caller's own pre-checks (stage-4 review, PR #10 minor 3) — the same
+      // philosophy as removeMode refusing the last mode above.
+      if (nodes.length === 0) throw new Error('in combineAsVariants: at least one node is required');
+      for (const n of nodes) {
+        if (n.type !== 'COMPONENT') {
+          throw new Error(`in combineAsVariants: node "${n.name}" (${n.id}) is not a COMPONENT`);
+        }
+        if (n.parent?.type === 'COMPONENT_SET') {
+          throw new Error(`in combineAsVariants: node "${n.name}" (${n.id}) already belongs to a component set`);
+        }
+      }
       const set = new FakeNode('COMPONENT_SET');
       set.name = nodes[0]?.name ?? 'Component Set';
       for (const n of nodes) {


### PR DESCRIPTION
Closes #1.

## Summary
- `ui.vars.*` (rename/remove/describe a variable, add/rename/remove a mode, setModeValue) — every helper verifies its own write, throws E_EVAL on mismatch.
- `ui.componentSet(...)` — variant-matrix or combine-existing COMPONENT_SET builder, adapted from figma-console-mcp's `figma_create_component_set` (MIT, see THIRD-PARTY.md). Deliberately does NOT port the fork's manual rollback bookkeeping — this repo's own `--undo-group` bracket already gives atomic rollback.
- Fixes a pre-existing swallowed failure: `CREATE_VARIABLE --mode <unknown>` used to silently no-op and report success; now throws, naming the modes that exist.
- Two new knowledge recipes (`variables-and-modes.md`, `component-sets.md`) — the analysis recipe explicitly documents and avoids two bugs found in the studied fork (a case-sensitive `state=default` match, and a "guess the main interactive child" heuristic).
- `THIRD-PARTY.md` — MIT attribution table.

## Test plan
- [x] Test-first: the `CREATE_VARIABLE` fix and the component-set verify-mismatch path each have a dedicated regression test, proven to fail against the pre-fix code (revert → confirm fail → restore → confirm green).
- [x] 34 new tests (14 `exec-stdlib-variables`, 17 `exec-stdlib-component-set` + pure-matrix, 3 `executor-variables` regression).
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (cli 228.0kb, plugin 140.0kb)
- [x] `npm test` — 79 files / 1013 tests green (was 79/979 before this branch; +34 explained above, no unexplained drift)
- [x] Panel gate (`kernel/design-os` submodule) — 43/43 green

## NOT done — flagging, not faking
The plan's own Definition of Done asks for a real-canvas live run (build a variant matrix, exercise `ui.vars.*` end-to-end, confirm the `state=Default` case-sensitivity fix on a real set, confirm `--undo-group` rollback on a thrown script). I could not do this from this session: `figma-agent status` on this machine currently shows a broker with **no plugin connected** (`plugins: []`), and driving the Figma Desktop GUI to open/connect one is outside what I can do (no foreground GUI control). Every `[re-verify]` tag in the two new knowledge docs is worded as "unverified, from the fork" per the plan's own fallback instruction (§7) rather than claimed as confirmed. Needs an owner or a session with an actual connected canvas to close out.

Holding for review.