### PR TITLE
Audit fix: reply sender-verification in routeFromPlugin + op-scaled BATCH timeout

### DIFF
--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -2,7 +2,7 @@
 // BATCH request (single round-trip; plugin executes sequentially).
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { COMMANDS, type CommandName } from '../../../shared/protocol.ts';
+import { COMMAND_TIMEOUTS, COMMANDS, DEFAULT_TIMEOUT_MS, type CommandName } from '../../../shared/protocol.ts';
 import type { CommandArgs } from '../figma-agent.ts';
 import { CliError } from '../transport/protocol-helpers.ts';
 import { runCommand } from '../transport/broker-client.ts';
@@ -31,9 +31,51 @@ function loadOps(filePath: string): BatchOp[] {
   });
 }
 
+/**
+ * Audit backlog 2.10, phase 2 — BATCH executes every op sequentially in ONE
+ * uncancellable pass (the plugin sandbox cannot be interrupted mid-sequence), so a
+ * fixed timeout that fires early doesn't stop the work — it just makes the CLI's
+ * report contradict the file state (ops keep landing after the reported "failure")
+ * and invites a duplicate retry that double-applies. Mirrors
+ * southleft/figma-console-mcp's `componentSetTimeoutMs` (per-unit budget, floor,
+ * cap, hop buffer over the same base formula) — adapted per-OP rather than
+ * per-variant: this codebase has no CREATE_COMPONENT_SET-equivalent single
+ * command, so BATCH (N ops, one round trip, one uncancellable pass) is the
+ * structurally closest analog available to scale.
+ *
+ * Never scales BELOW `COMMAND_TIMEOUTS.BATCH` (today's fixed default): an ordinary
+ * batch keeps today's exact timeout unchanged. Only once `opCount * PER_OP_MS +
+ * HOP_BUFFER_MS` would exceed that default does the wait actually grow, capped at
+ * `CAP_MS` — mirroring the fork's own cap.
+ */
+export function batchTimeoutMs(opCount: number): number {
+  const PER_OP_MS = 1_200; // mirrors componentSetTimeoutMs's per-unit budget
+  const HOP_BUFFER_MS = 5_000; // mirrors the fork's buffer over its own hop
+  const CAP_MS = 120_000; // same cap the fork uses
+  const base = COMMAND_TIMEOUTS.BATCH ?? DEFAULT_TIMEOUT_MS;
+  const scaled = opCount * PER_OP_MS + HOP_BUFFER_MS;
+  return Math.min(CAP_MS, Math.max(base, scaled));
+}
+
+/** A command runner (the BATCH transport call), injectable for tests. */
+export type Runner = (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => Promise<unknown>;
+
+/**
+ * Decoupled from `CommandArgs` + the real transport so it is unit-testable with a
+ * stub runner and a fixture file, matching `scan-design-system.ts`'s `execute`
+ * pattern.
+ */
+export async function execute(
+  filePath: string,
+  stopOnError: boolean,
+  runner: Runner = runCommand,
+): Promise<unknown> {
+  const ops = loadOps(resolve(filePath));
+  return runner('BATCH', { ops, stopOnError }, { timeoutMs: batchTimeoutMs(ops.length) });
+}
+
 export async function run(args: CommandArgs): Promise<unknown> {
   const fileArg = args.positionals[0];
   if (!fileArg) throw new CliError('E_INVALID_ARGS', 'usage: figma-agent batch <file.json> [--stop-on-error]');
-  const ops = loadOps(resolve(fileArg));
-  return runCommand('BATCH', { ops, stopOnError: args.bool('stop-on-error') });
+  return execute(fileArg, args.bool('stop-on-error'));
 }

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -35,7 +35,7 @@ import {
   resolveProjectDir, writeBindCache, writeBindMarker, type Binding,
 } from './project-bind.ts';
 import {
-  JobTable, isFinishedState, toJobInfo, type JobRecord,
+  JobTable, isFinishedState, isReplyFromDispatchedInstance, toJobInfo, type JobRecord,
 } from './job-table.ts';
 import {
   completeSkippingStale, emptyQueue, enqueue as enqueueJob, queuePosition, remove as removeFromQueue,
@@ -376,6 +376,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // filesystem is exactly the state a resurrection would be repairing.
   let ownsAdvertisement = true;
   log(`broker listening on ${LOOPBACK_HOST}:${port}${wss6 ? ' + [::1]:' + port : ''} (${bindIndex.size} project binding(s) loaded)`);
+
+  // Sender-verification counter (backlog 2.10) — how many reply frames `routeFromPlugin`
+  // discarded because the sending socket's plugin instance did not match the job's
+  // `targetInstanceId`. Logged for visibility ("nothing vanishes silently"); scoped to
+  // this daemon run (a closure local, not module-level) so it never leaks across daemon
+  // instances started back-to-back within the same test process.
+  let senderMismatchCount = 0;
 
   // Error log writer (backlog 4.6): resolved once, one line per ReplyErr the broker relays.
   const errorsPath = errorLogPath();
@@ -850,12 +857,34 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (delivered > 0) log(`flushed ${delivered} parked request(s)`);
   };
 
-  const routeFromPlugin = (id: string, rawText: string, final: boolean): void => {
+  /**
+   * `senderWs` is the socket that ACTUALLY sent this reply/chunk frame — verified
+   * against the job's pinned `targetInstanceId` (backlog 2.10 audit) before anything
+   * below is allowed to touch `pending`/job state. Pre-fix, this function took only
+   * `(id, rawText, final)` and routed on `id` alone: any OTHER connected plugin
+   * instance sending a reply carrying the SAME id (reachable via a CLI-side request-id
+   * collision — ids are minted `c_<counter>_<ts>` per CLI PROCESS, so two concurrent
+   * CLI invocations can collide within the same millisecond) was accepted and forwarded
+   * to whichever CLI was waiting on that id, with no signal it came from the wrong
+   * plugin. A mismatched sender is now discarded outright — same shape as the
+   * already-terminal-job discard below (count + log, never mutate `replyFrames` or
+   * `pending`), so the REAL dispatched plugin's reply (or the watchdog timeout) is
+   * still what resolves the job.
+   */
+  const routeFromPlugin = (id: string, rawText: string, final: boolean, senderWs: WebSocket): void => {
+    const job = st.jobs.byRequestId(id);
+    const senderInstanceId = st.registry.getByWs(senderWs)?.instanceId ?? null;
+    if (!isReplyFromDispatchedInstance(job, senderInstanceId)) {
+      senderMismatchCount += 1;
+      log(`reply for job ${job?.jobId ?? '?'} (request ${id}) arrived from instance ` +
+        `[${senderInstanceId ?? 'unrecognised socket'}], expected [${job?.targetInstanceId}] — ` +
+        `discarded (sender mismatch #${senderMismatchCount})`);
+      return; // never touch pending/job state — the real dispatched target may still answer
+    }
     const client = st.pending.get(id);
     if (client && client.readyState === WebSocket.OPEN) {
       try { client.send(rawText); } catch { /* requester vanished */ }
     }
-    const job = st.jobs.byRequestId(id);
     if (job && isFinishedState(job.state)) {
       // Closing round (R1+R2 unified, reviewer Q1) — this job is ALREADY terminal
       // (force-released, watchdog-timed-out, or a genuine prior finish): this frame is
@@ -1092,13 +1121,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // THEN admits the request with its real `cmd`/`readOnly`/`expectedFile`/
       // `projectDir` — never a synthetic pseudo-command that would misroute a filtered
       // request or force a declared-read-only EXEC_JS to queue.
-      if (isPlugin) { st.registry.touchActive(ws); routeFromPlugin(msg.id, text, msg.last); }
+      if (isPlugin) { st.registry.touchActive(ws); routeFromPlugin(msg.id, text, msg.last, ws); }
       else admitChunk(ws, msg.id, text, msg.last);
     } else if (isReplyMsg(msg)) {
       if (isPlugin) {
         st.registry.touchActive(ws);
         broadcastPeers();
-        routeFromPlugin(msg.id, text, true);
+        routeFromPlugin(msg.id, text, true, ws);
         // Error log writer (backlog 4.6): every FAILED reply the broker relays, logged
         // regardless of whether a CLI is still around to read it live.
         if (!msg.ok) {

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -28,6 +28,39 @@ export function isFinishedState(state: JobInfo['state']): boolean {
   return FINISHED_STATES.has(state);
 }
 
+/**
+ * Sender verification (backlog 2.10) — whether a reply frame's ACTUAL sender is the
+ * plugin instance a job was dispatched to. `routeFromPlugin` (broker-daemon.ts) used to
+ * accept a reply keyed on `id` alone: it never checked which socket sent it against
+ * `job.targetInstanceId` (pinned at admission — see `JobRecord.targetInstanceId`'s own
+ * doc). Any OTHER currently-connected plugin instance sending a reply carrying the same
+ * `id` — reachable via a request-id collision (ids are minted CLI-process-side as
+ * `c_<counter>_<ts>`; two concurrent CLI invocations can collide within the same
+ * millisecond) — was routed to the waiting CLI as though it were the real dispatched
+ * plugin's answer, with zero signal that it wasn't.
+ *
+ * Deliberately identity-based (instanceId), never raw WebSocket-reference-based: a
+ * plugin's own reconnect (Figma iframe reload) replaces its socket in the registry
+ * while keeping the SAME instanceId (`PluginRegistry.register`'s `carried` id), so a
+ * ws-equality check would misclassify an honest reconnect as a spoof. This still
+ * correctly rejects the actual vulnerability (a genuinely DIFFERENT instance's socket),
+ * because that instance carries its OWN distinct instanceId.
+ *
+ * `senderInstanceId` is `null`/`undefined` when the registry does not recognise the
+ * sending socket at all (e.g. a stale reference to an already-superseded pre-reconnect
+ * socket) — treated the same as a genuine mismatch, never as a pass: an unidentifiable
+ * sender is not a verified one. A `job` of `undefined` (unknown/expired id — nothing to
+ * verify against) is not this function's concern; `routeFromPlugin`'s existing
+ * "no job found" handling already no-ops safely for that case.
+ */
+export function isReplyFromDispatchedInstance(
+  job: Pick<JobRecord, 'targetInstanceId'> | undefined,
+  senderInstanceId: string | null | undefined,
+): boolean {
+  if (!job) return true;
+  return senderInstanceId != null && senderInstanceId === job.targetInstanceId;
+}
+
 export interface JobRecord extends JobInfo {
   /** The join to `pending` / `dispatchedTo` — the SAME id `routeFromPlugin` routes replies by. */
   requestId: string;

--- a/tests/batch-timeout-scaling.test.ts
+++ b/tests/batch-timeout-scaling.test.ts
@@ -1,0 +1,110 @@
+// Backlog 2.10 audit, phase 2 — BATCH's per-attempt wire timeout scales by op count
+// instead of one fixed ceiling, mirroring southleft/figma-console-mcp's
+// componentSetTimeoutMs (per-unit budget, floor, cap, hop buffer) adapted per-OP
+// (this codebase has no CREATE_COMPONENT_SET-equivalent single command — BATCH, N ops
+// in one uncancellable round trip, is the structurally closest analog). `batchTimeoutMs`
+// and `execute` did not exist before this fix (batch.ts only had `run`, which called
+// runCommand with no timeoutMs override at all — every batch used the flat
+// COMMAND_TIMEOUTS.BATCH regardless of size).
+import { describe, expect, it } from 'vitest';
+import { writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { batchTimeoutMs, execute, type Runner } from '../cli/src/commands/batch.ts';
+import { COMMAND_TIMEOUTS } from '../shared/protocol.ts';
+
+const BASE_MS = COMMAND_TIMEOUTS.BATCH!;
+
+describe('batchTimeoutMs — scales past the fixed default, never below it', () => {
+  it('an ordinary small batch keeps the EXACT unchanged default', () => {
+    expect(batchTimeoutMs(1)).toBe(BASE_MS);
+    expect(batchTimeoutMs(10)).toBe(BASE_MS);
+  });
+
+  it('REGRESSION LOCK: a batch large enough that 1.2s/op + the hop buffer exceeds the default scales UP past it', () => {
+    // 1.2s * 100 + 5s = 125s, well past the 60s default and above the 120s cap.
+    const scaledButUncapped = batchTimeoutMs(46); // 1.2*46+5 = 60.2s > 60s base
+    expect(scaledButUncapped).toBeGreaterThan(BASE_MS);
+  });
+
+  it('caps at 120s regardless of how large the batch is', () => {
+    expect(batchTimeoutMs(1_000)).toBe(120_000);
+    expect(batchTimeoutMs(1_000_000)).toBe(120_000);
+  });
+
+  it('is monotonically non-decreasing in op count', () => {
+    let prev = batchTimeoutMs(0);
+    for (const n of [1, 5, 20, 46, 60, 100, 200]) {
+      const cur = batchTimeoutMs(n);
+      expect(cur).toBeGreaterThanOrEqual(prev);
+      prev = cur;
+    }
+  });
+});
+
+describe('batch execute() — threads the scaled timeout into the transport call', () => {
+  let scratchDir: string;
+
+  function writeBatchFile(ops: Array<{ cmd: string; params: unknown }>): string {
+    scratchDir = mkdtempSync(join(tmpdir(), 'fa-batch-timeout-'));
+    const filePath = join(scratchDir, 'ops.json');
+    writeFileSync(filePath, JSON.stringify(ops));
+    return filePath;
+  }
+
+  function cleanup(): void {
+    if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+  }
+
+  it('a small batch gets the unchanged default timeout', async () => {
+    const ops = Array.from({ length: 3 }, () => ({ cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' } }));
+    const filePath = writeBatchFile(ops);
+    try {
+      const calls: Array<{ cmd: string; params: unknown; opts?: { timeoutMs?: number } }> = [];
+      const runner: Runner = async (cmd, params, opts) => {
+        calls.push({ cmd, params, opts });
+        return { ok: true };
+      };
+      await execute(filePath, false, runner);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.cmd).toBe('BATCH');
+      expect(calls[0]?.opts?.timeoutMs).toBe(BASE_MS);
+      expect((calls[0]?.params as { ops: unknown[] }).ops).toHaveLength(3);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('a large batch gets a scaled timeout matching batchTimeoutMs(opCount)', async () => {
+    const ops = Array.from({ length: 60 }, () => ({ cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' } }));
+    const filePath = writeBatchFile(ops);
+    try {
+      const calls: Array<{ opts?: { timeoutMs?: number } }> = [];
+      const runner: Runner = async (cmd, params, opts) => {
+        calls.push({ opts });
+        return { ok: true };
+      };
+      await execute(filePath, false, runner);
+      expect(calls[0]?.opts?.timeoutMs).toBe(batchTimeoutMs(60));
+      expect(calls[0]?.opts?.timeoutMs).toBeGreaterThan(BASE_MS);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('threads stopOnError through unchanged', async () => {
+    const filePath = writeBatchFile([{ cmd: 'SET_TEXT', params: {} }]);
+    try {
+      const calls: Array<{ params: unknown }> = [];
+      const runner: Runner = async (cmd, params) => {
+        calls.push({ params });
+        return { ok: true };
+      };
+      await execute(filePath, true, runner);
+      expect((calls[0]?.params as { stopOnError: boolean }).stopOnError).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -483,3 +483,58 @@ describe('daemon harness — advertisement self-heals while alive, never resurre
     expect(existsSync(advertisePath)).toBe(false);
   });
 });
+
+// Backlog 2.10 audit — sender verification in routeFromPlugin. AUDIT FINDING:
+// `routeFromPlugin` routed a reply frame to the waiting CLI keyed on `id` ALONE — it
+// never checked which socket actually sent the frame against `job.targetInstanceId`
+// (the plugin instance the job was dispatched to, pinned at admission). ANY other
+// currently-connected plugin instance sending a reply carrying the same `id` was
+// accepted and forwarded as if it were the real dispatched plugin's answer. Reachable
+// in practice via a CLI-side request-id collision: ids are minted `c_<counter>_<ts>`
+// per CLI PROCESS (`requestCounter` resets to 0 on every fresh `figma-agent` invocation),
+// so two concurrent CLI invocations issuing their first command in the same millisecond
+// produce identical ids. The fix (job-table.ts's `isReplyFromDispatchedInstance`,
+// wired into `routeFromPlugin` with the sender's `ws`) verifies by INSTANCE IDENTITY,
+// not raw socket reference, so an honest plugin reconnect (new ws, same instanceId)
+// still completes its own job normally — only a genuinely different instance's reply
+// is discarded.
+describe('daemon harness — routeFromPlugin verifies the reply sender against the dispatched instance (backlog 2.10)', () => {
+  it('a reply from a DIFFERENT plugin instance carrying the dispatched job\'s id is discarded, not delivered to the waiting CLI', async () => {
+    const port = await startTestBroker();
+    const pluginX = await connectSocket(port);
+    const pluginY = await connectSocket(port);
+    await helloPlugin(pluginX, 'inst-x', 'FileX');
+    await helloPlugin(pluginY, 'inst-y', 'FileY');
+
+    const cli = await connectSocket(port);
+    const reqId = 'req-sender-verify-1';
+    // `expectedFile` pins dispatch to X specifically — two plugins are connected, so
+    // dispatch must not depend on ambient recency to land on X.
+    cli.send(JSON.stringify(makeRequestFrame(reqId, 'SET_TEXT', { nodeId: '1:1', text: 'x' }, undefined, 'FileX')));
+    await nextFrame(cli, (m) => (m as EventMsg).type === 'JOB_STATE'); // dispatch confirmed
+
+    // Y (a DIFFERENT, genuinely connected instance) sends a reply carrying X's dispatched
+    // id — simulating the collision/cross-talk this audit exists to catch.
+    pluginY.send(JSON.stringify({ id: reqId, ok: true, result: { spoofed: true, from: 'Y' } }));
+
+    // X (the REAL dispatched target) sends its own, later, genuine reply.
+    pluginX.send(JSON.stringify({ id: reqId, ok: true, result: { spoofed: false, from: 'X' } }));
+
+    const reply = await nextFrame<ReplyOk>(cli, (m) => (m as ReplyOk | ReplyErr).id === reqId);
+    // The FIRST (and only) frame the CLI actually receives for this id must be X's real
+    // reply — Y's spoofed frame must never have reached it at all.
+    expect(reply.result).toEqual({ spoofed: false, from: 'X' });
+  });
+
+  // NOTE on reconnect: a full end-to-end "reconnect, then the NEW socket answers the
+  // OLD dispatched id" integration test is not exercised here, because it races an
+  // orthogonal, PRE-EXISTING behavior — `handleClose`'s disconnect-triggered job
+  // failure. The daemon closes the superseded (pre-reconnect) socket itself the
+  // moment the SAME instanceId re-HELLOs; that socket's 'close' event fires
+  // `handleClose`, which fails every job still pinned to it (E_NO_PLUGIN) BEFORE the
+  // reconnected socket could plausibly answer — unaffected by this fix either way.
+  // The identity-vs-socket-reference distinction this fix actually adds (an honest
+  // reconnect must not be misread as "a different instance") is proven directly and
+  // deterministically at the predicate level instead — see
+  // tests/job-table-sender-verification.test.ts.
+});

--- a/tests/job-table-sender-verification.test.ts
+++ b/tests/job-table-sender-verification.test.ts
@@ -1,0 +1,42 @@
+// Backlog 2.10 audit — `isReplyFromDispatchedInstance` is the pure decision core of
+// the fix wired into `routeFromPlugin` (see tests/broker-daemon-harness.test.ts for the
+// full-daemon spoofing scenario this closes). Unit-tested here in isolation because the
+// identity-vs-socket-reference distinction — the exact nuance the issue's "esp. around
+// reconnect with same instanceId, socket changed" called out — is deterministic and
+// racy to prove through a real WebSocket reconnect (it competes with the unrelated,
+// pre-existing `handleClose` disconnect-triggered job failure). `isReplyFromDispatchedInstance`
+// did not exist before this fix.
+import { describe, expect, it } from 'vitest';
+import { isReplyFromDispatchedInstance } from '../cli/src/transport/job-table.ts';
+
+describe('isReplyFromDispatchedInstance — identity-based, never socket-reference-based', () => {
+  it('the dispatched instance replying is authorized', () => {
+    expect(isReplyFromDispatchedInstance({ targetInstanceId: 'inst-x' }, 'inst-x')).toBe(true);
+  });
+
+  it('REGRESSION LOCK: a DIFFERENT instance replying with the same request id is rejected', () => {
+    // This is the exact audit finding — pre-fix, routeFromPlugin never made this
+    // comparison at all, so nothing distinguished this case from the one above.
+    expect(isReplyFromDispatchedInstance({ targetInstanceId: 'inst-x' }, 'inst-y')).toBe(false);
+  });
+
+  it('an unrecognised sender (registry has no entry for that socket — e.g. a stale reference to an already-superseded pre-reconnect socket) is never authorized', () => {
+    expect(isReplyFromDispatchedInstance({ targetInstanceId: 'inst-x' }, null)).toBe(false);
+    expect(isReplyFromDispatchedInstance({ targetInstanceId: 'inst-x' }, undefined)).toBe(false);
+  });
+
+  it('reconnect resilience: the SAME instanceId is authorized regardless of which literal socket carries it — identity, not a ws-reference, is what is checked', () => {
+    // Simulates PluginRegistry.register() replacing the ws for instanceId 'inst-x' on
+    // reconnect: the job's targetInstanceId (pinned at admission, before the
+    // reconnect) is unchanged, and the reconnected socket's registry entry reports the
+    // SAME instanceId — this must read as authorized, not as "a different instance".
+    const job = { targetInstanceId: 'inst-x' };
+    expect(isReplyFromDispatchedInstance(job, 'inst-x')).toBe(true); // pre-reconnect socket
+    expect(isReplyFromDispatchedInstance(job, 'inst-x')).toBe(true); // post-reconnect socket, same id
+  });
+
+  it('an unknown/expired job (nothing to verify against) is not this function\'s concern — routeFromPlugin\'s existing no-job handling already no-ops safely', () => {
+    expect(isReplyFromDispatchedInstance(undefined, 'inst-x')).toBe(true);
+    expect(isReplyFromDispatchedInstance(undefined, null)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #6.

## Audit finding (phase 1, reported before any fix)

**The hole exists.** `routeFromPlugin` (`cli/src/transport/broker-daemon.ts`) routed a
reply frame to the waiting CLI keyed on the wire `id` alone. It never checked which
socket actually sent the frame against `job.targetInstanceId` — the plugin instance a
job was pinned to at admission (`JobRecord.targetInstanceId`, already present in this
codebase's job table). Any OTHER currently-connected plugin instance sending a reply
carrying the same `id` was accepted and forwarded to the CLI as though it were the real
dispatched plugin's answer, with zero signal that it wasn't.

**How it's reachable.** Request ids are minted CLI-process-side as `c_<counter>_<ts>`
(`shared/protocol.ts`'s `makeRequestId`), and `requestCounter` resets to 0 on every fresh
`figma-agent` invocation. Two concurrent CLI invocations (two terminals, a script
launching parallel commands) issuing their first command in the same millisecond produce
identical ids. If those two commands dispatch to two different plugin instances (e.g. two
open Figma files), whichever admission call landed second silently overwrote `pending`/
`dispatchedTo` for that id — and the FIRST plugin's real reply then got routed to the
SECOND CLI caller as if it were the answer that CLI was waiting for.

**Reconnect nuance (the issue's specific callout).** A naive fix comparing raw
`WebSocket` object references would have broken a legitimate case: when a plugin
reconnects (Figma iframe reload), `PluginRegistry.register()` replaces the socket for the
SAME `instanceId` — any job dispatched before the reconnect still has the OLD ws in
`dispatchedTo`. A ws-reference check would misclassify the reconnected instance's own
reply as "a different instance". The fix verifies by **instance identity**
(`instanceId`), never socket reference, so this stays correct.

**Proof.** `tests/broker-daemon-harness.test.ts` — two genuinely distinct, simultaneously
connected plugin instances (X, Y); dispatch a job to X; Y sends a spoofed reply carrying
X's dispatched id; assert the CLI never receives Y's payload, only X's real one. This
test fails against pre-fix code (Y's spoofed `{spoofed: true, from: 'Y'}` was what the CLI
actually received).

## Fix (phase 1)

`isReplyFromDispatchedInstance` (`cli/src/transport/job-table.ts`) — a pure predicate
comparing the sender's registry-resolved `instanceId` against `job.targetInstanceId`.
Wired into `routeFromPlugin`, which now takes the sender's own `ws` at both of its call
sites (chunk and reply). A mismatch is counted + logged and discarded outright — never
touches `pending`/job state, so the real dispatched plugin's reply (or the existing
watchdog timeout) is still what resolves the job. Unit-tested directly in
`tests/job-table-sender-verification.test.ts` (dispatched-instance match, cross-instance
mismatch, unrecognised/superseded sender, reconnect-identity resilience, unknown-job
no-op) — deterministic, since racing a real WebSocket reconnect against the unrelated
pre-existing `handleClose` disconnect-triggered job failure is not a reliable integration
test (documented in the harness test file).

## Phase 2 — per-op timeout scaling

**Deviation flagged:** the issue's phrasing ("component-set-class operations scale by
variant count") assumes a `CREATE_COMPONENT_SET`-equivalent command. This codebase has no
such command — the structurally closest analog to "many variants built in one
uncancellable pass" is `BATCH` (N arbitrary ops executed sequentially in one round trip).
`batchTimeoutMs` (`cli/src/commands/batch.ts`) scales `BATCH`'s per-attempt timeout by op
count, adapting `componentSetTimeoutMs`'s formula (per-unit budget, floor, cap, hop
buffer) from southleft/figma-console-mcp — same 1.2s-per-unit budget and 120s cap, but
the floor is pinned to today's existing `COMMAND_TIMEOUTS.BATCH` (60s) so an ordinary
batch keeps its exact current timeout; only a batch large enough that `1.2s × opCount +
5s` would exceed 60s gets more room.

`batch.ts` gained an `execute(filePath, stopOnError, runner)` + injectable `Runner` type,
matching `scan-design-system.ts`'s existing DI pattern for testability without a live
broker.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build` (no drift in committed `plugin/code.js`/`cli/dist` — this PR never
      touches `plugin/src`)
- [x] `npm test` — 1068/1068 (up from 1055), re-run 3x for stability
- [x] Test-first verified honestly: stashed all source changes, confirmed all 13
      new/changed test cases fail against pre-fix code (the daemon-harness spoof test
      literally receives Y's spoofed payload instead of X's real one), restored the fix

## Not verified

- No live Figma plugin round-trip (no Figma Desktop instance in this environment).
- The full real-world reconnect race (superseded socket closing, `handleClose` racing a
  legitimately reconnected instance's reply) is not exercised end-to-end — see the note
  in `tests/broker-daemon-harness.test.ts` for why, and `tests/job-table-sender-verification.test.ts`
  for the deterministic identity-level proof instead.
- Did not add a `BATCH` size ceiling/warning (the fork's write-tools.ts advises splitting
  above ~40 variants) — out of scope for this backlog item as phrased; flagging in case a
  follow-up wants it.
