### PR TITLE
feat: shared safeCleanup() helper, close cleanup-masking class

### DIFF
--- a/cli/src/transport/broker-discovery.ts
+++ b/cli/src/transport/broker-discovery.ts
@@ -16,6 +16,7 @@ import {
   type BrokerAdvertisement,
 } from '../../../shared/protocol.ts';
 import { CliError, envMs } from './protocol-helpers.ts';
+import { safeCleanup } from '../../../shared/safe-cleanup.ts';
 
 // Mirrors broker-daemon.ts's own `HEARTBEAT_MS` override (same env var, same
 // fallback) — see envMs's doc for why this must be the ONE shared reader, not a
@@ -105,8 +106,10 @@ function writeFileAtomic(path: string, contents: string): void {
     writeFileSync(tmpPath, contents);
     renameSync(tmpPath, path);
   } catch (err) {
-    try { unlinkSync(tmpPath); } catch { /* best-effort */ }
-    throw err;
+    // Best-effort temp-file removal on failure (issue #24: routed through the
+    // shared `safeCleanup` so the original write/rename error always propagates,
+    // never masked by an unlink failure).
+    safeCleanup(err, () => unlinkSync(tmpPath));
   }
 }
 

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -2813,6 +2813,28 @@
     };
   }
 
+  // shared/safe-cleanup.ts
+  function safeCleanup(originalError, cleanupFn) {
+    try {
+      cleanupFn();
+    } catch (cleanupError) {
+      attachCleanupError(originalError, cleanupError);
+    }
+    throw originalError;
+  }
+  function attachCleanupError(originalError, cleanupError) {
+    const canAttach = originalError !== null && typeof originalError === "object" && Object.isExtensible(originalError);
+    if (!canAttach) {
+      console.error("safeCleanup: cleanup failed and originalError is not extensible, logging instead of attaching:", cleanupError);
+      return;
+    }
+    try {
+      originalError.cleanupError = cleanupError;
+    } catch (attachError) {
+      console.error("safeCleanup: failed to attach cleanupError despite isExtensible check:", cleanupError, attachError);
+    }
+  }
+
   // plugin/src/main/exec-stdlib-component-set.ts
   var VALID_PARENT_TYPES = /* @__PURE__ */ new Set(["PAGE", "FRAME", "SECTION", "GROUP"]);
   async function resolveParent(ref) {
@@ -2863,14 +2885,7 @@
         ...build.warnings.length ? { warnings: build.warnings } : {}
       };
     } catch (err) {
-      try {
-        build.cleanup();
-      } catch (cleanupErr) {
-        if (err && typeof err === "object") {
-          err.cleanupError = cleanupErr;
-        }
-      }
-      throw err;
+      safeCleanup(err, () => build.cleanup());
     }
   }
   function createExecStdlibComponentSet() {

--- a/plugin/src/main/exec-stdlib-component-set.ts
+++ b/plugin/src/main/exec-stdlib-component-set.ts
@@ -14,6 +14,7 @@
 import { withCode } from './executor-styles';
 import { WARN_ABOVE, parseComboName, sameAxisMap } from './exec-stdlib-component-matrix';
 import { buildModeA, buildModeB } from './exec-stdlib-component-build';
+import { safeCleanup } from '../../../shared/safe-cleanup';
 
 export interface ComponentSetOpts {
   base?: string;
@@ -117,15 +118,9 @@ async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult>
     // best-effort basis over live Figma state (removing a clone, restoring a name),
     // and can itself throw (a locked node, a clone something else already removed).
     // A throwing cleanup must never replace the failure that triggered it (stage-4
-    // follow-up, issue #11 item 1); it is appended for visibility, never swapped in.
-    try {
-      build.cleanup();
-    } catch (cleanupErr) {
-      if (err && typeof err === 'object') {
-        (err as { cleanupError?: unknown }).cleanupError = cleanupErr;
-      }
-    }
-    throw err;
+    // follow-up, issue #11 item 1); centralized in `safeCleanup` (issue #24) so this
+    // guarantee lives in one place instead of being re-derived per call site.
+    safeCleanup(err, () => build.cleanup());
   }
 }
 

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "b6831cc" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "db3c452" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/shared/safe-cleanup.ts
+++ b/shared/safe-cleanup.ts
@@ -1,0 +1,51 @@
+// Shared helper closing the "a throwing cleanup() masks the original error" class
+// (issue #24). That bug was found and fixed independently four times — PR #12
+// (broker-discovery.ts's `writeFileAtomic`), PR #13 stage-4 (`addSlotProperty`'s
+// rollback, exec-stdlib-slot-property.ts), and PR #23 stage-4
+// (`componentSet`'s cleanup, exec-stdlib-component-set.ts) are the confirmed
+// sites — each correct on its own, each a local copy of the same pattern.
+//
+// Contract: run `cleanupFn` in its own try. If it throws, attach the cleanup
+// failure to `originalError` as `.cleanupError` — WITHOUT substituting — then
+// throw `originalError` unchanged (code + message byte-preserved). If cleanup
+// does not throw, `originalError` is thrown untouched.
+//
+// Airtight edge (PR #23 stage-4 review): `originalError` may be frozen or
+// otherwise non-extensible (e.g. Object.freeze'd, or a proxy that forbids new
+// properties). Assigning `.cleanupError` on such an object throws a TypeError
+// in strict-mode ESM, which would itself replace the original error — exactly
+// the bug this helper exists to prevent. The attachment is therefore guarded by
+// `Object.isExtensible` AND wrapped in its own try; if it cannot be attached,
+// the cleanup failure is only logged (never dropped silently, never allowed to
+// re-mask), and the original error still propagates unchanged.
+export function safeCleanup(originalError: unknown, cleanupFn: () => void): never {
+  try {
+    cleanupFn();
+  } catch (cleanupError) {
+    attachCleanupError(originalError, cleanupError);
+  }
+  throw originalError;
+}
+
+/** Attach `cleanupError` to `originalError` as `.cleanupError` when it is safe to do
+ *  so, otherwise log it — never lets the attachment itself throw and never drops
+ *  the cleanup failure on the floor. */
+function attachCleanupError(originalError: unknown, cleanupError: unknown): void {
+  const canAttach = originalError !== null
+    && typeof originalError === 'object'
+    && Object.isExtensible(originalError);
+  if (!canAttach) {
+    // eslint-disable-next-line no-console -- last-resort visibility; there is no
+    // other channel once the target refuses the property.
+    console.error('safeCleanup: cleanup failed and originalError is not extensible, logging instead of attaching:', cleanupError);
+    return;
+  }
+  try {
+    (originalError as { cleanupError?: unknown }).cleanupError = cleanupError;
+  } catch (attachError) {
+    // Belt-and-suspenders: isExtensible said yes but the assignment still threw
+    // (a setter, a Proxy trap, a frozen prototype chain quirk) — log both rather
+    // than let this throw and mask originalError.
+    console.error('safeCleanup: failed to attach cleanupError despite isExtensible check:', cleanupError, attachError);
+  }
+}

