### PR TITLE
fix(broker): surface senderMismatchCount in the reply/status envelope

### DIFF
--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -32,6 +32,10 @@ export async function run(args: CommandArgs): Promise<unknown> {
     pid: ad.pid,
     uptimeMs: (hello.uptimeMs as number | undefined) ?? null,
     protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
+    // Sender-verification counter (backlog 2.10 / issue #15) — mirrors BROKER_HELLO's
+    // own byte-identical-when-zero contract: present only once a cross-instance reply
+    // has actually been discarded, so the common (zero) case stays unchanged here too.
+    ...(typeof hello.senderMismatchCount === 'number' && { senderMismatchCount: hello.senderMismatchCount }),
   };
   const all = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntryWithJob[]) : [];
 

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -1268,7 +1268,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     type: 'BROKER_HELLO',
     data: buildBrokerHelloData(
       st.registry,
-      { port, pid: process.pid, protocolV: PROTOCOL_VERSION, buildMtime: selfBuildMtime(), uptimeMs: Date.now() - startedAt },
+      {
+        port, pid: process.pid, protocolV: PROTOCOL_VERSION, buildMtime: selfBuildMtime(),
+        uptimeMs: Date.now() - startedAt, senderMismatchCount,
+      },
       currentFilter(),
       Date.now,
       jobStatusFor,

--- a/cli/src/transport/broker-status.ts
+++ b/cli/src/transport/broker-status.ts
@@ -25,6 +25,11 @@ export interface BrokerMeta {
   protocolV: number;
   buildMtime: number;
   uptimeMs: number;
+  /** Sender-verification counter (backlog 2.10 / issue #15) — how many reply frames
+   *  `routeFromPlugin` has discarded this daemon run because the sending socket's
+   *  plugin instance did not match the job's `targetInstanceId` (a spoofed/misrouted
+   *  cross-instance reply). Daemon-scoped, not per-job. */
+  senderMismatchCount: number;
 }
 
 /**
@@ -65,6 +70,13 @@ export function buildBrokerHelloData(
     uptimeMs: meta.uptimeMs,
     plugins: withJobs,
     activePlugin: target ? (target.scene.fileName as string | undefined) ?? null : null,
+    // Sender-verification counter (backlog 2.10 / issue #15) — same "discarded thing
+    // gets a machine-readable counter, but not one that clutters the common zero case"
+    // contract as job-table.ts's `resultDropped`/`lateReplyCount`: present only once a
+    // mismatch has actually happened, so a broker with zero spoofed replies (the
+    // overwhelming common case) keeps this payload byte-identical to before this field
+    // existed.
+    ...(meta.senderMismatchCount > 0 && { senderMismatchCount: meta.senderMismatchCount }),
     // ── legacy compat shim (mirrors the ACTIVE plugin) ──
     pluginConnected: connected,
     pluginState: connected ? 'connected' : 'disconnected',

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -72,6 +72,27 @@ function connectSocket(port: number): Promise<WebSocket> {
   });
 }
 
+/** Connect AND resolve with the greeting BROKER_HELLO frame — race-free by construction:
+ *  the broker sends BROKER_HELLO the instant its 'connection' handler fires (broker-
+ *  daemon.ts's `onConnection`), which can beat this client's own 'open' event under load
+ *  (both are separate events derived from the same handshake completing). Attaching the
+ *  `message` listener HERE, synchronously at socket construction — instead of the usual
+ *  `connectSocket` → `await 'open'` → THEN attach a listener sequence every other helper
+ *  uses — means the listener exists before any I/O can possibly happen, so no frame the
+ *  broker sends immediately on connect can ever be dropped waiting for a listener that
+ *  attaches only after a network round trip. */
+function connectAndAwaitBrokerHello(port: number): Promise<{ ws: WebSocket; hello: EventMsg }> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    sockets.push(ws);
+    ws.once('error', reject);
+    ws.on('message', (raw) => {
+      const msg = JSON.parse(raw.toString()) as WireMsg;
+      if ((msg as EventMsg).type === 'BROKER_HELLO') resolve({ ws, hello: msg as EventMsg });
+    });
+  });
+}
+
 /** Resolve on the next parsed frame matching `predicate` (default: any frame). */
 function nextFrame<T extends WireMsg | EventMsg>(ws: WebSocket, predicate?: (m: WireMsg) => boolean): Promise<T> {
   return new Promise((resolve) => {
@@ -537,4 +558,37 @@ describe('daemon harness — routeFromPlugin verifies the reply sender against t
   // reconnect must not be misread as "a different instance") is proven directly and
   // deterministically at the predicate level instead — see
   // tests/job-table-sender-verification.test.ts.
+
+  // Issue #15 (PR #14 review, non-blocking) — the discard above incremented a
+  // `senderMismatchCount` that was LOG-ONLY: no machine-readable trace of a spoofed/
+  // misrouted reply existed anywhere a caller could read. This repo's own law
+  // ("nothing vanishes silently") already surfaces this exact counter class
+  // (resultDropped, lateReplyCount) in envelopes — a discarded cross-instance reply is
+  // the most security-relevant member of that class, so it must surface too.
+  it('a discarded cross-instance reply bumps senderMismatchCount, visible on a fresh BROKER_HELLO', async () => {
+    const port = await startTestBroker();
+    const pluginX = await connectSocket(port);
+    const pluginY = await connectSocket(port);
+    await helloPlugin(pluginX, 'inst-x', 'FileX');
+    await helloPlugin(pluginY, 'inst-y', 'FileY');
+
+    const cli = await connectSocket(port);
+    const reqId = 'req-sender-verify-mismatch-count';
+    cli.send(JSON.stringify(makeRequestFrame(reqId, 'SET_TEXT', { nodeId: '1:1', text: 'x' }, undefined, 'FileX')));
+    await nextFrame(cli, (m) => (m as EventMsg).type === 'JOB_STATE');
+
+    // Y spoofs X's dispatched id — discarded by isReplyFromDispatchedInstance.
+    pluginY.send(JSON.stringify({ id: reqId, ok: true, result: { spoofed: true, from: 'Y' } }));
+    pluginX.send(JSON.stringify({ id: reqId, ok: true, result: { spoofed: false, from: 'X' } }));
+    await nextFrame<ReplyOk>(cli, (m) => (m as ReplyOk | ReplyErr).id === reqId); // drain X's real reply
+
+    // A NEW connection's BROKER_HELLO greeting (the same data `figma-agent status`
+    // reads via fetchBrokerHello) must now report the mismatch — daemon-scoped, not
+    // per-job, so it must be visible from ANY connection, not just the original CLI.
+    // `connectAndAwaitBrokerHello` (not `connectSocket` + `nextFrame`) is deliberate: the
+    // broker sends this greeting synchronously in its 'connection' handler, which can
+    // race this client's own 'open' event — see that helper's own doc.
+    const { hello } = await connectAndAwaitBrokerHello(port);
+    expect((hello.data as Record<string, unknown>).senderMismatchCount).toBe(1);
+  });
 });

--- a/tests/broker-status.test.ts
+++ b/tests/broker-status.test.ts
@@ -7,7 +7,7 @@ import { buildBrokerHelloData, noPluginMessage, type BrokerMeta } from '../cli/s
 import type { RouteFilter } from '../cli/src/transport/route-filter.ts';
 
 const sock = (): RegistrySocket => ({ readyState: WS_OPEN });
-const META: BrokerMeta = { port: 9410, pid: 4242, protocolV: 1, buildMtime: 111, uptimeMs: 5000 };
+const META: BrokerMeta = { port: 9410, pid: 4242, protocolV: 1, buildMtime: 111, uptimeMs: 5000, senderMismatchCount: 0 };
 
 /** Registry with a fixed clock so lastHeartbeatAge is deterministic. */
 function seed(now = 1_000) {
@@ -95,6 +95,20 @@ describe('buildBrokerHelloData — jobStatusFor (concurrency & jobs, backlog 1.1
     // An idle file reports null + 0 explicitly — never an omitted key.
     expect(ds.runningJob).toBeNull();
     expect(ds.queueDepth).toBe(0);
+  });
+});
+
+describe('buildBrokerHelloData — senderMismatchCount (issue #15, PR #14 review)', () => {
+  it('zero mismatches → the key is OMITTED, keeping the payload byte-identical to before this field existed', () => {
+    const { reg, clock } = seed();
+    const d = buildBrokerHelloData(reg, { ...META, senderMismatchCount: 0 }, null, clock);
+    expect('senderMismatchCount' in d).toBe(false);
+  });
+
+  it('a nonzero count surfaces verbatim — the same "discarded thing gets a machine-readable counter" contract as resultDropped/lateReplyCount', () => {
+    const { reg, clock } = seed();
+    const d = buildBrokerHelloData(reg, { ...META, senderMismatchCount: 3 }, null, clock);
+    expect(d.senderMismatchCount).toBe(3);
   });
 });
 


