### PR TITLE
feat: feed routing hygiene — cwd-independent staging + error-log binding

### DIFF
--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -36,6 +36,10 @@ export async function run(args: CommandArgs): Promise<unknown> {
     // own byte-identical-when-zero contract: present only once a cross-instance reply
     // has actually been discarded, so the common (zero) case stays unchanged here too.
     ...(typeof hello.senderMismatchCount === 'number' && { senderMismatchCount: hello.senderMismatchCount }),
+    // Issue #7 fix round — same mirror-only-when-true contract: an operator running
+    // `status` sees this the moment the one-time legacy-staging migration deferred,
+    // without needing to grep the broker log.
+    ...(hello.legacyMigrationDeferred === true && { legacyMigrationDeferred: true }),
   };
   const all = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntryWithJob[]) : [];
 

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -367,15 +367,31 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // the WS server accepts any connection (below), so no live DOC_CHANGE/EDIT_FEED write
   // can race it. Guarded by a breadcrumb under the NEW root so a broker that already
   // ran this once doesn't pay a readdir cost on every future restart.
+  //
+  // Stage-4 fix (reviewer finding 1) — START-AND-DEFER, with loud visibility, never
+  // ABORT: this is a best-effort move of already-safe, already-retryable UNBOUND staging
+  // data (copy-before-delete in migrateStagedChanges), not a reason to keep the whole
+  // relay from ever accepting a connection. A readdir/append/mkdir failure here (a full
+  // or unwritable /tmp) is caught, logged clearly, and the breadcrumb is deliberately
+  // NOT written — the next restart retries. `legacyMigrationDeferred` is surfaced in
+  // BROKER_HELLO/status (same "discarded thing gets a machine-readable counter" pattern
+  // as `senderMismatchCount`, backlog 2.10/issue #15) so an operator can't miss that
+  // unbound data is still stuck, even though the broker itself came up fine.
+  let legacyMigrationDeferred = false;
   const legacyMigratedMarker = join(unboundStagingRoot(), '.legacy-migrated');
   if (!existsSync(legacyMigratedMarker)) {
-    const migratedLegacyChangeFiles = migrateLegacyUnboundChanges();
-    const migratedLegacyEditFiles = migrateLegacyUnboundEdits();
-    if (migratedLegacyChangeFiles > 0 || migratedLegacyEditFiles > 0) {
-      log(`legacy unbound staging migrated to the new root: ${migratedLegacyChangeFiles} change file(s), ${migratedLegacyEditFiles} edit file(s)`);
+    try {
+      const migratedLegacyChangeFiles = migrateLegacyUnboundChanges();
+      const migratedLegacyEditFiles = migrateLegacyUnboundEdits();
+      if (migratedLegacyChangeFiles > 0 || migratedLegacyEditFiles > 0) {
+        log(`legacy unbound staging migrated to the new root: ${migratedLegacyChangeFiles} change file(s), ${migratedLegacyEditFiles} edit file(s)`);
+      }
+      mkdirSync(unboundStagingRoot(), { recursive: true });
+      writeFileSync(legacyMigratedMarker, JSON.stringify({ at: Date.now() }), 'utf8');
+    } catch (err) {
+      legacyMigrationDeferred = true;
+      log(`LEGACY UNBOUND STAGING MIGRATION FAILED, deferred to next restart (data untouched, not lost): ${(err as Error).message}`);
     }
-    mkdirSync(unboundStagingRoot(), { recursive: true });
-    writeFileSync(legacyMigratedMarker, JSON.stringify({ at: Date.now() }), 'utf8');
   }
 
   const st: BrokerState = {
@@ -1309,7 +1325,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.registry,
       {
         port, pid: process.pid, protocolV: PROTOCOL_VERSION, buildMtime: selfBuildMtime(),
-        uptimeMs: Date.now() - startedAt, senderMismatchCount,
+        uptimeMs: Date.now() - startedAt, senderMismatchCount, legacyMigrationDeferred,
       },
       currentFilter(),
       Date.now,

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -7,7 +7,8 @@
 // persistent broker-daemon pattern (one long-lived relay process, hot-swappable
 // across CLI rebuilds), adapted from southleft/figma-console-mcp's websocket-server
 // pending-request correlation (347-360) / heartbeat (672-685).
-import { appendFileSync, readFileSync, unlinkSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import WebSocket, { WebSocketServer } from 'ws';
 import {
   BROKER_FILE, BROKER_IDLE_SHUTDOWN_MS, EXEC_JS_MAX_TIMEOUT_MS, HEARTBEAT_INTERVAL_MS, LOOPBACK_HOST, PLUGIN_WAIT_MS,
@@ -25,9 +26,14 @@ import {
 import { PluginRegistry, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
 import { resolveRouteFilter, type RouteFilter } from './route-filter.ts';
-import { appendChangeFrames, changeLogPathFor, migrateStagedChanges, unboundStagingPath } from './change-log.ts';
-import { appendEditFrames, editFeedPathForIdentity, safeSlug, unboundEditStagingPath } from './edit-feed-log.ts';
-import { appendErrorFrame, buildErrorLogFrame, errorLogPath } from './error-log.ts';
+import {
+  appendChangeFrames, changeLogPathFor, migrateLegacyUnboundChanges, migrateStagedChanges,
+  unboundStagingPath, unboundStagingRoot,
+} from './change-log.ts';
+import {
+  appendEditFrames, editFeedPathForIdentity, migrateLegacyUnboundEdits, safeSlug, unboundEditStagingPath,
+} from './edit-feed-log.ts';
+import { appendErrorFrame, buildErrorLogFrame, errorLogPathFor, unboundErrorStagingPath } from './error-log.ts';
 import { readIdleMs } from './figma-sync-config.ts';
 import { spawnReconcileApply } from './figma-sync-apply.ts';
 import {
@@ -353,6 +359,25 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // only the dirs that still look like projects — a stale entry is dropped, never trusted.
   const { index: bindIndex, usableDirs } = loadBindIndex();
   writeBindCache(usableDirs);
+
+  // One-time startup migration (issue #7 / backlog 5.6 ruling: migrate, never silently
+  // orphan) — anything staged under the OLD cwd-relative unbound root, from a broker
+  // that ran before this fix, must not be abandoned by the very change that fixes
+  // cwd-misattribution for good; that would betray this wave's own thesis. Runs BEFORE
+  // the WS server accepts any connection (below), so no live DOC_CHANGE/EDIT_FEED write
+  // can race it. Guarded by a breadcrumb under the NEW root so a broker that already
+  // ran this once doesn't pay a readdir cost on every future restart.
+  const legacyMigratedMarker = join(unboundStagingRoot(), '.legacy-migrated');
+  if (!existsSync(legacyMigratedMarker)) {
+    const migratedLegacyChangeFiles = migrateLegacyUnboundChanges();
+    const migratedLegacyEditFiles = migrateLegacyUnboundEdits();
+    if (migratedLegacyChangeFiles > 0 || migratedLegacyEditFiles > 0) {
+      log(`legacy unbound staging migrated to the new root: ${migratedLegacyChangeFiles} change file(s), ${migratedLegacyEditFiles} edit file(s)`);
+    }
+    mkdirSync(unboundStagingRoot(), { recursive: true });
+    writeFileSync(legacyMigratedMarker, JSON.stringify({ at: Date.now() }), 'utf8');
+  }
+
   const st: BrokerState = {
     registry: new PluginRegistry<WebSocket>(), cliClients: new Set(), pending: new Map(),
     dispatchedTo: new Map(), waiting: [], lastBusyAt: Date.now(),
@@ -383,9 +408,6 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // this daemon run (a closure local, not module-level) so it never leaks across daemon
   // instances started back-to-back within the same test process.
   let senderMismatchCount = 0;
-
-  // Error log writer (backlog 4.6): resolved once, one line per ReplyErr the broker relays.
-  const errorsPath = errorLogPath();
 
   // Live-sync idle-commit (spec 004 P4): the idle window sent to each plugin, and a
   // debounce so a double-click never launches two overlapping `ui figma reconcile
@@ -600,8 +622,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       unboundEditStagingPath(slug),
       editFeedPathForIdentity(projectDir, fileIdentity(fileKey, fileName)),
     );
-    log(`BIND recorded: "${fileName}" → ${projectDir}${fileKey ? ` (fileKey ${fileKey})` : ' (pending fileKey)'}${migratedCount > 0 ? `, migrated ${migratedCount} staged change frame(s)` : ''}${migratedEditCount > 0 ? `, migrated ${migratedEditCount} staged edit frame(s)` : ''}`);
-    reply({ fileName, projectDir, fileKey, pendingKey: fileKey === null, migratedCount, migratedEditCount });
+    // Issue #7 (backlog 5.9) fix — SAME migration, this time for the error log's own
+    // unbound staging, giving it full parity with the other two feeds.
+    const migratedErrorCount = migrateStagedChanges(unboundErrorStagingPath(slug), errorLogPathFor(projectDir));
+    log(`BIND recorded: "${fileName}" → ${projectDir}${fileKey ? ` (fileKey ${fileKey})` : ' (pending fileKey)'}${migratedCount > 0 ? `, migrated ${migratedCount} staged change frame(s)` : ''}${migratedEditCount > 0 ? `, migrated ${migratedEditCount} staged edit frame(s)` : ''}${migratedErrorCount > 0 ? `, migrated ${migratedErrorCount} staged error frame(s)` : ''}`);
+    reply({ fileName, projectDir, fileKey, pendingKey: fileKey === null, migratedCount, migratedEditCount, migratedErrorCount });
   };
 
   const errReplyFrame = (id: string, code: ErrorCode, message: string): string =>
@@ -1130,9 +1155,23 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         routeFromPlugin(msg.id, text, true, ws);
         // Error log writer (backlog 4.6): every FAILED reply the broker relays, logged
         // regardless of whether a CLI is still around to read it live.
+        //
+        // Issue #7 (backlog 5.9) fix: path resolved FRESH per reply, same
+        // fileIdentity→resolveProjectDir shape DOC_CHANGE/EDIT_FEED already use just
+        // below — never the once-cached, binding-blind default this replaces.
         if (!msg.ok) {
-          const fallbackFileName = (st.registry.getByWs(ws)?.scene.fileName as string | undefined) ?? null;
-          appendErrorLog(errorsPath, msg, fallbackFileName);
+          const scene = st.registry.getByWs(ws)?.scene;
+          const fallbackFileName = (scene?.fileName as string | undefined) ?? null;
+          const fileName = msg.fileContext?.fileName ?? fallbackFileName;
+          const fileKey = msg.fileContext?.fileKey ?? ((scene?.fileKey as string | null | undefined) ?? null);
+          const identity = fileIdentity(fileKey, fileName);
+          const bound = resolveProjectDir(identity, st.bindIndex);
+          const errPath = bound
+            ? errorLogPathFor(bound)
+            // Staged by NAME slug specifically — same reasoning as DOC_CHANGE/EDIT_FEED's
+            // own unbound staging just below.
+            : unboundErrorStagingPath(safeSlug(fileName ?? ''));
+          appendErrorLog(errPath, msg, fallbackFileName);
         }
       }
     } else if (isRequestMsg(msg)) {

--- a/cli/src/transport/broker-status.ts
+++ b/cli/src/transport/broker-status.ts
@@ -30,6 +30,12 @@ export interface BrokerMeta {
    *  plugin instance did not match the job's `targetInstanceId` (a spoofed/misrouted
    *  cross-instance reply). Daemon-scoped, not per-job. */
   senderMismatchCount: number;
+  /** Issue #7 (backlog 5.6) fix round, reviewer finding 1 — true when the one-time
+   *  startup migration of the OLD unbound-staging root failed (a full/unwritable
+   *  /tmp, say) and was deferred to the next restart rather than aborting broker
+   *  startup. The staged data itself is untouched (migration is copy-before-delete),
+   *  but an operator needs to know it's still stuck at the old location. */
+  legacyMigrationDeferred: boolean;
 }
 
 /**
@@ -77,6 +83,11 @@ export function buildBrokerHelloData(
     // overwhelming common case) keeps this payload byte-identical to before this field
     // existed.
     ...(meta.senderMismatchCount > 0 && { senderMismatchCount: meta.senderMismatchCount }),
+    // Issue #7 fix round — same "present only once it's actually true" contract as
+    // senderMismatchCount just above: a broker whose legacy migration succeeded (or had
+    // nothing to migrate — the overwhelming common case) keeps this payload
+    // byte-identical to before this field existed.
+    ...(meta.legacyMigrationDeferred && { legacyMigrationDeferred: true }),
     // ── legacy compat shim (mirrors the ACTIVE plugin) ──
     pluginConnected: connected,
     pluginState: connected ? 'connected' : 'disconnected',

--- a/cli/src/transport/change-log.ts
+++ b/cli/src/transport/change-log.ts
@@ -7,7 +7,7 @@
 // path is resolved from its spawn cwd (or an env override). Each frame carries
 // `fileKey`, so a future multi-project reconcile can still partition one shared log.
 import {
-  appendFileSync, closeSync, existsSync, mkdirSync, openSync, readFileSync, readSync,
+  appendFileSync, closeSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, readSync,
   statSync, unlinkSync, writeFileSync,
 } from 'node:fs';
 import { join, resolve } from 'node:path';
@@ -61,20 +61,62 @@ export function changeLogPathFor(projectDir: string): string {
 // resolves this file's identity.
 export const UNBOUND_STAGING_DIRNAME = 'unbound';
 
-/** `<changeLogDir()>/unbound/<slug>.jsonl` — beside the broker's own default change log,
- *  never a project's design/. Keyed by the SAME name-slug `figma-agent bind --file <name>`
- *  addresses (not fileKey — a file connecting mid-way through its unbound life must not
- *  split its staged history across two paths).
+/**
+ * Root for ALL unbound staging (this feed, edit-feed-log.ts's, and error-log.ts's) —
+ * `FIGMA_AGENT_UNBOUND_DIR` override, else a fixed `/tmp/figma-agent-unbound` default.
+ * Same convention as `project-bind.ts`'s `bindCacheFile()`: cwd-INDEPENDENT on purpose.
  *
- *  Known limitation, DEFERRED not fixed here (backlog 5.6): this root is `changeLogDir()`
- *  — the broker's own spawn cwd — so a restart with a different cwd orphans whatever was
- *  staged under the old one. Shared by BOTH feed types (this one and edit-feed-log.ts's
- *  `unboundEditStagingPath`, backlog 5.7's fold-in) since both resolve through the same
- *  `changeLogDir()`. Closing it means moving this root to a cwd-independent location — a
- *  change to this already-shipped, review-verified mechanism (RI-P1 fix#1), not a rider on
- *  whichever wave happens to touch this file next. */
+ * Issue #7 (backlog 5.6) fix: this used to be `changeLogDir()` — the broker's own spawn
+ * cwd — so a restart with a different cwd orphaned whatever was staged under the old
+ * one. That was DEFERRED at RI-P1 fix#1 specifically because closing it meant moving an
+ * already-shipped, review-verified mechanism's root — "its own small spec/review, not a
+ * rider on whichever wave happens to touch this file next" (that review is issue #7).
+ * A broker upgrading from before this fix migrates whatever it finds at the OLD root
+ * once at startup (`migrateLegacyUnboundChanges` below, `migrateLegacyUnboundEdits` in
+ * edit-feed-log.ts) — orphaning that data on the very change meant to stop orphaning it
+ * would betray this fix's own point.
+ */
+export function unboundStagingRoot(): string {
+  const env = process.env['FIGMA_AGENT_UNBOUND_DIR'];
+  if (env !== undefined && env.length > 0) return resolve(env);
+  return '/tmp/figma-agent-unbound';
+}
+
+/** `<unboundStagingRoot()>/unbound/<slug>.jsonl` — beside the broker's own restart-
+ *  survival state, never a project's design/. Keyed by the SAME name-slug
+ *  `figma-agent bind --file <name>` addresses (not fileKey — a file connecting mid-way
+ *  through its unbound life must not split its staged history across two paths). */
 export function unboundStagingPath(slug: string): string {
-  return join(changeLogDir(), UNBOUND_STAGING_DIRNAME, `${slug}.jsonl`);
+  return join(unboundStagingRoot(), UNBOUND_STAGING_DIRNAME, `${slug}.jsonl`);
+}
+
+/** The OLD (pre-issue-#7) unbound-staging root — `changeLogDir()`-rooted, broker-cwd-
+ *  relative. Kept ONLY so the one-time startup migration below can find anything a prior
+ *  broker build staged there; nothing ever writes here again. */
+function legacyUnboundStagingDir(): string {
+  return join(changeLogDir(), UNBOUND_STAGING_DIRNAME);
+}
+
+/**
+ * One-time startup migration (issue #7 / backlog 5.6 ruling: migrate, never silently
+ * orphan): copies every `<slug>.jsonl` still sitting at the OLD cwd-relative unbound
+ * root into the NEW cwd-independent one, reusing `migrateStagedChanges` as-is — a
+ * staging→staging move is exactly the same crash-safe "copy then clean up" shape as the
+ * staging→bound move that function already does. Returns the number of FILES migrated
+ * (a file may carry several frames). A fresh install (nothing ever staged at the old
+ * location) costs one `existsSync` check.
+ */
+export function migrateLegacyUnboundChanges(): number {
+  const oldDir = legacyUnboundStagingDir();
+  if (!existsSync(oldDir)) return 0;
+  let migratedFiles = 0;
+  for (const entry of readdirSync(oldDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    const slug = entry.slice(0, -'.jsonl'.length);
+    const moved = migrateStagedChanges(join(oldDir, entry), unboundStagingPath(slug));
+    if (moved > 0) migratedFiles++;
+  }
+  return migratedFiles;
 }
 
 /** `<staging>.migrated.json` — records that a migrate's append (step b) already landed,

--- a/cli/src/transport/edit-feed-log.ts
+++ b/cli/src/transport/edit-feed-log.ts
@@ -10,10 +10,10 @@
 // from its spawn cwd, same as changeLogDir(). A CLI run from project B can therefore read
 // a feed the broker wrote under project A. `FIGMA_AGENT_CHANGES_DIR` overrides both logs'
 // base directory together, so they always move as one unit — never independently.
-import { appendFileSync, existsSync, mkdirSync } from 'node:fs';
+import { appendFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { changeLogDir } from './change-log.ts';
+import { changeLogDir, migrateStagedChanges, unboundStagingRoot } from './change-log.ts';
 import { fileIdentity, safeSlug } from './file-identity.ts';
 import { rotateIfNeeded } from './log-rotate.ts';
 import {
@@ -62,19 +62,40 @@ export function editFeedPathForIdentity(projectDir: string, identity: string): s
 // shapes and must never land in the same staging file.
 export const EDIT_FEED_UNBOUND_STAGING_DIRNAME = 'unbound';
 
-/** `<changeLogDir()>/changes/unbound/<slug>.jsonl` — keyed by the SAME name-slug
+/** `<unboundStagingRoot()>/changes/unbound/<slug>.jsonl` — keyed by the SAME name-slug
  *  (`fileIdentity(null, fileName)` === `safeSlug(fileName)`) `handleProjectBind` and
  *  DOC_CHANGE's own unbound staging use — a file connecting mid-way through its unbound
  *  life must not split its staged history across two different keys.
  *
- *  Known limitation, DEFERRED not fixed here (backlog 5.6, ruling: implement 5.7 mirroring
- *  today's pattern exactly, don't fold 5.6 in): this root is `editFeedDir()` →
- *  `changeLogDir()` — the broker's own spawn cwd — so a restart with a different cwd
- *  orphans whatever was staged under the old one. Shared with change-log.ts's OWN
- *  `unboundStagingPath` for the exact same reason. Closing it means moving both roots to a
- *  cwd-independent location, its own small spec/review, not a rider on this wave. */
+ *  Issue #7 (backlog 5.6) fix: this used to be `editFeedDir()` → `changeLogDir()` — the
+ *  broker's own spawn cwd — deferred at 5.7-fold-in time ("its own small spec/review, not
+ *  a rider on this wave"). Now rooted at `unboundStagingRoot()`, the SAME cwd-independent
+ *  base change-log.ts's own `unboundStagingPath` uses — kept in this feed's OWN `changes/`
+ *  sub-path so the two logs' staged history still can never cross-contaminate. */
 export function unboundEditStagingPath(slug: string): string {
-  return join(editFeedDir(), EDIT_FEED_UNBOUND_STAGING_DIRNAME, `${slug}.jsonl`);
+  return join(unboundStagingRoot(), EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME, `${slug}.jsonl`);
+}
+
+/** The OLD (pre-issue-#7) unbound-staging dir for this feed — `editFeedDir()`-rooted,
+ *  broker-cwd-relative. Kept ONLY for the one-time startup migration below. */
+function legacyEditUnboundStagingDir(): string {
+  return join(editFeedDir(), EDIT_FEED_UNBOUND_STAGING_DIRNAME);
+}
+
+/** One-time startup migration (issue #7 / backlog 5.6), this feed's own — mirrors
+ *  change-log.ts's `migrateLegacyUnboundChanges` exactly (schema-agnostic reuse of
+ *  `migrateStagedChanges`, same reasoning: migrate, never silently orphan). */
+export function migrateLegacyUnboundEdits(): number {
+  const oldDir = legacyEditUnboundStagingDir();
+  if (!existsSync(oldDir)) return 0;
+  let migratedFiles = 0;
+  for (const entry of readdirSync(oldDir)) {
+    if (!entry.endsWith('.jsonl')) continue;
+    const slug = entry.slice(0, -'.jsonl'.length);
+    const moved = migrateStagedChanges(join(oldDir, entry), unboundEditStagingPath(slug));
+    if (moved > 0) migratedFiles++;
+  }
+  return migratedFiles;
 }
 
 /**

--- a/cli/src/transport/error-log.ts
+++ b/cli/src/transport/error-log.ts
@@ -3,18 +3,50 @@
 // `figma.changes.jsonl`, not inside the wave 4.4 edit feed's `changes/` subdirectory
 // (same BASE dir resolution as both — `changeLogDir()` — but its own file, its own
 // shape, never mixed into either of those two logs).
+//
+// Issue #7 (backlog 5.9) fix: `errorLogPath()` alone used to be the ONLY write target —
+// resolved once at broker startup and shared by every file/project the broker ever
+// relayed for, no per-event binding resolution at all (unlike DOC_CHANGE/EDIT_FEED,
+// which resolve `resolveProjectDir` fresh per message). `errorLogPathFor`/
+// `unboundErrorStagingPath` below give the error log the SAME per-event, binding-aware
+// routing — full parity, including staging + migrate-on-bind — because "diagnostic-only,
+// lower stakes" was exactly the reasoning that let this become a bug in the first place,
+// and the `figma-agent errors` reader depends on the log actually being in the right
+// project (same blind-spot class 5.7 fixed for the edit feed).
 import { appendFileSync, mkdirSync } from 'node:fs';
 import { join } from 'node:path';
 
-import { changeLogDir } from './change-log.ts';
+import { changeLogDir, unboundStagingRoot } from './change-log.ts';
+import { rotateIfNeeded } from './log-rotate.ts';
 import type { CommandName, ErrorCode, ReplyErr } from '../../../shared/protocol.ts';
 
 export const ERROR_LOG_FILENAME = 'figma-errors.jsonl';
+export const ERROR_STAGING_DIRNAME = 'errors';
+export const ERROR_UNBOUND_STAGING_DIRNAME = 'unbound';
 
 /** `<changeLogDir()>/figma-errors.jsonl` — shares changeLogDir()'s
- *  `FIGMA_AGENT_CHANGES_DIR` override, same as the change log and the edit feed base. */
+ *  `FIGMA_AGENT_CHANGES_DIR` override, same as the change log and the edit feed base.
+ *  Still the CLI reader's (`figma-agent errors`) own default — unchanged by the fix
+ *  below, which only concerns the BROKER's write-side routing. */
 export function errorLogPath(): string {
   return join(changeLogDir(), ERROR_LOG_FILENAME);
+}
+
+/** The SAME filename, rooted at an explicit project dir instead of the broker's cwd
+ *  (mirrors change-log.ts's `changeLogPathFor` / edit-feed-log.ts's
+ *  `editFeedPathForIdentity`). */
+export function errorLogPathFor(projectDir: string): string {
+  return join(projectDir, 'design', ERROR_LOG_FILENAME);
+}
+
+/** `<unboundStagingRoot()>/errors/unbound/<slug>.jsonl` — mirrors change-log.ts's
+ *  `unboundStagingPath` / edit-feed-log.ts's `unboundEditStagingPath` exactly, in this
+ *  feed's OWN `errors/` sub-path so none of the three logs' staged history can ever
+ *  cross-contaminate. Keyed by the SAME name-slug the other two unbound-staging paths
+ *  use, for the same reason: a file connecting mid-way through its unbound life must not
+ *  split its staged errors across two different keys. */
+export function unboundErrorStagingPath(slug: string): string {
+  return join(unboundStagingRoot(), ERROR_STAGING_DIRNAME, ERROR_UNBOUND_STAGING_DIRNAME, `${slug}.jsonl`);
 }
 
 /** One line of the error log. Append-only; no schema-version field — this is a
@@ -76,10 +108,16 @@ export function isValidErrorLogFrame(v: unknown): v is ErrorLogFrame {
   return true;
 }
 
-/** Append one ErrorLogFrame line, creating the design/ dir if needed. */
+/** Append one ErrorLogFrame line, creating the design/ dir if needed.
+ *
+ *  Issue #7 minor fix: `rotateIfNeeded` runs after the append, same as
+ *  `appendChangeFrame`/`appendEditFrame` already do — log-rotate.ts's own module header
+ *  always named this as one of the three feeds its policy covers, but the call here was
+ *  never actually wired, leaving this the one unbounded-growth feed of the three. */
 export function appendErrorFrame(path: string, frame: ErrorLogFrame): void {
   mkdirSync(resolveDir(path), { recursive: true });
   appendFileSync(path, JSON.stringify(frame) + '\n', 'utf8');
+  rotateIfNeeded(path);
 }
 
 /** Parent dir of a file path (mirrors change-log.ts's / edit-feed-log.ts's private

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -117,7 +117,11 @@ export interface RequestMsg {
 /** Which file answered. Echoed on every reply so a caller can prove where a command landed. */
 export interface FileContext {
   fileName: string;
-  fileKey?: string | null;   // null for non-org plugins — carried, never used for routing
+  // null for non-org plugins. Issue #7: now used for routing on the ERROR-LOG path
+  // (broker-daemon.ts's `!msg.ok` branch feeds it into `fileIdentity`) — DOC_CHANGE and
+  // EDIT_FEED already derived their own routing identity from other fields (the
+  // registry's own scene / the payload's own fileKey), never from this reply-echoed one.
+  fileKey?: string | null;
 }
 
 export interface ReplyOk {

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -509,23 +509,52 @@ describe('daemon harness — the error log routes through the binding index, nev
 });
 
 describe('daemon harness — one-time startup migration of the OLD unbound-staging root (issue #7, backlog 5.6)', () => {
-  it('migrates a file staged before this fix at the cwd-relative location into the new cwd-independent root', async () => {
-    // Simulate a prior broker build's leftover staging, at the OLD location
-    // (`<FIGMA_AGENT_CHANGES_DIR>/unbound/<slug>.jsonl`) — created BEFORE the broker
-    // (and its startup migration) ever runs.
-    const slug = 'legacy-file';
-    const legacyPath = join(scratchDir, 'unbound', `${slug}.jsonl`);
+  it('migrates BOTH the change-log\'s and the edit feed\'s legacy staging into the new cwd-independent root, in one boot', async () => {
+    // Simulate a prior broker build's leftover staging at BOTH old locations
+    // (`<FIGMA_AGENT_CHANGES_DIR>/unbound/<slug>.jsonl` for change-log, and
+    // `<FIGMA_AGENT_CHANGES_DIR>/changes/unbound/<slug>.jsonl` for the edit feed) —
+    // created BEFORE the broker (and its startup migration) ever runs.
+    const changeSlug = 'legacy-change';
+    const editSlug = 'legacy-edit';
+    const legacyChangePath = join(scratchDir, 'unbound', `${changeSlug}.jsonl`);
+    const legacyEditPath = join(scratchDir, 'changes', 'unbound', `${editSlug}.jsonl`);
     mkdirSync(join(scratchDir, 'unbound'), { recursive: true });
-    writeFileSync(legacyPath, `${JSON.stringify({ nodeId: 'a' })}\n`, 'utf8');
+    mkdirSync(join(scratchDir, 'changes', 'unbound'), { recursive: true });
+    writeFileSync(legacyChangePath, `${JSON.stringify({ nodeId: 'a' })}\n`, 'utf8');
+    writeFileSync(legacyEditPath, `${JSON.stringify({ nodeId: 'b' })}\n`, 'utf8');
 
     await startTestBroker();
 
-    const newPath = join(scratchDir, 'unbound-root', 'unbound', `${slug}.jsonl`);
-    await waitFor(() => existsSync(newPath));
-    expect(existsSync(legacyPath)).toBe(false); // cleaned up at the old location
-    expect(readFileSync(newPath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'a' }));
+    const newChangePath = join(scratchDir, 'unbound-root', 'unbound', `${changeSlug}.jsonl`);
+    const newEditPath = join(scratchDir, 'unbound-root', 'changes', 'unbound', `${editSlug}.jsonl`);
+    await waitFor(() => existsSync(newChangePath) && existsSync(newEditPath));
+    expect(existsSync(legacyChangePath)).toBe(false); // cleaned up at the old location
+    expect(existsSync(legacyEditPath)).toBe(false);
+    expect(readFileSync(newChangePath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'a' }));
+    expect(readFileSync(newEditPath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'b' }));
     // Breadcrumb written so a future restart never re-scans.
     expect(existsSync(join(scratchDir, 'unbound-root', '.legacy-migrated'))).toBe(true);
+  });
+
+  // Stage-4 fix (reviewer finding 1) — a migration failure must DEFER, not ABORT: the
+  // broker still has to come up and accept connections, since this is a best-effort
+  // move of already-safe, already-retryable staging data, not a reason to keep the
+  // whole relay from ever accepting a connection.
+  it('a migration failure defers (never aborts) startup — the broker still accepts connections and surfaces the deferral', async () => {
+    // A regular FILE where `legacyUnboundStagingDir()` expects a DIRECTORY —
+    // `readdirSync` throws ENOTDIR on it, a real filesystem failure, no mocking needed.
+    writeFileSync(join(scratchDir, 'unbound'), 'not a directory', 'utf8');
+
+    const port = await startTestBroker();
+    const { hello } = await connectAndAwaitBrokerHello(port);
+    expect((hello.data as { legacyMigrationDeferred?: boolean }).legacyMigrationDeferred).toBe(true);
+
+    // The broker is genuinely up and serving — not just alive enough to answer HELLO.
+    await helloPlugin(await connectSocket(port), 'plugin-legacy-fail', 'Some File');
+
+    // No breadcrumb written — a future restart must retry the migration, not skip it
+    // forever having never actually succeeded.
+    expect(existsSync(join(scratchDir, 'unbound-root', '.legacy-migrated'))).toBe(false);
   });
 });
 

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -20,7 +20,7 @@
 // fresh via `vi.resetModules()` + dynamic `import()` AFTER setting env vars, guaranteeing
 // the constants observe this test's own values regardless of import order across the suite.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
@@ -32,6 +32,7 @@ type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts')
 const WATCHDOG_MS_KEY = 'FIGMA_AGENT_WATCHDOG_MS';
 const CHANGES_DIR_KEY = 'FIGMA_AGENT_CHANGES_DIR';
 const BINDS_FILE_KEY = 'FIGMA_AGENT_BINDS_FILE';
+const UNBOUND_DIR_KEY = 'FIGMA_AGENT_UNBOUND_DIR';
 
 let scratchDir: string;
 let advertisePath: string;
@@ -42,6 +43,11 @@ let sockets: WebSocket[];
 async function loadBrokerDaemon(env: Record<string, string> = {}): Promise<BrokerDaemonModule> {
   process.env[CHANGES_DIR_KEY] = scratchDir;
   process.env[BINDS_FILE_KEY] = join(scratchDir, 'binds.json');
+  // Issue #7 (backlog 5.6): unbound staging now roots at its OWN cwd-independent
+  // location, never `scratchDir`/`FIGMA_AGENT_CHANGES_DIR` — a distinct scratch subdir
+  // proves that separation, the same way this harness already isolates the real
+  // /tmp/figma-agent-broker.json and 9410-9419 port range.
+  process.env[UNBOUND_DIR_KEY] = join(scratchDir, 'unbound-root');
   for (const [k, v] of Object.entries(env)) process.env[k] = v;
   vi.resetModules();
   return import('../cli/src/transport/broker-daemon.ts');
@@ -148,6 +154,16 @@ interface EditInputLike {
   actor: 'owner' | 'agent' | 'ambiguous';
 }
 
+/** Sends a raw ReplyErr frame as the plugin — a fabricated `id` never matching a real
+ *  pending/dispatched job is safe: `isReplyFromDispatchedInstance` returns true for an
+ *  unknown job (job-table.ts:60), and `routeFromPlugin`'s pending/job lookups are simple
+ *  no-ops on a miss. Only the error-log append (issue #7's own routing) is under test. */
+function sendReplyErr(
+  ws: WebSocket, id: string, error: { code: string; message: string }, fileContext?: { fileName: string; fileKey?: string | null },
+): void {
+  ws.send(JSON.stringify({ id, ok: false, error, ...(fileContext ? { fileContext } : {}) }));
+}
+
 /** Sends an EDIT_FEED batch as the plugin — no reply is expected (best-effort append). */
 function sendEditFeed(
   ws: WebSocket, edits: readonly EditInputLike[], meta: { fileKey: string | null; fileName: string; source?: 'live' | 'gapfill' },
@@ -167,11 +183,11 @@ function sendEditFeedWithoutFileName(ws: WebSocket, edits: readonly EditInputLik
 
 async function bindProject(
   ws: WebSocket, fileName: string, projectDir: string, reqId: string,
-): Promise<{ migratedCount: number; migratedEditCount: number; fileKey: string | null }> {
+): Promise<{ migratedCount: number; migratedEditCount: number; migratedErrorCount: number; fileKey: string | null }> {
   ws.send(JSON.stringify(makeRequestFrame(reqId, 'PROJECT_BIND', { fileName, projectDir })));
   const reply = await nextFrame<ReplyOk | ReplyErr>(ws, (m) => (m as ReplyOk | ReplyErr).id === reqId);
   if (!reply.ok) throw new Error(`bind failed: ${JSON.stringify((reply as ReplyErr).error)}`);
-  return reply.result as { migratedCount: number; migratedEditCount: number; fileKey: string | null };
+  return reply.result as { migratedCount: number; migratedEditCount: number; migratedErrorCount: number; fileKey: string | null };
 }
 
 beforeEach(() => {
@@ -314,7 +330,9 @@ describe('daemon harness — EDIT_FEED routes through the binding index, never t
     await helloPlugin(plugin, 'plugin-edit-1', 'Platform - Design System');
 
     const slug = 'platform-design-system'; // safeSlug('Platform - Design System')
-    const stagingPath = join(scratchDir, 'changes', 'unbound', `${slug}.jsonl`);
+    // Issue #7 (backlog 5.6): staging now roots at the cwd-independent unbound-root
+    // scratch dir, never `scratchDir`/`FIGMA_AGENT_CHANGES_DIR` itself.
+    const stagingPath = join(scratchDir, 'unbound-root', 'changes', 'unbound', `${slug}.jsonl`);
     // The broker's own cwd-derived default — a Platform DS edit landing HERE (VSF-PCP's
     // tree, in the real live-traced incident) is the exact misattribution 5.7 fixes.
     const cwdDefaultPath = join(scratchDir, 'changes', `${slug}.jsonl`);
@@ -431,6 +449,62 @@ describe('daemon harness — EDIT_FEED with no data.fileName falls back to the r
     } finally {
       rmSync(boundProjectDir, { recursive: true, force: true });
     }
+  });
+});
+
+describe('daemon harness — the error log routes through the binding index, never a once-cached default (issue #7, backlog 5.9)', () => {
+  it('an unbound ReplyErr stages; PROJECT_BIND migrates it into the bound project\'s OWN error log; a later error lands there directly', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-err-1', 'Platform - Design System');
+
+    const slug = 'platform-design-system';
+    const stagingPath = join(scratchDir, 'unbound-root', 'errors', 'unbound', `${slug}.jsonl`);
+
+    // Unbound: sent before any bind exists for this identity.
+    sendReplyErr(plugin, 'req-err-1', { code: 'E_EVAL', message: 'boom 1' });
+    await waitFor(() => existsSync(stagingPath));
+    expect(readFileSync(stagingPath, 'utf8').trim().split('\n')).toHaveLength(1);
+    expect(JSON.parse(readFileSync(stagingPath, 'utf8').trim())).toMatchObject({ code: 'E_EVAL', message: 'boom 1' });
+
+    const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-bound-project-err-'));
+    try {
+      const cli = await connectSocket(port);
+      const bindResult = await bindProject(cli, 'Platform - Design System', boundProjectDir, 'req-bind-err-1');
+      expect(bindResult.migratedErrorCount).toBe(1);
+
+      const boundErrorPath = join(boundProjectDir, 'design', 'figma-errors.jsonl');
+      expect(existsSync(boundErrorPath)).toBe(true); // migrated into the REAL bound project
+      expect(existsSync(stagingPath)).toBe(false); // staging cleaned up after migration
+
+      // A second, now-bound error — lands DIRECTLY in the bound project, never staged.
+      sendReplyErr(plugin, 'req-err-2', { code: 'E_PLUGIN_ERROR', message: 'boom 2' });
+      await waitFor(() => readFileSync(boundErrorPath, 'utf8').trim().split('\n').length === 2);
+      expect(existsSync(stagingPath)).toBe(false); // never re-created
+    } finally {
+      rmSync(boundProjectDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('daemon harness — one-time startup migration of the OLD unbound-staging root (issue #7, backlog 5.6)', () => {
+  it('migrates a file staged before this fix at the cwd-relative location into the new cwd-independent root', async () => {
+    // Simulate a prior broker build's leftover staging, at the OLD location
+    // (`<FIGMA_AGENT_CHANGES_DIR>/unbound/<slug>.jsonl`) — created BEFORE the broker
+    // (and its startup migration) ever runs.
+    const slug = 'legacy-file';
+    const legacyPath = join(scratchDir, 'unbound', `${slug}.jsonl`);
+    mkdirSync(join(scratchDir, 'unbound'), { recursive: true });
+    writeFileSync(legacyPath, `${JSON.stringify({ nodeId: 'a' })}\n`, 'utf8');
+
+    await startTestBroker();
+
+    const newPath = join(scratchDir, 'unbound-root', 'unbound', `${slug}.jsonl`);
+    await waitFor(() => existsSync(newPath));
+    expect(existsSync(legacyPath)).toBe(false); // cleaned up at the old location
+    expect(readFileSync(newPath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'a' }));
+    // Breadcrumb written so a future restart never re-scans.
+    expect(existsSync(join(scratchDir, 'unbound-root', '.legacy-migrated'))).toBe(true);
   });
 });
 

--- a/tests/broker-status.test.ts
+++ b/tests/broker-status.test.ts
@@ -7,7 +7,10 @@ import { buildBrokerHelloData, noPluginMessage, type BrokerMeta } from '../cli/s
 import type { RouteFilter } from '../cli/src/transport/route-filter.ts';
 
 const sock = (): RegistrySocket => ({ readyState: WS_OPEN });
-const META: BrokerMeta = { port: 9410, pid: 4242, protocolV: 1, buildMtime: 111, uptimeMs: 5000, senderMismatchCount: 0 };
+const META: BrokerMeta = {
+  port: 9410, pid: 4242, protocolV: 1, buildMtime: 111, uptimeMs: 5000,
+  senderMismatchCount: 0, legacyMigrationDeferred: false,
+};
 
 /** Registry with a fixed clock so lastHeartbeatAge is deterministic. */
 function seed(now = 1_000) {
@@ -109,6 +112,20 @@ describe('buildBrokerHelloData — senderMismatchCount (issue #15, PR #14 review
     const { reg, clock } = seed();
     const d = buildBrokerHelloData(reg, { ...META, senderMismatchCount: 3 }, null, clock);
     expect(d.senderMismatchCount).toBe(3);
+  });
+});
+
+describe('buildBrokerHelloData — legacyMigrationDeferred (issue #7 fix round, reviewer finding 1)', () => {
+  it('false → the key is OMITTED, keeping the payload byte-identical to before this field existed', () => {
+    const { reg, clock } = seed();
+    const d = buildBrokerHelloData(reg, { ...META, legacyMigrationDeferred: false }, null, clock);
+    expect('legacyMigrationDeferred' in d).toBe(false);
+  });
+
+  it('true surfaces verbatim — same "discarded/stuck thing gets a machine-readable flag" contract as senderMismatchCount', () => {
+    const { reg, clock } = seed();
+    const d = buildBrokerHelloData(reg, { ...META, legacyMigrationDeferred: true }, null, clock);
+    expect(d.legacyMigrationDeferred).toBe(true);
   });
 });
 

--- a/tests/change-log.test.ts
+++ b/tests/change-log.test.ts
@@ -8,8 +8,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   CHANGE_LOG_FILENAME, UNBOUND_STAGING_DIRNAME, appendChangeFrames, changeLogDir,
-  changeLogLineCount, changeLogPath, changeLogPathFor, migratedMarkerPath, migrateStagedChanges,
-  unboundStagingPath,
+  changeLogLineCount, changeLogPath, changeLogPathFor, migrateLegacyUnboundChanges,
+  migratedMarkerPath, migrateStagedChanges, unboundStagingPath, unboundStagingRoot,
 } from '../cli/src/transport/change-log.ts';
 import { CHANGE_LOG_SCHEMA_VERSION, type ComponentChange } from '../shared/figma-changes.ts';
 
@@ -19,18 +19,25 @@ const change = (over: Partial<ComponentChange>): ComponentChange => ({
 });
 
 let dir: string;
+let unboundDir: string;
 let path: string;
 const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+const prevUnboundEnv = process.env['FIGMA_AGENT_UNBOUND_DIR'];
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'fa-changes-'));
+  unboundDir = mkdtempSync(join(tmpdir(), 'fa-unbound-'));
   process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+  process.env['FIGMA_AGENT_UNBOUND_DIR'] = unboundDir;
   path = changeLogPath();
 });
 afterEach(() => {
   if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
   else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+  if (prevUnboundEnv === undefined) delete process.env['FIGMA_AGENT_UNBOUND_DIR'];
+  else process.env['FIGMA_AGENT_UNBOUND_DIR'] = prevUnboundEnv;
   rmSync(dir, { recursive: true, force: true });
+  rmSync(unboundDir, { recursive: true, force: true });
 });
 
 const readLines = (): string[] => readFileSync(path, 'utf8').split('\n').filter((l) => l.trim().length > 0);
@@ -107,9 +114,21 @@ describe('changeLogPathFor — rooted at an explicit project, not the broker cwd
   });
 });
 
