### PR TITLE
chore: drop the unstated "200-line cap" citation from stdlib headers

### DIFF
--- a/plugin/src/main/exec-js-normalize.ts
+++ b/plugin/src/main/exec-js-normalize.ts
@@ -1,5 +1,5 @@
-// Pure EXEC_JS script normalization — split out of executor-exec-js.ts to stay under the
-// repo's 200-line module cap. No `figma` global access:
+// Pure EXEC_JS script normalization — split out of executor-exec-js.ts so the pure,
+// sandbox-free logic reads on its own. No `figma` global access:
 // expression-vs-statement compilation, node-ish result summarization, and the empty/null/
 // undefined result classification are all pure functions of their input, so a plain import
 // works without a Figma sandbox (the exec-js-normalize.test.ts suite relies on exactly this).

--- a/plugin/src/main/exec-stdlib-figjam-table.ts
+++ b/plugin/src/main/exec-stdlib-figjam-table.ts
@@ -1,6 +1,6 @@
 // `ui.figjam.table` / `ui.figjam.codeBlock` — split out of exec-stdlib-figjam-content.ts
-// to stay under the 200-line cap (absorption phase-03). Adapted from the fork's
-// handlers (MIT; see THIRD-PARTY.md), code.js:6275-6317.
+// so table/code-block handling reads as its own surface (absorption phase-03). Adapted
+// from the fork's handlers (MIT; see THIRD-PARTY.md), code.js:6275-6317.
 import { requireEditor } from './exec-stdlib-editor';
 import { withCode } from './executor-styles';
 import { MAX_TABLE_ROWS, MAX_TABLE_COLUMNS, MAX_CODE_BLOCK_CHARS } from './exec-stdlib-figjam-types';

--- a/plugin/src/main/exec-stdlib-figjam.ts
+++ b/plugin/src/main/exec-stdlib-figjam.ts
@@ -1,7 +1,7 @@
 // `ui.figjam.*` — FigJam capabilities (absorption phase-03). Adapted from the fork's
 // FigJam handlers (MIT; see THIRD-PARTY.md), code.js:5970-6524, figjam-tools.ts:8-59.
-// Split across four files (this one plus -types/-content/-arrange/-read) to stay
-// under the 200-line cap — the same split-by-shape precedent as exec-stdlib-slot.ts.
+// Split across four files (this one plus -types/-content/-arrange/-read) so each
+// concern reads on its own — the same split-by-shape precedent as exec-stdlib-slot.ts.
 import { sticky, stickies, connector, shape, section } from './exec-stdlib-figjam-content';
 import { table, codeBlock } from './exec-stdlib-figjam-table';
 import { arrange } from './exec-stdlib-figjam-arrange';

--- a/plugin/src/main/exec-stdlib-instance.ts
+++ b/plugin/src/main/exec-stdlib-instance.ts
@@ -1,5 +1,5 @@
-// INSTANCE-shaped ui.* helpers, split out of exec-stdlib.ts to stay under the repo's
-// 200-line module cap (backlog 3.1/3.2). Reuse, do not re-implement: component-ref
+// INSTANCE-shaped ui.* helpers, split out of exec-stdlib.ts so INSTANCE-specific logic
+// reads as its own surface (backlog 3.1/3.2). Reuse, do not re-implement: component-ref
 // resolution goes through resolveMainComponent (resolve-main-component.ts:1-10) — a
 // second copy of ref-resolution here would be the mistake that module exists to avoid.
 import { resolveMainComponent } from './resolve-main-component';

--- a/plugin/src/main/exec-stdlib-slides.ts
+++ b/plugin/src/main/exec-stdlib-slides.ts
@@ -1,8 +1,8 @@
 // `ui.slides.*` — Figma Slides capabilities (absorption phase-04, the last phase of
 // the capability-absorption track). Adapted from the fork's Slides handlers (MIT;
 // see THIRD-PARTY.md), code.js:6530-7220, slides-tools.ts:8-63. Split across four
-// files (this one plus -types/-resolve/-crud/-view/-content) to stay under the
-// 200-line cap — same split-by-shape precedent as exec-stdlib-figjam.ts.
+// files (this one plus -types/-resolve/-crud/-view/-content) so each concern reads on
+// its own — same split-by-shape precedent as exec-stdlib-figjam.ts.
 import { list, grid, create, remove, duplicate, reorder } from './exec-stdlib-slides-crud';
 import { setTransition, transition, viewMode, focused, focus, skip } from './exec-stdlib-slides-view';
 import { background, addText, addShape, content } from './exec-stdlib-slides-content';

