### PR TITLE
fix: route SYNC_CONFIG idleMs through the file's project binding

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -34,7 +34,7 @@ import {
   appendEditFrames, editFeedPathForIdentity, migrateLegacyUnboundEdits, safeSlug, unboundEditStagingPath,
 } from './edit-feed-log.ts';
 import { appendErrorFrame, buildErrorLogFrame, errorLogPathFor, unboundErrorStagingPath } from './error-log.ts';
-import { readIdleMs } from './figma-sync-config.ts';
+import { readIdleMs, readIdleMsFor } from './figma-sync-config.ts';
 import { spawnReconcileApply } from './figma-sync-apply.ts';
 import {
   fileIdentity, loadBindIndex, needsAliasPromotion, readBindMarker, recordBinding, removeBinding,
@@ -642,6 +642,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // unbound staging, giving it full parity with the other two feeds.
     const migratedErrorCount = migrateStagedChanges(unboundErrorStagingPath(slug), errorLogPathFor(projectDir));
     log(`BIND recorded: "${fileName}" → ${projectDir}${fileKey ? ` (fileKey ${fileKey})` : ' (pending fileKey)'}${migratedCount > 0 ? `, migrated ${migratedCount} staged change frame(s)` : ''}${migratedEditCount > 0 ? `, migrated ${migratedEditCount} staged edit frame(s)` : ''}${migratedErrorCount > 0 ? `, migrated ${migratedErrorCount} staged error frame(s)` : ''}`);
+    // Issue #20 fix: an ALREADY-CONNECTED plugin for this file received SYNC_CONFIG at
+    // HELLO time, before this binding existed — its idle timer is still running on the
+    // broker's cwd default (or a stale project's). Push the newly-bound project's own
+    // idle window now, so it takes effect without waiting for a reconnect.
+    if (hit) sendEvent(hit.ws, 'SYNC_CONFIG', { idleMs: readIdleMsFor(projectDir) });
     reply({ fileName, projectDir, fileKey, pendingKey: fileKey === null, migratedCount, migratedEditCount, migratedErrorCount });
   };
 
@@ -1208,7 +1213,18 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         log(`plugin registered [${instanceId}]${replaced ? ' (replaced — same instance re-hello)' : ''}: ${JSON.stringify(msg.data)}`);
         // Live-sync (spec 004 P4): hand this plugin the idle window so its debounce
         // timer matches the project's design/figma-sync.json.