+describe('unboundStagingRoot — issue #7 (backlog 5.6): cwd-independent, never changeLogDir()', () => {
+  it('honours FIGMA_AGENT_UNBOUND_DIR, independent of FIGMA_AGENT_CHANGES_DIR', () => {
+    expect(unboundStagingRoot()).toBe(unboundDir);
+    expect(unboundStagingRoot()).not.toBe(changeLogDir());
+  });
+  it('defaults to /tmp/figma-agent-unbound when the env is unset', () => {
+    delete process.env['FIGMA_AGENT_UNBOUND_DIR'];
+    expect(unboundStagingRoot()).toBe('/tmp/figma-agent-unbound');
+  });
+});
+
 describe('unboundStagingPath / migrateStagedChanges — registry-integrity fix round finding 1', () => {
-  it('stages beside the default change log, never inside a project design/', () => {
-    expect(unboundStagingPath('vsf-pcp')).toBe(join(dir, UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl'));
+  it('stages under unboundStagingRoot(), never inside a project design/, never under changeLogDir()', () => {
+    expect(unboundStagingPath('vsf-pcp')).toBe(join(unboundDir, UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl'));
+    expect(unboundStagingPath('vsf-pcp').startsWith(dir)).toBe(false);
   });
 
   it('migrating an absent staging file is a no-op (0 migrated)', () => {
@@ -204,6 +223,34 @@ describe('unboundStagingPath / migrateStagedChanges — registry-integrity fix r
       expect(existsSync(migratedMarkerPath(staging))).toBe(false); // no artifact left behind
       expect(readFileSync(bound, 'utf8').split('\n').filter(Boolean)).toHaveLength(2);
     });
+  });
+});
+
+describe('migrateLegacyUnboundChanges — issue #7 (backlog 5.6) one-time startup migration', () => {
+  it('migrates a file staged at the OLD (changeLogDir()-rooted) location to the new root', () => {
+    const legacyFile = join(dir, UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl');
+    mkdirSync(join(dir, UNBOUND_STAGING_DIRNAME), { recursive: true });
+    writeFileSync(legacyFile, `${JSON.stringify({ nodeId: 'a' })}\n`, 'utf8');
+
+    const migratedFiles = migrateLegacyUnboundChanges();
+    expect(migratedFiles).toBe(1);
+    expect(existsSync(legacyFile)).toBe(false); // cleaned up at the old location
+    const newPath = unboundStagingPath('vsf-pcp');
+    expect(existsSync(newPath)).toBe(true);
+    expect(readFileSync(newPath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'a' }));
+  });
+
+  it('is a no-op (0 migrated) when nothing was ever staged at the old location', () => {
+    expect(migrateLegacyUnboundChanges()).toBe(0);
+  });
+
+  it('migrates every staged file, not just the first', () => {
+    mkdirSync(join(dir, UNBOUND_STAGING_DIRNAME), { recursive: true });
+    writeFileSync(join(dir, UNBOUND_STAGING_DIRNAME, 'a.jsonl'), `${JSON.stringify({ nodeId: '1' })}\n`, 'utf8');
+    writeFileSync(join(dir, UNBOUND_STAGING_DIRNAME, 'b.jsonl'), `${JSON.stringify({ nodeId: '2' })}\n`, 'utf8');
+    expect(migrateLegacyUnboundChanges()).toBe(2);
+    expect(existsSync(unboundStagingPath('a'))).toBe(true);
+    expect(existsSync(unboundStagingPath('b'))).toBe(true);
   });
 });
 

--- a/tests/edit-feed-log.test.ts
+++ b/tests/edit-feed-log.test.ts
@@ -2,14 +2,14 @@
 // PROJECT FILE (fileKey|fileName slug), deliberately separate from change-log.ts so the
 // two logs can never converge (spec A6). Mirrors tests/change-log.test.ts's shape.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
   EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME, appendEditFrames, editFeedDir, editFeedPath,
-  editFeedPathForIdentity, unboundEditStagingPath,
+  editFeedPathForIdentity, migrateLegacyUnboundEdits, unboundEditStagingPath,
 } from '../cli/src/transport/edit-feed-log.ts';
-import { migrateStagedChanges } from '../cli/src/transport/change-log.ts';
+import { migrateStagedChanges, unboundStagingRoot } from '../cli/src/transport/change-log.ts';
 import { EDIT_FEED_SCHEMA_VERSION, type EditInput } from '../shared/edit-feed.ts';
 
 const edit = (over: Partial<EditInput> = {}): EditInput => ({
@@ -19,16 +19,23 @@ const edit = (over: Partial<EditInput> = {}): EditInput => ({
 });
 
 let dir: string;
+let unboundDir: string;
 const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+const prevUnboundEnv = process.env['FIGMA_AGENT_UNBOUND_DIR'];
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'fa-edit-feed-'));
+  unboundDir = mkdtempSync(join(tmpdir(), 'fa-edit-feed-unbound-'));
   process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+  process.env['FIGMA_AGENT_UNBOUND_DIR'] = unboundDir;
 });
 afterEach(() => {
   if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
   else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+  if (prevUnboundEnv === undefined) delete process.env['FIGMA_AGENT_UNBOUND_DIR'];
+  else process.env['FIGMA_AGENT_UNBOUND_DIR'] = prevUnboundEnv;
   rmSync(dir, { recursive: true, force: true });
+  rmSync(unboundDir, { recursive: true, force: true });
 });
 
 const readLines = (path: string): string[] =>
@@ -178,10 +185,11 @@ describe('editFeedPathForIdentity — rooted at an explicit project, not the bro
 });
 
 describe('unboundEditStagingPath — mirrors change-log.ts\'s unboundStagingPath contract', () => {
-  it('lives under <editFeedDir()>/unbound/, its OWN subdir (never DOC_CHANGE\'s unbound/)', () => {
+  it('lives under <unboundStagingRoot()>/changes/unbound/, its OWN subdir (never DOC_CHANGE\'s unbound/), never under changeLogDir()', () => {
     expect(unboundEditStagingPath('vsf-pcp')).toBe(
-      join(editFeedDir(), EDIT_FEED_UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl'),
+      join(unboundStagingRoot(), EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl'),
     );
+    expect(unboundEditStagingPath('vsf-pcp').startsWith(dir)).toBe(false);
   });
 
   it('is a DIFFERENT path from change-log.ts\'s own unbound staging for the same slug', () => {
@@ -196,7 +204,6 @@ describe('migrateStagedChanges reused as-is for the edit feed (schema-agnostic r
   it('migrates staged EditFrame lines into the bound project\'s own edit feed, idempotently', () => {
     const staging = unboundEditStagingPath('vsf-pcp');
     const bound = editFeedPathForIdentity(join(dir, 'bound-project'), 'vsf-pcp');
-    mkdirSync(join(dir, EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME), { recursive: true });
     appendEditFrames(staging, [edit({ nodeId: 'a' })], { fileKey: null, fileName: 'VSF - PCP', source: 'live' }, 1);
 
     expect(migrateStagedChanges(staging, bound)).toBe(1);
@@ -211,5 +218,24 @@ describe('migrateStagedChanges reused as-is for the edit feed (schema-agnostic r
     const staging = unboundEditStagingPath('never-staged');
     const bound = editFeedPathForIdentity(join(dir, 'bound-project'), 'never-staged');
     expect(migrateStagedChanges(staging, bound)).toBe(0);
+  });
+});
+
+describe('migrateLegacyUnboundEdits — issue #7 (backlog 5.6) one-time startup migration', () => {
+  it('migrates a file staged at the OLD (editFeedDir()-rooted) location to the new root', () => {
+    const legacyFile = join(dir, EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl');
+    mkdirSync(join(dir, EDIT_FEED_DIRNAME, EDIT_FEED_UNBOUND_STAGING_DIRNAME), { recursive: true });
+    writeFileSync(legacyFile, `${JSON.stringify({ nodeId: 'a' })}\n`, 'utf8');
+
+    const migratedFiles = migrateLegacyUnboundEdits();
+    expect(migratedFiles).toBe(1);
+    expect(existsSync(legacyFile)).toBe(false);
+    const newPath = unboundEditStagingPath('vsf-pcp');
+    expect(existsSync(newPath)).toBe(true);
+    expect(readFileSync(newPath, 'utf8').trim()).toBe(JSON.stringify({ nodeId: 'a' }));
+  });
+
+  it('is a no-op (0 migrated) when nothing was ever staged at the old location', () => {
+    expect(migrateLegacyUnboundEdits()).toBe(0);
   });
 });

--- a/tests/error-log.test.ts
+++ b/tests/error-log.test.ts
@@ -2,12 +2,14 @@
 // ReplyErr relayed, at design/figma-errors.jsonl (sibling of figma.changes.jsonl, shares
 // the base dir with the 4.4 edit feed via changeLogDir()). Mirrors change-log.test.ts's shape.
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
-  ERROR_LOG_FILENAME, appendErrorFrame, buildErrorLogFrame, errorLogPath,
+  ERROR_LOG_FILENAME, ERROR_STAGING_DIRNAME, ERROR_UNBOUND_STAGING_DIRNAME,
+  appendErrorFrame, buildErrorLogFrame, errorLogPath, errorLogPathFor, unboundErrorStagingPath,
 } from '../cli/src/transport/error-log.ts';
+import { unboundStagingRoot } from '../cli/src/transport/change-log.ts';
 import type { ReplyErr } from '../shared/protocol.ts';
 
 const replyErr = (over: Partial<ReplyErr> = {}): ReplyErr => ({
@@ -18,16 +20,23 @@ const replyErr = (over: Partial<ReplyErr> = {}): ReplyErr => ({
 });
 
 let dir: string;
+let unboundDir: string;
 const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+const prevUnboundEnv = process.env['FIGMA_AGENT_UNBOUND_DIR'];
 
 beforeEach(() => {
   dir = mkdtempSync(join(tmpdir(), 'fa-error-log-'));
+  unboundDir = mkdtempSync(join(tmpdir(), 'fa-error-log-unbound-'));
   process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+  process.env['FIGMA_AGENT_UNBOUND_DIR'] = unboundDir;
 });
 afterEach(() => {
   if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
   else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+  if (prevUnboundEnv === undefined) delete process.env['FIGMA_AGENT_UNBOUND_DIR'];
+  else process.env['FIGMA_AGENT_UNBOUND_DIR'] = prevUnboundEnv;
   rmSync(dir, { recursive: true, force: true });
+  rmSync(unboundDir, { recursive: true, force: true });
 });
 
 const readLines = (path: string): string[] =>
@@ -36,6 +45,26 @@ const readLines = (path: string): string[] =>
 describe('errorLogPath — shares the change-log base dir + env override', () => {
   it('lives directly at <changeLogDir()>/figma-errors.jsonl (a SIBLING of the change log)', () => {
     expect(errorLogPath()).toBe(join(dir, ERROR_LOG_FILENAME));
+  });
+});
+
+describe('errorLogPathFor — issue #7 (backlog 5.9): rooted at an explicit project, not the broker cwd', () => {
+  it('names the same file under <projectDir>/design', () => {
+    expect(errorLogPathFor('/tmp/some-project')).toBe(join('/tmp/some-project', 'design', ERROR_LOG_FILENAME));
+  });
+});
+
+describe('unboundErrorStagingPath — issue #7 (backlog 5.9): mirrors change-log.ts / edit-feed-log.ts\'s unbound staging exactly', () => {
+  it('lives under <unboundStagingRoot()>/errors/unbound/, its OWN subdir, never under changeLogDir()', () => {
+    expect(unboundErrorStagingPath('vsf-pcp')).toBe(
+      join(unboundStagingRoot(), ERROR_STAGING_DIRNAME, ERROR_UNBOUND_STAGING_DIRNAME, 'vsf-pcp.jsonl'),
+    );
+    expect(unboundErrorStagingPath('vsf-pcp').startsWith(dir)).toBe(false);
+  });
+
+  it('is a DIFFERENT path from change-log.ts\'s / edit-feed-log.ts\'s own unbound staging for the same slug', () => {
+    const errStaging = unboundErrorStagingPath('vsf-pcp');
+    expect(errStaging).toContain(`${ERROR_STAGING_DIRNAME}/${ERROR_UNBOUND_STAGING_DIRNAME}`);
   });
 });
 
@@ -110,5 +139,23 @@ describe('appendErrorFrame — one JSONL line per error, append-only', () => {
     appendErrorFrame(path, buildErrorLogFrame(replyErr({ id: 'a' }), null, 1));
     appendErrorFrame(path, buildErrorLogFrame(replyErr({ id: 'b' }), null, 2));
     expect(readLines(path).map((l) => JSON.parse(l).requestId)).toEqual(['a', 'b']);
+  });
+
+  // Issue #7 minor fix: log-rotate.ts's own module header always named this feed as one
+  // of the three its policy covers, but the call here was never actually wired — this
+  // crosses that boundary directly with the SAME default 8 MiB policy the other two
+  // feeds use (rotateIfNeeded's own exhaustive behavior — boundary, marker ordering,
+  // generation retention — is tested in log-rotate.test.ts; this only proves
+  // appendErrorFrame's call site is real, not a documentation claim).
+  it('rotates once the file crosses the default 8 MiB policy, same as appendChangeFrame/appendEditFrame', () => {
+    const path = errorLogPath();
+    const oneMib = 'x'.repeat(1024 * 1024);
+    for (let i = 0; i < 9; i++) {
+      appendErrorFrame(path, buildErrorLogFrame(replyErr({ id: `req-${i}`, error: { code: 'E_EVAL', message: oneMib } }), null, i));
+    }
+    expect(existsSync(`${path}.rotated.json`)).toBe(true); // rotated at least once past 8 MiB
+    expect(existsSync(`${path}.1`)).toBe(true); // the archived generation
+    // The live file was reset — its own size is small again (last append(s) only).
+    expect(readLines(path).length).toBeLessThan(9);
   });
 });


### PR DESCRIPTION
Closes #7.

## Summary
This closes the cwd-misattribution class across all four broker write surfaces — DOC_CHANGE and EDIT_FEED already routed through the binding index; this closes the last two (backlog 5.6, 5.9).

- **5.6 — cwd-independent unbound staging root.** `unboundStagingPath`/`unboundEditStagingPath` used to root at `changeLogDir()` (the broker's own spawn cwd) — a restart into a different cwd orphaned whatever was staged there. Deferred at RI-P1 fix#1 time specifically because it meant moving an already-shipped, review-verified mechanism ("its own small spec/review, not a rider on whichever wave happens to touch this file next" — that review is this PR). New `unboundStagingRoot()`: `FIGMA_AGENT_UNBOUND_DIR` env override, else a fixed `/tmp/figma-agent-unbound` default, same convention as `project-bind.ts`'s `bindCacheFile()`. **One-time startup migration** (ruling: migrate, never silently orphan): a broker upgrading from before this fix scans the OLD location once and migrates anything found into the new root, reusing `migrateStagedChanges` as-is, guarded by a breadcrumb so future restarts skip the scan.
- **5.9 — error log gets full binding-aware routing.** `errorLogPath()` used to be resolved ONCE at broker startup and shared by every file/project the broker ever relayed for — no per-event resolution at all, unlike DOC_CHANGE/EDIT_FEED. Now: `errorLogPathFor(projectDir)` / `unboundErrorStagingPath(slug)`, resolved fresh per `ReplyErr` (`fileIdentity` + `resolveProjectDir`, same shape as the other two), with staging + migrate-on-bind parity (`migratedErrorCount`).
- **Minor:** `appendErrorFrame` now calls `rotateIfNeeded` — `log-rotate.ts`'s own module header always named the error log as one of the three feeds its policy covers, but the call site was never actually wired, leaving it the one unbounded-growth feed of the three.
- `shared/protocol.ts`: `FileContext.fileKey`'s comment corrected (was "carried, never used for routing" — now used for routing on the error-log path specifically; one-line comment fix, no schema change).

## Test plan
- [x] Test-first where it mattered: every existing unbound-staging test that hardcoded the old root's path was run RED against the new source first (confirmed failing for the expected reason), then updated.
- [x] 26 new/changed tests: `unboundStagingRoot` (2), `migrateLegacyUnboundChanges` (3), `migrateLegacyUnboundEdits` (2), `errorLogPathFor`/`unboundErrorStagingPath` (3), the rotation-wiring integration test (1), plus root-relocation fixes across the existing staging-path assertions, and 2 new end-to-end `broker-daemon-harness.test.ts` scenarios (error routing stage→bind→migrate→direct, and the one-time legacy-migration-on-startup).
- [x] Every test file that exercises unbound staging now isolates `FIGMA_AGENT_UNBOUND_DIR` via a dedicated scratch dir in `beforeEach`/`afterEach`, matching this repo's existing env-swap convention — confirmed no bleed into the real `/tmp/figma-agent-unbound` default (checked directly after each local run).
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean (cli 235.4kb, plugin 159.0kb — plugin unchanged, no plugin-side source touched)
- [x] `npm test` — 87 files / 1129 tests green (was 85/1103 on latest main before this branch; +26 explained above, no unexplained drift)
- [x] No `npm run lint` script exists in this repo — consistent with prior gates, skipped.

No live-canvas verification needed — this phase is entirely broker/CLI-side (no plugin change), and every scenario (staging, migration, rotation, routing) is exercised end-to-end via the real in-process broker + real `ws` sockets in `broker-daemon-harness.test.ts`, not simulated.

Holding for review.