--- a/plugin/src/main/exec-stdlib-slot.ts
+++ b/plugin/src/main/exec-stdlib-slot.ts
@@ -3,9 +3,9 @@
 // code.js:409-486 (list/target resolution). `addProperty`'s merge pattern is adapted
 // from slot-tools.ts:291-377.
 //
-// Split across four files (this one plus -types/-resolve/-content/-property) to stay
-// under the 200-line cap once verification + the fork's absorbed refusals were all
-// written out — the same split-by-shape convention as exec-stdlib-instance.ts.
+// Split across four files (this one plus -types/-resolve/-content/-property) once
+// verification + the fork's absorbed refusals were all written out, so each concern
+// reads on its own — the same split-by-shape convention as exec-stdlib-instance.ts.
 //
 // Absorbed facts THIS file enforces (phase-02 spec §5; append/reset's facts are
 // documented in exec-stdlib-slot-content.ts):

--- a/plugin/src/main/exec-stdlib.ts
+++ b/plugin/src/main/exec-stdlib.ts
@@ -7,7 +7,7 @@
 // because a second copy of ref-resolution was the mistake to avoid): variable-name resolution
 // goes through resolveVariable, field binding through bindVariableToField, node serialization
 // through serializeNode/jsonSafe. setProps/swapInstance (INSTANCE-shaped) live in
-// exec-stdlib-instance.ts — this file crossed the repo's 200-line cap with them inline.
+// exec-stdlib-instance.ts — split out by shape so INSTANCE-specific logic isn't inlined here.
 import { resolveVariable, bindVariableToField } from './executor-variables';
 import {
   serializeNode, jsonSafe, SERIALIZED_NODE_FIELDS, type SerializedNode,
@@ -16,9 +16,9 @@ import { withCode } from './executor-styles';
 import { readBindings } from './scan-node-utils';
 import { resolvePropKey, setProps, swapInstance } from './exec-stdlib-instance';
 // Absorption phase-01 (Basket B): variable/mode CRUD and variant-matrix component-set
-// helpers, each its own split file for the same 200-line-cap reason as
+// helpers, each its own split file for the same split-by-shape reason as
 // exec-stdlib-instance.ts — `vars` and `componentSet` are namespaced sub-objects, not
-// inlined here, so this file's own cap never has to make room for them.
+// inlined here, so this file stays focused on its own surface.
 import { createExecStdlibVars, type ExecStdlibVars } from './exec-stdlib-variables';
 import { createExecStdlibComponentSet, type ComponentSetOpts, type ComponentSetResult } from './exec-stdlib-component-set';
 // Absorption phase-02: Slots + annotations, same namespaced-sub-object pattern.


### PR DESCRIPTION
## Summary
Several `plugin/src/main/exec-stdlib*.ts` and `exec-js-normalize.ts` header comments cited a "200-line module cap" as the reason a file was split — that's not a rule stated anywhere in this repo, just an invented framing that crept into the comments. This PR rewrites those 8 citations across 7 files to state the real, true reason: these files were split by shape/concern, so each surface (INSTANCE-shaped helpers, FigJam, Slides, Slots, etc.) reads on its own. No numeric line count or "cap" language remains. Sibling cross-references ("same split-by-shape precedent as exec-stdlib-figjam.ts") are preserved.

Comment-only change — no code, imports, or exports touched.

## Files changed
- `plugin/src/main/exec-stdlib.ts` (2 citations)
- `plugin/src/main/exec-stdlib-slides.ts`
- `plugin/src/main/exec-stdlib-slot.ts`
- `plugin/src/main/exec-stdlib-instance.ts`
- `plugin/src/main/exec-stdlib-figjam.ts`
- `plugin/src/main/exec-stdlib-figjam-table.ts`
- `plugin/src/main/exec-js-normalize.ts`

## Test plan
- [x] `npm run typecheck` — passes clean (tsc -p cli --noEmit && tsc -p plugin --noEmit, no output/errors)
- [x] `npm run build` — passes (`cli/dist/figma-agent.js 239.2kb`, `plugin/code.js 188.6kb`, both built without error)
- [ ] `npm test` intentionally skipped for this change — comments-only diff, and the broker-daemon test harness would disturb an active local plugin session's broker discovery