--- a/tests/safe-cleanup.test.ts
+++ b/tests/safe-cleanup.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { safeCleanup } from '../shared/safe-cleanup';
+
+describe('safeCleanup', () => {
+  it('rethrows the original error unchanged when cleanup succeeds', () => {
+    const original = new Error('original failure');
+    const cleanup = vi.fn();
+    expect(() => safeCleanup(original, cleanup)).toThrow(original);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect((original as Error & { cleanupError?: unknown }).cleanupError).toBeUndefined();
+  });
+
+  it('surfaces the original error, with the cleanup failure attached, when cleanup throws', () => {
+    const original = new Error('original failure');
+    const cleanupError = new Error('cleanup failure');
+    let thrown: unknown;
+    try {
+      safeCleanup(original, () => { throw cleanupError; });
+    } catch (err) {
+      thrown = err;
+    }
+    // The ORIGINAL error propagates — never substituted by the cleanup failure.
+    expect(thrown).toBe(original);
+    expect((thrown as Error).message).toBe('original failure');
+    expect((thrown as Error & { cleanupError?: unknown }).cleanupError).toBe(cleanupError);
+  });
+
+  it('preserves a custom error subclass\'s code and message byte-for-byte', () => {
+    class CliError extends Error {
+      constructor(readonly code: string, message: string) {
+        super(message);
+      }
+    }
+    const original = new CliError('E_EVAL', 'exact message must survive');
+    try {
+      safeCleanup(original, () => { throw new Error('cleanup boom'); });
+      throw new Error('safeCleanup did not throw');
+    } catch (err) {
+      expect(err).toBe(original);
+      expect((err as CliError).code).toBe('E_EVAL');
+      expect((err as CliError).message).toBe('exact message must survive');
+    }
+  });
+
+  // The airtight case PR #23's reviewer flagged: a frozen/non-extensible
+  // originalError. A naive `err.cleanupError = cleanupErr` assignment throws a
+  // TypeError in strict mode against a frozen object — which would itself
+  // replace the original error and re-mask it. This test fails against that
+  // naive implementation and passes only when the attachment is guarded.
+  it('does not re-mask when originalError is frozen (non-extensible)', () => {
+    const original = Object.freeze(new Error('frozen original failure'));
+    const cleanupError = new Error('cleanup failure');
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      let thrown: unknown;
+      try {
+        safeCleanup(original, () => { throw cleanupError; });
+      } catch (err) {
+        thrown = err;
+      }
+      // The un-masking guarantee must never itself throw: the frozen original
+      // error propagates unchanged, not a TypeError from the attempted assignment.
+      expect(thrown).toBe(original);
+      expect((thrown as Error).message).toBe('frozen original failure');
+      expect((thrown as Error).constructor).toBe(Error);
+      // Since attachment onto a frozen object is impossible, the cleanup failure
+      // must be surfaced some other way (logging) rather than silently dropped.
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+
+  it('does not call cleanupFn\'s throw path when cleanup does not throw, even for a frozen originalError', () => {
+    const original = Object.freeze(new Error('frozen but fine'));
+    const cleanup = vi.fn();
+    let thrown: unknown;
+    try {
+      safeCleanup(original, cleanup);
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBe(original);
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #24: the "a throwing cleanup() masks the original error" class has been found and independently fixed four times (PR #12, #13, #19-adjacent, #23). This adds one shared `safeCleanup(originalError, cleanupFn)` helper in `shared/safe-cleanup.ts` so the guarantee lives in one place.
- Contract: run `cleanupFn()` in its own try; if it throws, attach the failure to `originalError` as `.cleanupError` without substituting, then rethrow the original error unchanged (code + message byte-preserved).
- Airtight against the frozen/non-extensible `originalError` edge flagged by PR #23's reviewer: the `.cleanupError` attachment is guarded by `Object.isExtensible` plus its own try, so the un-masking guarantee can never itself throw and re-mask. When attachment isn't possible, the cleanup failure is logged instead of dropped.

## Sites routed through the helper
- `plugin/src/main/exec-stdlib-component-set.ts` — `componentSet`'s cleanup (was PR #23's local fix; contract matched exactly).
- `cli/src/transport/broker-discovery.ts` — `writeFileAtomic`'s temp-file cleanup (PR #12's site; same try-cleanup-rethrow shape).

## Site NOT routed (with reason)
- `plugin/src/main/exec-stdlib-slot-property.ts`'s `addProperty` rollback (PR #13) is intentionally left alone. Its locked behavior — asserted by `tests/exec-stdlib-slot.test.ts` ("names the leftover property in the error when the rollback deletion itself fails") — throws a **new** `Error` whose message concatenates the original failure and the rollback failure (`"...not linked to...additionally...cleanup...deletion refused"`). That is a different contract from `safeCleanup`'s byte-preserved rethrow-with-attached-property, and forcing it through the helper would either break that test or require bolting extra message-building logic onto the call site, defeating the point of centralizing. Flagged rather than forced.
- Could not find an independent "PR #19-adjacent" cleanup-masking site in the current tree — the nearby fix from that window (`1bca6ca`, legacy-migration-defers-on-failure in `broker-daemon.ts`) is a different pattern (swallows and never rethrows, doesn't mask an original error), so it isn't a `safeCleanup` candidate.

## Tests
- New `tests/safe-cleanup.test.ts`: throwing cleanup surfaces the original error unchanged with `.cleanupError` attached; non-throwing cleanup is fully transparent; a custom error subclass's `code`/`message` survive byte-for-byte; the airtight frozen-`originalError` case (verified to fail against a naive assignment-without-guard implementation, restored after confirming); a frozen `originalError` with a non-throwing cleanup stays untouched.
- All existing tests for the two routed sites remain green, unmodified.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (97 files / 1228 tests, includes the panel gate against the pinned `kernel/design-os` submodule)