### PR TITLE
fix(cli): refuse BATCH admission above the 120s scaled-timeout ceiling

### DIFF
--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -31,6 +31,15 @@ function loadOps(filePath: string): BatchOp[] {
   });
 }
 
+// Mirrors southleft/figma-console-mcp's componentSetTimeoutMs's per-unit budget,
+// hop buffer, and cap — shared between `batchTimeoutMs` (scales the wait) and
+// `maxBatchOps`/`assertBatchAdmissible` (issue #16: refuses what the SAME formula
+// says the cap can no longer cover). Hoisted to module scope so both readings of
+// the formula can never drift apart.
+const PER_OP_MS = 1_200; // mirrors componentSetTimeoutMs's per-unit budget
+const HOP_BUFFER_MS = 5_000; // mirrors the fork's buffer over its own hop
+const CAP_MS = 120_000; // same cap the fork uses
+
 /**
  * Audit backlog 2.10, phase 2 — BATCH executes every op sequentially in ONE
  * uncancellable pass (the plugin sandbox cannot be interrupted mid-sequence), so a
@@ -49,12 +58,40 @@ function loadOps(filePath: string): BatchOp[] {
  * `CAP_MS` — mirroring the fork's own cap.
  */
 export function batchTimeoutMs(opCount: number): number {
-  const PER_OP_MS = 1_200; // mirrors componentSetTimeoutMs's per-unit budget
-  const HOP_BUFFER_MS = 5_000; // mirrors the fork's buffer over its own hop
-  const CAP_MS = 120_000; // same cap the fork uses
   const base = COMMAND_TIMEOUTS.BATCH ?? DEFAULT_TIMEOUT_MS;
   const scaled = opCount * PER_OP_MS + HOP_BUFFER_MS;
   return Math.min(CAP_MS, Math.max(base, scaled));
+}
+
+/**
+ * Issue #16 ruling (follow-up to PR #14) — the largest op count whose UNCAPPED
+ * scaled budget (`opCount * PER_OP_MS + HOP_BUFFER_MS`) still fits inside `CAP_MS`.
+ * Above this count, `batchTimeoutMs` clamps the wait to `CAP_MS` while the formula
+ * itself says the pass needs MORE than that — the clamp doesn't shrink the work,
+ * only the time the CLI is told to wait for it, so the uncancellable plugin-side
+ * pass keeps running past the clamped timeout and the CLI reports a false timeout
+ * failure mid-flight (with the ops still landing, inviting a double-apply retry).
+ */
+export function maxBatchOps(): number {
+  return Math.floor((CAP_MS - HOP_BUFFER_MS) / PER_OP_MS);
+}
+
+/**
+ * Hard refusal (issue #16), not a raised cap: a BATCH whose scaled budget would
+ * exceed `CAP_MS` is refused BEFORE dispatch — a job is never created for a pass
+ * this codebase already knows it cannot honor in one uncancellable round trip.
+ * Cheap, loud, and carries no double-apply risk (nothing was sent to the broker
+ * yet), unlike letting it run and hit the wire timeout, or raising the cap (which
+ * only moves the same failure to a higher op count).
+ */
+export function assertBatchAdmissible(opCount: number): void {
+  const max = maxBatchOps();
+  if (opCount > max) {
+    throw new CliError(
+      'E_INVALID_ARGS',
+      `${opCount} ops exceeds the single-pass budget of ${CAP_MS / 1_000}s; split into batches of ≤${max}`,
+    );
+  }
 }
 
 /** A command runner (the BATCH transport call), injectable for tests. */
@@ -71,6 +108,7 @@ export async function execute(
   runner: Runner = runCommand,
 ): Promise<unknown> {
   const ops = loadOps(resolve(filePath));
+  assertBatchAdmissible(ops.length);
   return runner('BATCH', { ops, stopOnError }, { timeoutMs: batchTimeoutMs(ops.length) });
 }
 