-        sendEvent(ws, 'SYNC_CONFIG', { idleMs });
+        //
+        // Issue #20 fix: resolved from THIS file's binding, same fileIdentity→
+        // resolveProjectDir shape the error-log/edit-feed paths already use — never the
+        // once-cached, broker-cwd-derived `idleMs` unconditionally, or a broker spawned
+        // from one project's cwd hands every OTHER bound project's plugin the wrong idle
+        // window. A genuinely unbound file (no PROJECT_BIND yet) still falls back to the
+        // broker's own cwd default — there is nowhere else to read it from.
+        const helloScene = st.registry.getByWs(ws)?.scene;
+        const helloFileName = (helloScene?.fileName as string | undefined) ?? null;
+        const helloFileKey = (helloScene?.fileKey as string | null | undefined) ?? null;
+        const helloBound = resolveProjectDir(fileIdentity(helloFileKey, helloFileName), st.bindIndex);
+        sendEvent(ws, 'SYNC_CONFIG', { idleMs: helloBound ? readIdleMsFor(helloBound) : idleMs });
         flushWaiting(); // deliver any requests parked during the reconnect gap
         broadcastPeers();
       } else if (msg.type === 'PING') {

--- a/cli/src/transport/figma-sync-config.ts
+++ b/cli/src/transport/figma-sync-config.ts
@@ -3,27 +3,12 @@
 // broker reads it once at connect and sends it as SYNC_CONFIG; the plugin's idle
 // timer uses it (clamped to a floor). Kept tiny + pure-ish (fs read only, no network).
 import { existsSync, readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { join } from 'node:path';
 
 import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../../../shared/protocol.ts';
 import { changeLogDir } from './change-log.ts';
 
 export const SYNC_CONFIG_FILENAME = 'figma-sync.json';
-
-/**
- * Project dir holding `design/` — the parent of the change-log dir (the broker's spawn
- * cwd, or `FIGMA_AGENT_CHANGES_DIR`). Kept ONLY for `syncConfigPath()` below (a
- * broker-local `figma-sync.json` read for the idle window).
- *
- * ⚠️ Registry-integrity phase 01 (5.1): do NOT import this into the apply path
- * (figma-sync-apply.ts / broker-daemon.ts's `handleSyncRequest`) again. The apply target
- * must come from `project-bind.ts`'s `resolveProjectDir`, resolved from the FILE that
- * triggered the sync — never the daemon's spawn cwd. Re-wiring this back in silently
- * reintroduces the cross-project write corruption this phase fixed.
- */
-export function projectDir(): string {
-  return dirname(changeLogDir());
-}
 
 /** Absolute path to `<broker-cwd-or-env-override>/figma-sync.json` — the GLOBAL
  *  fallback used only while a file has no resolved project binding yet (see

--- a/cli/src/transport/figma-sync-config.ts
+++ b/cli/src/transport/figma-sync-config.ts
@@ -25,21 +25,54 @@ export function projectDir(): string {
   return dirname(changeLogDir());
 }
 
-/** Absolute path to `<project>/design/figma-sync.json`. */
+/** Absolute path to `<broker-cwd-or-env-override>/figma-sync.json` — the GLOBAL
+ *  fallback used only while a file has no resolved project binding yet (see
+ *  `readIdleMs()` below). A BOUND file must use `syncConfigPathFor()` instead. */
 export function syncConfigPath(): string {
   return join(changeLogDir(), SYNC_CONFIG_FILENAME);
 }
 
 /**
- * Resolve the idle window in ms. Order: `FIGMA_AGENT_IDLE_MS` env (fast test
- * override) → `design/figma-sync.json` {"idleMs"} → DEFAULT_IDLE_MS. Any malformed
- * / too-small value floors to MIN_IDLE_MS so a typo can never spin the timer.
+ * Resolve the idle window in ms for a file with NO resolved project binding (broker
+ * startup default, and the transient window before a PROJECT_BIND lands). Order:
+ * `FIGMA_AGENT_IDLE_MS` env (fast test override) → the broker's own cwd-relative
+ * `figma-sync.json` {"idleMs"} → DEFAULT_IDLE_MS. Any malformed/too-small value floors
+ * to MIN_IDLE_MS so a typo can never spin the timer.
+ *
+ * Issue #20 audit: this is deliberately NOT the only idle-window resolver. The broker
+ * is a multi-project daemon (`project-bind.ts`'s `bindIndex` routes many bound
+ * projects through one process) — once a file's identity resolves to a project via
+ * the binding, its idle window must come from THAT project's own
+ * `design/figma-sync.json` (`readIdleMsFor()`), never this cwd-relative default, or a
+ * broker spawned from project A's cwd would hand project B's plugin project A's idle
+ * window. Callers: `broker-daemon.ts`'s PLUGIN_HELLO handler resolves the binding
+ * first and only falls back to this function when the file is genuinely unbound.
  */
 export function readIdleMs(): number {
   const env = process.env['FIGMA_AGENT_IDLE_MS'];
   if (env !== undefined) return clampIdle(Number(env));
+  return readIdleMsFromPath(syncConfigPath());
+}
 
-  const path = syncConfigPath();
+/** Absolute path to `<projectDir>/design/figma-sync.json` — the per-project idle
+ *  config, same shape as `change-log.ts`'s `changeLogPathFor()`. */
+export function syncConfigPathFor(projectDir: string): string {
+  return join(projectDir, 'design', SYNC_CONFIG_FILENAME);
+}
+
+/**
+ * Resolve the idle window in ms for a file that IS bound to `projectDir` (issue #20).
+ * Same precedence as `readIdleMs()` — the env override still wins globally (an
+ * operator's fast-test override must not require per-project files) — but the file
+ * fallback reads `<projectDir>/design/figma-sync.json`, never the broker's own cwd.
+ */
+export function readIdleMsFor(projectDir: string): number {
+  const env = process.env['FIGMA_AGENT_IDLE_MS'];
+  if (env !== undefined) return clampIdle(Number(env));
+  return readIdleMsFromPath(syncConfigPathFor(projectDir));
+}
+
+function readIdleMsFromPath(path: string): number {
   if (!existsSync(path)) return DEFAULT_IDLE_MS;
   try {
     const parsed = JSON.parse(readFileSync(path, 'utf8')) as { idleMs?: unknown };

--- a/cli/src/transport/project-bind.ts
+++ b/cli/src/transport/project-bind.ts
@@ -1,6 +1,6 @@
 // Registry-integrity phase 01 (5.1) — file↔project binding. Durable project state (the
 // registry, its sidecars, cursor, manifest) currently derives from the broker's OWN spawn
-// cwd (figma-sync-config.ts's `projectDir()`), never from which project the edit actually
+// cwd (change-log.ts's `changeLogDir()`), never from which project the edit actually
 // came from. This module is the fix's pure core: it never guesses a project for an unknown
 // file — the caller (figma-sync-apply.ts §3) must refuse instead.
 //

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -695,3 +695,64 @@ describe('daemon harness — routeFromPlugin verifies the reply sender against t
     expect((hello.data as Record<string, unknown>).senderMismatchCount).toBe(1);
   });
 });
+
+describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, never the broker\'s spawn cwd (issue #20)', () => {
+  it('a plugin bound to a project with its OWN figma-sync.json gets THAT idleMs, not the broker cwd default, on HELLO after the bind', async () => {
+    // Simulates the broker being spawned from "Project A"'s cwd — its own idle window,
+    // distinct from the project this daemon ends up serving.
+    writeFileSync(join(scratchDir, 'figma-sync.json'), JSON.stringify({ idleMs: 111_000 }), 'utf8');
+    const port = await startTestBroker();
+
+    const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-sync-bound-project-'));
+    try {
+      mkdirSync(join(boundProjectDir, 'design'), { recursive: true });
+      // "Project B" — the project this file is actually bound to — has its OWN idle
+      // window, deliberately different from the broker's cwd default above.
+      writeFileSync(join(boundProjectDir, 'design', 'figma-sync.json'), JSON.stringify({ idleMs: 222_000 }), 'utf8');
+
+      const plugin = await connectSocket(port);
+      await helloPlugin(plugin, 'plugin-sync-1', 'Project B File');
+
+      const cli = await connectSocket(port);
+      await bindProject(cli, 'Project B File', boundProjectDir, 'req-bind-sync-1');
+
+      // A fresh HELLO for the SAME (now-bound) file — e.g. a plugin reconnect, or the
+      // broker itself having restarted from a different cwd in the meantime. The file
+      // identity is bound to Project B, so its SYNC_CONFIG must reflect Project B's own
+      // figma-sync.json, never the broker's spawn-cwd default (Project A's 111_000).
+      const plugin2 = await connectSocket(port);
+      const syncConfigPromise = nextFrame<EventMsg>(plugin2, (m) => (m as EventMsg).type === 'SYNC_CONFIG');
+      plugin2.send(JSON.stringify({
+        type: 'PLUGIN_HELLO',
+        data: { instanceId: 'plugin-sync-2', fileName: 'Project B File', fileKey: null, caps: ['fileGuard'] },
+      } satisfies EventMsg));
+      const syncConfig = await syncConfigPromise;
+      expect((syncConfig.data as { idleMs: number }).idleMs).toBe(222_000);
+    } finally {
+      rmSync(boundProjectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('an ALREADY-CONNECTED plugin gets an updated SYNC_CONFIG the moment its file is bound, without needing to reconnect', async () => {
+    writeFileSync(join(scratchDir, 'figma-sync.json'), JSON.stringify({ idleMs: 111_000 }), 'utf8');
+    const port = await startTestBroker();
+
+    const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-sync-bound-project-live-'));
+    try {
+      mkdirSync(join(boundProjectDir, 'design'), { recursive: true });
+      writeFileSync(join(boundProjectDir, 'design', 'figma-sync.json'), JSON.stringify({ idleMs: 333_000 }), 'utf8');
+
+      const plugin = await connectSocket(port);
+      await helloPlugin(plugin, 'plugin-sync-live-1', 'Project C File'); // unbound: gets the broker-cwd default
+
+      const postBindSyncConfig = nextFrame<EventMsg>(plugin, (m) => (m as EventMsg).type === 'SYNC_CONFIG');
+      const cli = await connectSocket(port);
+      await bindProject(cli, 'Project C File', boundProjectDir, 'req-bind-sync-live-1');
+
+      const syncConfig = await postBindSyncConfig;
+      expect((syncConfig.data as { idleMs: number }).idleMs).toBe(333_000);
+    } finally {
+      rmSync(boundProjectDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -733,14 +733,26 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
     }
   });
 
-  it('an ALREADY-CONNECTED plugin gets an updated SYNC_CONFIG the moment its file is bound, without needing to reconnect', async () => {
+  it('an ALREADY-CONNECTED plugin gets an updated SYNC_CONFIG the moment its file is bound, without needing to reconnect — and an unrelated plugin bound to a DIFFERENT project gets nothing', async () => {
     writeFileSync(join(scratchDir, 'figma-sync.json'), JSON.stringify({ idleMs: 111_000 }), 'utf8');
     const port = await startTestBroker();
 
     const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-sync-bound-project-live-'));
+    const otherProjectDir = mkdtempSync(join(tmpdir(), 'fa-sync-other-project-'));
     try {
       mkdirSync(join(boundProjectDir, 'design'), { recursive: true });
       writeFileSync(join(boundProjectDir, 'design', 'figma-sync.json'), JSON.stringify({ idleMs: 333_000 }), 'utf8');
+      mkdirSync(join(otherProjectDir, 'design'), { recursive: true });
+      writeFileSync(join(otherProjectDir, 'design', 'figma-sync.json'), JSON.stringify({ idleMs: 444_000 }), 'utf8');
+
+      // An unrelated plugin, already bound to a DIFFERENT project, connected BEFORE
+      // Project C's bind fires — proves the post-bind push targets the one socket whose
+      // file was just bound, never every connected plugin.
+      const pluginOther = await connectSocket(port);
+      await helloPlugin(pluginOther, 'plugin-sync-other-1', 'Project Other File');
+      const cliOther = await connectSocket(port);
+      await bindProject(cliOther, 'Project Other File', otherProjectDir, 'req-bind-sync-other-1');
+      const otherFrames = collectFrames(pluginOther); // observe from here on — its own HELLO/bind traffic already drained
 
       const plugin = await connectSocket(port);
       await helloPlugin(plugin, 'plugin-sync-live-1', 'Project C File'); // unbound: gets the broker-cwd default
@@ -751,8 +763,15 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
 
       const syncConfig = await postBindSyncConfig;
       expect((syncConfig.data as { idleMs: number }).idleMs).toBe(333_000);
+
+      // Give the unrelated plugin's socket a beat to receive anything it's going to
+      // receive, then assert it got NOTHING out of Project C's bind — targeted, not
+      // broadcast.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(otherFrames.frames.some((f) => (f as EventMsg).type === 'SYNC_CONFIG')).toBe(false);
     } finally {
       rmSync(boundProjectDir, { recursive: true, force: true });
+      rmSync(otherProjectDir, { recursive: true, force: true });
     }
   });
 });

--- a/tests/figma-sync-config.test.ts
+++ b/tests/figma-sync-config.test.ts
@@ -4,7 +4,7 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { readIdleMs, projectDir, syncConfigPath } from '../cli/src/transport/figma-sync-config.ts';
+import { readIdleMs, syncConfigPath } from '../cli/src/transport/figma-sync-config.ts';
 import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../shared/protocol.ts';
 
 let dir: string;
@@ -53,8 +53,5 @@ describe('figma-sync-config — readIdleMs', () => {
   it('a non-numeric idleMs falls back to DEFAULT_IDLE_MS', () => {
     writeConfig({ idleMs: 'soon' });
     expect(readIdleMs()).toBe(DEFAULT_IDLE_MS);
-  });
-  it('projectDir is the parent of the design/ change-log dir', () => {
-    expect(projectDir()).toBe(dir);
   });
 });


### PR DESCRIPTION
## Audit finding (issue #20)

`syncConfigPath()`/`readIdleMs()` was the last cwd-relative path resolver left in the
broker after #19 closed the cwd-misattribution class across the four capture-WRITE
surfaces. The hole is real, not a documented single-project contract:

- The broker is a multi-project daemon by design (`project-bind.ts`'s `bindIndex`
  routes many bound projects through one long-lived process — see `loadBindIndex`,
  the `/tmp/figma-agent-binds.json` restart-survival cache, `PROJECT_BIND`).
- `idleMs` was resolved ONCE at broker startup from the broker's own spawn cwd (or
  `FIGMA_AGENT_CHANGES_DIR`) and sent unconditionally to every `PLUGIN_HELLO`,
  regardless of which project that plugin's file was bound to.
- Concretely: a broker spawned from project A's cwd (its own `design/figma-sync.json`)
  serving a plugin bound to project B hands B's plugin A's idle window — and even an
  already-connected plugin never picks up its own project's config after a
  `PROJECT_BIND` resolves it, since `SYNC_CONFIG` is only ever sent once, at HELLO.

Two discriminating tests in `tests/broker-daemon-harness.test.ts` reproduce this
against pre-fix code (both fail: one asserts `222_000`, gets the broker-cwd default
`111_000`; the other times out because no second `SYNC_CONFIG` is ever sent after
bind).

## Fix

- `cli/src/transport/figma-sync-config.ts`: add `syncConfigPathFor(projectDir)` /
  `readIdleMsFor(projectDir)`, mirroring `change-log.ts`'s `changeLogPathFor()`
  convention. `syncConfigPath()`/`readIdleMs()` stay as the documented GLOBAL fallback
  for a genuinely unbound file.
- `cli/src/transport/broker-daemon.ts`:
  - `PLUGIN_HELLO` now resolves the file's binding first (same
    `fileIdentity`→`resolveProjectDir` shape the error-log/edit-feed paths already use)
    and sends that project's own idle window, falling back to the broker-cwd default
    only when unbound.
  - `handleProjectBind` pushes a fresh `SYNC_CONFIG` to an already-connected plugin the
    moment its file is bound, so the correct idle window takes effect without a
    reconnect.

No changes to `plugin/` or the pinned `kernel/design-os` submodule.

## Gates (in the worktree)

- `npm run typecheck` — pass
- `npm run build` — pass
- `npm test` — 88 files / 1145 tests pass (includes the panel gate)

Closes #20