### PR TITLE
Polish follow-ups from PR #10 review

### DIFF
--- a/knowledge/component-sets.md
+++ b/knowledge/component-sets.md
@@ -32,14 +32,28 @@ return await ui.componentSet({
 });
 ```
 
-- **Run this behind `--undo-group`.** `ui.componentSet` cleans up its OWN mutations
-  (restores a renamed base, removes the clones it created) if one of ITS OWN later
-  steps throws — that is a narrow, self-scoped safety net, not a substitute for the
-  real undo bracket. If a DIFFERENT step in the same script fails after
-  `ui.componentSet` already returned successfully, `--undo-group` is what rolls the
-  whole script back; without it, a successfully-built set stays on the canvas even
-  if a later line in the same script throws. Always wrap a script that calls this
-  in `exec-js --undo-group` unless you specifically want partial results to survive.
+- **Run this behind `--undo-group`.** `ui.componentSet` cleans up its OWN mutations —
+  and ONLY those — if one of ITS OWN later steps throws (a size mismatch, a name that
+  didn't parse back to the intended axes, `combineAsVariants` itself rejecting the
+  call). Say precisely what that means, because "cleans up" understates it:
+  - **IS restored**: the base's original name (mode 1), and each combined component's
+    original name (mode 2) — whatever `buildModeA`/`buildModeB` renamed gets renamed
+    back. A clone `buildModeA` created for the matrix is removed.
+  - **IS NOT restored**: if `combineAsVariants` already ran before the failure (i.e. the
+    throw came from the post-combine verification, not from `combineAsVariants` itself),
+    the COMPONENT_SET it created stays on the canvas — cleanup renames/removes the
+    build's own nodes, it does not un-combine Figma's structure or delete the set.
+    Concretely: a verify-mismatch after a successful `combineAsVariants` leaves the
+    combined set standing. In mode 1, the base (renamed back to its original name)
+    remains as the set's only child once the clone(s) built for the matrix are removed.
+    In mode 2, every original component stays parented inside the set — each renamed
+    back to its own original name, but the set itself and its full membership persist.
+  - This is a narrow, self-scoped safety net for build's OWN pre-combine mutations, not
+    a substitute for the real undo bracket. If a DIFFERENT step in the same script fails
+    (including this leftover COMPONENT_SET case above), `--undo-group` is what rolls the
+    whole script back; without it, a successfully-built set — or the orphaned one left
+    by a verify-mismatch — stays on the canvas. Always wrap a script that calls this in
+    `exec-js --undo-group` unless you specifically want partial results to survive.
 - **Exactly one of `base`+`axes` or `components`** — both or neither throws, naming the
   two valid shapes.
 - **Axis and value names must not contain `=` or `,`** — Figma parses variant properties

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -2746,10 +2746,7 @@
     if (variantProps && variantProps.length !== ids.length) {
       throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), "E_INVALID_ARGS");
     }
-    const nodes = [];
-    const expected = [];
-    const warnings2 = [];
-    const renamed = [];
+    const resolved = [];
     for (let i = 0; i < ids.length; i++) {
       const node = await figma.getNodeByIdAsync(ids[i]);
       if (!node || node.type !== "COMPONENT") {
@@ -2766,6 +2763,18 @@
           assertCleanToken("property", k);
           assertCleanToken("value", props[k]);
         }
+      }
+      resolved.push(node);
+    }
+    const nodes = [];
+    const expected = [];
+    const warnings2 = [];
+    const renamed = [];
+    for (let i = 0; i < resolved.length; i++) {
+      const node = resolved[i];
+      if (variantProps) {
+        const props = variantProps[i];
+        const keys = Object.keys(props);
         renamed.push({ node, originalName: node.name });
         node.name = comboName(props, keys);
         expected.push({ ...props });
@@ -2839,7 +2848,13 @@
         ...build.warnings.length ? { warnings: build.warnings } : {}
       };
     } catch (err) {
-      build.cleanup();
+      try {
+        build.cleanup();
+      } catch (cleanupErr) {
+        if (err && typeof err === "object") {
+          err.cleanupError = cleanupErr;
+        }
+      }
       throw err;
     }
   }

--- a/plugin/src/main/exec-stdlib-component-build.ts
+++ b/plugin/src/main/exec-stdlib-component-build.ts
@@ -1,5 +1,5 @@
 // Mode-specific node preparation behind `ui.componentSet(...)` — split out of
-// exec-stdlib-component-set.ts to stay under this repo's 200-line cap. Each build
+// exec-stdlib-component-set.ts to keep that file to one shape. Each build
 // function mutates the canvas (renames, clones) and returns a `cleanup()` that
 // reverses EXACTLY those mutations — the caller (componentSet()) invokes it if a
 // LATER step (parent resolution, combineAsVariants, verification) throws, so a
@@ -72,10 +72,12 @@ export async function buildModeB(
   if (variantProps && variantProps.length !== ids.length) {
     throw withCode(new Error(`variantProps length (${variantProps.length}) must match components length (${ids.length})`), 'E_INVALID_ARGS');
   }
-  const nodes: ComponentNode[] = [];
-  const expected: Record<string, string>[] = [];
-  const warnings: string[] = [];
-  const renamed: { node: ComponentNode; originalName: string }[] = [];
+
+  // Pass 1 — resolve and validate EVERY input before mutating anything. A rejection
+  // partway through must never leave an EARLIER component in this same call already
+  // renamed with no closure (stage-4 follow-up, issue #11 item 3: fail before the
+  // first mutation, not validate-then-rename per iteration).
+  const resolved: ComponentNode[] = [];
   for (let i = 0; i < ids.length; i++) {
     const node = await figma.getNodeByIdAsync(ids[i]!);
     if (!node || node.type !== 'COMPONENT') {
@@ -89,7 +91,21 @@ export async function buildModeB(
       const keys = Object.keys(props);
       if (keys.length === 0) throw withCode(new Error(`variantProps[${i}] is empty — needs at least one property`), 'E_INVALID_ARGS');
       for (const k of keys) { assertCleanToken('property', k); assertCleanToken('value', props[k]!); }
-      renamed.push({ node: node as ComponentNode, originalName: node.name });
+    }
+    resolved.push(node as ComponentNode);
+  }
+
+  // Pass 2 — every input is validated; only now do we mutate (rename via variantProps).
+  const nodes: ComponentNode[] = [];
+  const expected: Record<string, string>[] = [];
+  const warnings: string[] = [];
+  const renamed: { node: ComponentNode; originalName: string }[] = [];
+  for (let i = 0; i < resolved.length; i++) {
+    const node = resolved[i]!;
+    if (variantProps) {
+      const props = variantProps[i]!;
+      const keys = Object.keys(props);
+      renamed.push({ node, originalName: node.name });
       node.name = comboName(props, keys);
       expected.push({ ...props });
     } else {
@@ -104,7 +120,7 @@ export async function buildModeB(
         expected.push(parseComboName(node.name));
       }
     }
-    nodes.push(node as ComponentNode);
+    nodes.push(node);
   }
   return {
     nodes, expected, warnings,

--- a/plugin/src/main/exec-stdlib-component-matrix.ts
+++ b/plugin/src/main/exec-stdlib-component-matrix.ts
@@ -1,6 +1,6 @@
 // Pure helpers behind `ui.componentSet(...)` (exec-stdlib-component-set.ts) — split out
-// so that file stays under the repo's 200-line cap (the same split-by-shape convention
-// as exec-stdlib-instance.ts). No `figma` global here, so these are unit-testable without
+// so that file stays focused on one shape (the same split-by-shape convention as
+// exec-stdlib-instance.ts). No `figma` global here, so these are unit-testable without
 // a live plugin or a mock — the cartesian-order determinism and the `=`/`,` rejection
 // are asserted directly against these functions.
 import { withCode } from './executor-styles';

--- a/plugin/src/main/exec-stdlib-component-set.ts
+++ b/plugin/src/main/exec-stdlib-component-set.ts
@@ -113,7 +113,18 @@ async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult>
       ...(build.warnings.length ? { warnings: build.warnings } : {}),
     };
   } catch (err) {
-    build.cleanup();
+    // The ORIGINAL error is what the caller must see, always — cleanup() runs on a
+    // best-effort basis over live Figma state (removing a clone, restoring a name),
+    // and can itself throw (a locked node, a clone something else already removed).
+    // A throwing cleanup must never replace the failure that triggered it (stage-4
+    // follow-up, issue #11 item 1); it is appended for visibility, never swapped in.
+    try {
+      build.cleanup();
+    } catch (cleanupErr) {
+      if (err && typeof err === 'object') {
+        (err as { cleanupError?: unknown }).cleanupError = cleanupErr;
+      }
+    }
     throw err;
   }
 }

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "5fa2199" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "2b1fac5" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/tests/exec-stdlib-component-set.test.ts
+++ b/tests/exec-stdlib-component-set.test.ts
@@ -3,7 +3,7 @@
 // throw, bad-input throws, cartesian-order determinism, `=`/`,` rejection, and the
 // over-cap rejection (plan §8 Definition of Done).
 import { describe, it, expect } from 'vitest';
-import { installMockFigma, setMockComponents, type FakeNode } from './helpers/mock-figma.ts';
+import { installMockFigma, setMockComponents, FakeNode } from './helpers/mock-figma.ts';
 import { createExecStdlibComponentSet } from '../plugin/src/main/exec-stdlib-component-set.ts';
 import {
   cartesianProduct, comboName, assertCleanToken, parseComboName, sameAxisMap,
@@ -146,6 +146,33 @@ describe('componentSet — mode 1 (base + axes)', () => {
     expect(frame.children).toEqual([base]);
   });
 
+  it('surfaces the ORIGINAL error even when cleanup() itself throws — a throwing cleanup must never mask the failure that triggered it (issue #11 item 1)', async () => {
+    const figma = installMockFigma();
+    const base = makeComponent('Base');
+    setMockComponents([base]);
+    const originalCombine = figma.combineAsVariants.bind(figma);
+    // Force the same E_EVAL verify-mismatch as the test above...
+    figma.combineAsVariants = ((nodes: FakeNode[], parent: FakeNode) => {
+      const set = originalCombine(nodes, parent);
+      set.children = set.children.slice(0, 1);
+      return set;
+    }) as typeof figma.combineAsVariants;
+
+    // ...but ALSO make the helper's own cleanup() throw (a real Figma failure mode:
+    // a locked node, a clone already removed by something else, etc). The original
+    // E_EVAL must still be what the caller sees — never the cleanup failure.
+    const originalRemove = FakeNode.prototype.remove;
+    FakeNode.prototype.remove = function throwingRemove(): never {
+      throw new Error('cleanup boom: node cannot be removed');
+    };
+    try {
+      await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['default', 'hover'] } }))
+        .rejects.toMatchObject({ code: 'E_EVAL', message: expect.stringContaining('componentSet combined') });
+    } finally {
+      FakeNode.prototype.remove = originalRemove;
+    }
+  });
+
   it('rejects a parent that cannot sensibly hold a component set (a COMPONENT, not PAGE/FRAME/SECTION/GROUP)', async () => {
     installMockFigma();
     const base = makeComponent('Base');
@@ -199,6 +226,23 @@ describe('componentSet — mode 2 (combine existing components)', () => {
     setMockComponents([a]);
     await expect(createExecStdlibComponentSet().componentSet({ components: [a.id], variantProps: [] }))
       .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('validates ALL inputs before renaming ANY of them — a later validation failure must not leave an earlier component renamed with no closure (issue #11 item 3)', async () => {
+    installMockFigma();
+    const a = makeComponent('CompA');
+    const b = makeComponent('CompB');
+    setMockComponents([a, b]);
+
+    // component[0]'s variantProps are valid; component[1]'s carry a banned token.
+    // fail-before-mutate means neither rename happens — not "the first one, then throw".
+    await expect(createExecStdlibComponentSet().componentSet({
+      components: [a.id, b.id],
+      variantProps: [{ State: 'default' }, { 'Sta=te': 'hover' }],
+    })).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+
+    expect(a.name).toBe('CompA');
+    expect(b.name).toBe('CompB');
   });
 
   it('restores each component\'s original name when a later step throws — mode 2\'s own rollback', async () => {


### PR DESCRIPTION
## Summary

Four non-blocking polish items from PR #10's stage-4 re-review (issue #11):

1. **cleanup() masking the original error** — `componentSet()`'s catch block called
   `build.cleanup()` unguarded; if cleanup itself threw (a locked node, a clone already
   removed elsewhere), that new error replaced the original failure the caller was
   trying to see. Now wrapped: a cleanup failure is attached (`cleanupError`), never
   substituted — the original error's code and message always propagate.
2. **`knowledge/component-sets.md` over-stated restoration** — reworded to say exactly
   what cleanup restores (build's own renames/clones) and what it doesn't (a
   verify-mismatch after a successful `combineAsVariants` leaves the combined
   COMPONENT_SET standing on the canvas, not un-combined).
3. **`buildModeB` renamed as it validated** — a mid-loop rejection could leave earlier
   components already renamed with no cleanup, since the failure happened before a
   `BuildResult` (and its `cleanup()`) even existed. Split into two passes: validate
   every input fully, then rename.
4. **"200-line cap" citation with no repo doc backing it** — dropped from the two
   PR #10 headers (`exec-stdlib-component-build.ts`, `exec-stdlib-component-matrix.ts`).
   No doc in this repo states the convention, and it isn't enforced (a sibling stdlib
   file already runs over it, uncited).

Closes #11.

## Test plan

- Both code fixes (items 1 and 3) are test-first: added tests reproduce the bug and
  fail against pre-fix code, then pass after the fix (verified locally).
- `npm run typecheck` — clean
- `npm run build` — clean (regenerated `plugin/code.js` / `plugin/ui.html`, committed
  build outputs per this repo's convention)
- `npm test` — 88 test files, 1146 tests, all green (includes the panel gate against
  the pinned `kernel/design-os` submodule)