--- a/tests/batch-op-ceiling.test.ts
+++ b/tests/batch-op-ceiling.test.ts
@@ -1,0 +1,102 @@
+// Issue #16 (follow-up to PR #14) — PR #14's op-scaled BATCH timeout clamps at 120s
+// (CAP_MS in cli/src/commands/batch.ts), so from ~96 ops up the UNCAPPED formula
+// (opCount * PER_OP_MS + HOP_BUFFER_MS) already exceeds the cap: batchTimeoutMs
+// silently returns 120s regardless, but that is now LESS than what the formula says
+// the pass needs. Dispatching anyway sends an uncancellable, sequential plugin-side
+// pass that keeps running past its own reported timeout — the CLI declares failure
+// while ops keep landing, inviting a double-apply retry.
+//
+// RULING: hard refusal before dispatch, not a raised cap. `assertBatchAdmissible`
+// (and its `execute()` call site) did not exist before this fix — pre-fix, `execute`
+// called `runner('BATCH', ...)` unconditionally for any op count, so an over-ceiling
+// batch was dispatched and left to time out mid-flight.
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { assertBatchAdmissible, execute, maxBatchOps, type Runner } from '../cli/src/commands/batch.ts';
+
+describe('maxBatchOps — derived from the exact PR #14 formula, not re-guessed', () => {
+  it('REGRESSION LOCK: the boundary is 95 ops (95*1200+5000=119000 <= 120000; 96*1200+5000=120200 > 120000)', () => {
+    expect(maxBatchOps()).toBe(95);
+  });
+});
+
+describe('assertBatchAdmissible — hard refusal above the 120s scaled-timeout ceiling', () => {
+  it('accepts exactly the boundary op count (M)', () => {
+    expect(() => assertBatchAdmissible(maxBatchOps())).not.toThrow();
+  });
+
+  it('accepts anything below the boundary', () => {
+    expect(() => assertBatchAdmissible(1)).not.toThrow();
+    expect(() => assertBatchAdmissible(60)).not.toThrow();
+  });
+
+  it('refuses M+1 — one op past the boundary', () => {
+    expect(() => assertBatchAdmissible(maxBatchOps() + 1)).toThrow();
+  });
+
+  it('refuses with a stable E_INVALID_ARGS code and an actionable message naming the op count, the ceiling, and the max that fits', () => {
+    const opCount = maxBatchOps() + 1;
+    try {
+      assertBatchAdmissible(opCount);
+      throw new Error('expected assertBatchAdmissible to throw');
+    } catch (err) {
+      const cliErr = err as { code?: string; message?: string };
+      expect(cliErr.code).toBe('E_INVALID_ARGS');
+      expect(cliErr.message).toContain(String(opCount));
+      expect(cliErr.message).toContain('120s');
+      expect(cliErr.message).toContain(String(maxBatchOps()));
+    }
+  });
+
+  it('refuses a grossly over-ceiling batch too, not just the boundary+1', () => {
+    expect(() => assertBatchAdmissible(1_000)).toThrow();
+  });
+});
+
+describe('execute() — the refusal fires BEFORE any dispatch, so the runner is never called', () => {
+  let scratchDir: string;
+
+  function writeBatchFile(count: number): string {
+    scratchDir = mkdtempSync(join(tmpdir(), 'fa-batch-ceiling-'));
+    const filePath = join(scratchDir, 'ops.json');
+    const ops = Array.from({ length: count }, () => ({ cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' } }));
+    writeFileSync(filePath, JSON.stringify(ops));
+    return filePath;
+  }
+
+  function cleanup(): void {
+    if (scratchDir) rmSync(scratchDir, { recursive: true, force: true });
+  }
+
+  it('a batch at the boundary (M ops) is dispatched normally', async () => {
+    const filePath = writeBatchFile(maxBatchOps());
+    try {
+      let called = false;
+      const runner: Runner = async () => {
+        called = true;
+        return { ok: true };
+      };
+      await execute(filePath, false, runner);
+      expect(called).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('a batch one op past the boundary (M+1 ops) is refused — the runner is never invoked, no job is ever created for a pass that would time out mid-flight', async () => {
+    const filePath = writeBatchFile(maxBatchOps() + 1);
+    try {
+      let called = false;
+      const runner: Runner = async () => {
+        called = true;
+        return { ok: true };
+      };
+      await expect(execute(filePath, false, runner)).rejects.toThrow();
+      expect(called).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Closes #16. PR #14's op-scaled BATCH timeout clamps at 120s (`CAP_MS`), so from
~96 ops up the uncapped formula (`opCount * PER_OP_MS + HOP_BUFFER_MS`) already
exceeds the cap: `batchTimeoutMs` silently returns 120s regardless, which is now
*less* than what the formula itself says the pass needs. Dispatching anyway
sends an uncancellable, sequential plugin-side pass that keeps running past its
own reported timeout — the CLI reports failure while ops keep landing, inviting
a double-apply retry.

Ruling from the issue: **hard refusal before dispatch, not a raised cap.**

- `maxBatchOps()` — the largest op count whose uncapped budget still fits inside
  `CAP_MS` (95: `95*1200+5000=119000 <= 120000`, `96*1200+5000=120200 > 120000`).
- `assertBatchAdmissible(opCount)` — throws `E_INVALID_ARGS` naming the op count,
  the 120s ceiling, and the max ops that fit, e.g.:
  `96 ops exceeds the single-pass budget of 120s; split into batches of ≤95`
- Wired into `execute()` before the runner is ever invoked — a batch over the
  boundary never reaches the broker; no job is created for a pass already known
  to time out mid-flight.
- `PER_OP_MS`/`HOP_BUFFER_MS`/`CAP_MS` hoisted to module scope so `batchTimeoutMs`
  and the new admission check share one formula instead of two constants that
  could drift apart.

## Test plan

- [x] New assertions in `tests/batch-op-ceiling.test.ts` confirmed to **fail
      against pre-fix `batch.ts`** (`assertBatchAdmissible`/`maxBatchOps` did not
      exist; `execute()` dispatched any op count unconditionally) — proven via
      `git stash` before implementing, re-run, `git stash pop`.
- [x] Boundary test: M (95) ops accepted and dispatched; M+1 (96) ops refused,
      runner never invoked.
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `npm test` — 88 test files, 1127 tests passed (includes the panel gate /
      submodule)