### PR DESCRIPTION
## Summary
- PR #14's sender-verification fix discards a reply from a plugin instance that doesn't match the job's dispatched target, and counts it in `senderMismatchCount` -- but that counter was log-only, invisible to any caller.
- This repo's own convention (`resultDropped`, `lateReplyCount`) already surfaces "a thing got discarded" as a machine-readable counter in envelopes. A discarded cross-instance reply (a spoof/misroute) is the most security-relevant member of that class, so it gets the same treatment.
- `senderMismatchCount` is daemon-scoped (not per-job), so it surfaces in `BROKER_HELLO` (`buildBrokerHelloData`/`BrokerMeta`) -- the same status payload `figma-agent status` already reads -- and is threaded through into `status.ts`'s own `broker` block.
- Follows the `resultDropped`/`lateReplyCount` convention exactly: the key is present only once a mismatch has actually happened, so the payload stays byte-identical to before this field existed when the count is zero.

Closes #15.

## Test plan
- [x] `tests/broker-status.test.ts` -- unit coverage on `buildBrokerHelloData`: zero mismatches omits the key (byte-identical), a nonzero count surfaces verbatim.
- [x] `tests/broker-daemon-harness.test.ts` -- full daemon integration test: two real plugin instances, one spoofs a dispatched job's reply id, a brand-new connection's `BROKER_HELLO` greeting reports `senderMismatchCount === 1`.
- [x] Both new tests verified to fail against pre-fix code (test-first).
- [x] `npm run typecheck && npm run build && npm test` all green (87 files, 1119 tests), including the panel gate against the pinned kernel submodule. Re-ran the full suite 3x to confirm no flakiness.