### PR TITLE
Add --instance <id> exact-target routing flag

### DIFF
--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -5,7 +5,7 @@ import { resolve } from 'node:path';
 import { runBrokerDaemon } from './transport/broker-daemon.ts';
 import { parseArgs, type CommandArgs } from './arg-parse.ts';
 import { CliError } from './transport/protocol-helpers.ts';
-import { getLastFileContext, setExpectedFile, setProjectDir, setReadOnly } from './transport/broker-client.ts';
+import { getLastFileContext, setExpectedFile, setExpectedInstance, setProjectDir, setReadOnly } from './transport/broker-client.ts';
 import { printErrorJson, printJson, withFileContext } from './util/json-out.ts';
 import * as batch from './commands/batch.ts';
 import * as changes from './commands/changes.ts';
@@ -120,6 +120,12 @@ Commands:
 Global: --file "<exact file name>"   route to that file's plugin AND refuse to run anywhere else
                                      (exact, case-insensitive; beats FIGMA_AGENT_FILE; payloads
                                       >512KB route by the env pin but are still guarded)
+        --instance <instanceId>     route to that EXACT plugin instance (from \`status\`'s
+                                     instanceId column) — beats --file and FIGMA_AGENT_FILE; the
+                                     one way to target a specific instance when --file's name is
+                                     ambiguous (e.g. two unsaved files both named "Untitled").
+                                     Mutually exclusive with --file: passing both refuses with
+                                     E_INVALID_ARGS naming both, it never silently picks one.
         --dir <projectDir>          this invocation's project root (default: cwd); stamped on
                                      every request so panel/idle sync can apply into the right
                                      project once bound (\`figma-agent bind\`) — never a guess
@@ -152,7 +158,24 @@ async function main(): Promise<void> {
   if (args.bool('file') && (args.str('file') ?? '').trim() === '') {
     printErrorJson(new CliError('E_INVALID_ARGS', '--file needs a file name, e.g. --file "VSF - PCP"'));
   }
+  // Same empty-value guard as --file, for the same reason: a typo'd --instance with no value
+  // must never fall through to "unrestricted routing".
+  if (args.bool('instance') && (args.str('instance') ?? '').trim() === '') {
+    printErrorJson(new CliError('E_INVALID_ARGS', '--instance needs an instanceId, e.g. --instance p_3_1712345678'));
+  }
+  const fileFlag = (args.str('file') ?? '').trim();
+  const instanceFlag = (args.str('instance') ?? '').trim();
+  // Mutual exclusion at the CLI boundary (spec 260801-1050): both set is refused outright,
+  // never silently resolved to one — resolveRouteFilter's own instance-beats-file precedence
+  // exists for env/recency fallback, not for a caller contradicting itself in one request.
+  if (fileFlag !== '' && instanceFlag !== '') {
+    printErrorJson(new CliError(
+      'E_INVALID_ARGS',
+      `--instance "${instanceFlag}" and --file "${fileFlag}" are mutually exclusive on one request — drop one`,
+    ));
+  }
   setExpectedFile(args.str('file'));   // global flag — verified: no command reads --file today
+  setExpectedInstance(args.str('instance')); // global flag, same choke point as --file
   setProjectDir(resolve(args.str('dir') ?? process.cwd())); // registry-integrity phase 01 §1
   setReadOnly(args.bool('read-only')); // concurrency & jobs (backlog 1.1+2.6+4.3) — TRUSTED, not enforced
   try {

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -165,7 +165,7 @@ async function main(): Promise<void> {
   }
   const fileFlag = (args.str('file') ?? '').trim();
   const instanceFlag = (args.str('instance') ?? '').trim();
-  // Mutual exclusion at the CLI boundary (spec 260801-1050): both set is refused outright,
+  // Mutual exclusion at the CLI boundary: both set is refused outright,
   // never silently resolved to one — resolveRouteFilter's own instance-beats-file precedence
   // exists for env/recency fallback, not for a caller contradicting itself in one request.
   if (fileFlag !== '' && instanceFlag !== '') {

--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -42,12 +42,21 @@ function sleep(ms: number): Promise<void> {
 let requestCounter = 0;
 
 let expectedFile: string | undefined;
+let expectedInstance: string | undefined;
 let lastFileContext: FileContext | undefined;
 let projectDir: string | undefined;
 let readOnlyGlobal = false;
 
 /** Set once per CLI invocation from the global --file flag; stamped on every request envelope. */
 export function setExpectedFile(name: string | undefined): void { expectedFile = name; }
+
+/**
+ * Set once per CLI invocation from the global `--instance` flag (spec 260801-1050); stamped on
+ * every request envelope the SAME choke point `setExpectedFile` uses. Mutual exclusion with
+ * `--file` is enforced at the CLI boundary before either setter runs, so the two are never both
+ * non-empty here.
+ */
+export function setExpectedInstance(id: string | undefined): void { expectedInstance = id; }
 export function getLastFileContext(): FileContext | undefined { return lastFileContext; }
 
 /**
@@ -178,7 +187,7 @@ export function exchange(
     ws.on('error', (err) => finish(() => reject(new CliError('E_NO_BROKER', `broker socket error: ${err.message}`))));
 
     try {
-      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity, expectedFile, projectDir, readOnly));
+      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity, expectedFile, projectDir, readOnly, expectedInstance));
     } catch (err) {
       finish(() => reject(new CliError('E_NO_BROKER', `failed to send request: ${(err as Error).message}`)));
     }

--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -51,7 +51,7 @@ let readOnlyGlobal = false;
 export function setExpectedFile(name: string | undefined): void { expectedFile = name; }
 
 /**
- * Set once per CLI invocation from the global `--instance` flag (spec 260801-1050); stamped on
+ * Set once per CLI invocation from the global `--instance` flag; stamped on
  * every request envelope the SAME choke point `setExpectedFile` uses. Mutual exclusion with
  * `--file` is enforced at the CLI boundary before either setter runs, so the two are never both
  * non-empty here.

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -728,27 +728,31 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    */
   const admitRequest = (
     from: WebSocket, id: string, rawText: string, cmd?: string, expectedFile?: string,
-    readOnly = false, projectDir?: string, activity?: string,
+    expectedInstance?: string, readOnly = false, projectDir?: string, activity?: string,
   ): void => {
-    const filter = resolveRouteFilter(expectedFile, currentFilter());
+    const filter = resolveRouteFilter(expectedFile, currentFilter(), expectedInstance);
     let targetWs = st.dispatchedTo.get(id);
     if (targetWs && targetWs.readyState !== WebSocket.OPEN) targetWs = undefined;
     if (!targetWs) {
-      const hits = st.registry.matching(filter.value, { exact: filter.exact });
+      const hits = st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind });
       // An explicit --file that matches two open files is AMBIGUOUS: same-named files are
       // indistinguishable here (fileKey is null for a non-org plugin), and guessing by recency
-      // is how a command lands in the file the caller did not name.
+      // is how a command lands in the file the caller did not name. (--instance can never hit
+      // this branch: kind:'instance' matches 0 or 1 entries by construction.)
       if (filter.source === 'flag' && hits.length > 1) {
         const ids = hits.map((e) => `${e.scene.fileName ?? '(unnamed)'}#${e.instanceId}`).join(', ');
         sendReplyErr(from, id, 'E_INVALID_ARGS',
-          `--file "${filter.value}" matches ${hits.length} connected files [${ids}] — close one panel, or rename the files apart`);
+          `--file "${filter.value}" matches ${hits.length} connected files [${ids}] — close one panel, rename the files apart, ` +
+          `or target one exactly with --instance <id> (e.g. --instance ${hits[0].instanceId})`);
         return;
       }
       const target = hits[0] ?? null;
       targetWs = target?.ws;
       // A plugin that predates the guard would ignore expectedFile and run anyway; refuse BEFORE
-      // forwarding rather than discovering it from a reply that has already mutated a file.
-      if (filter.source === 'flag' && target && !pluginSupportsFileGuard(target)) {
+      // forwarding rather than discovering it from a reply that has already mutated a file. Only
+      // meaningful for kind:'name' — `--instance` targets a specific socket directly and carries
+      // no filename guard to predate.
+      if (filter.source === 'flag' && filter.kind === 'name' && target && !pluginSupportsFileGuard(target)) {
         sendReplyErr(from, id, 'E_PLUGIN_STALE',
           `the plugin open in "${target.scene.fileName ?? '?'}" predates --file support — rebuild (npm run build) and reopen the panel`);
         return;
@@ -872,7 +876,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       sendReplyErr(from, id, 'E_CHUNK_LOST', `failed to reassemble chunked request: ${(err as Error).message}`);
       return;
     }
-    admitRequest(from, id, JSON.stringify(assembled), assembled.cmd, assembled.expectedFile, assembled.readOnly === true, assembled.projectDir, assembled.activity);
+    admitRequest(
+      from, id, JSON.stringify(assembled), assembled.cmd, assembled.expectedFile, assembled.expectedInstance,
+      assembled.readOnly === true, assembled.projectDir, assembled.activity,
+    );
   };
 
   // A plugin (re)registered → try to flush parked requests. Only admit a request once a
@@ -889,10 +896,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     let delivered = 0;
     for (const req of queued) {
       if (req.from.readyState !== WebSocket.OPEN) continue; // CLI gone — drop silently
-      if (st.registry.selectTarget(req.filter.value, { exact: req.filter.exact })) {
+      if (st.registry.selectTarget(req.filter.value, { exact: req.filter.exact, kind: req.filter.kind })) {
+        const flagValue = req.filter.source === 'flag' ? req.filter.value ?? undefined : undefined;
         admitRequest(
           req.from, req.id, req.rawText, req.cmd,
-          req.filter.source === 'flag' ? req.filter.value ?? undefined : undefined,
+          req.filter.kind === 'name' ? flagValue : undefined,
+          req.filter.kind === 'instance' ? flagValue : undefined,
           req.readOnly === true, req.projectDir, req.activity,
         );
         delivered++;
@@ -1200,7 +1209,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       else if (msg.cmd === 'JOB') handleJobCommand(ws, msg);
       // Envelope-only: cmd + readOnly decide queueing. params are never parsed — the
       // pure-relay rule (concurrency & jobs, backlog 1.1+2.6+4.3).
-      else admitRequest(ws, msg.id, text, msg.cmd, msg.expectedFile, msg.readOnly === true, msg.projectDir, msg.activity);
+      else admitRequest(ws, msg.id, text, msg.cmd, msg.expectedFile, msg.expectedInstance, msg.readOnly === true, msg.projectDir, msg.activity);
     } else if (isEventMsg(msg)) {
       if (msg.type === 'PLUGIN_HELLO') {
         // Multi-plugin: register this instance in its OWN slot — never evict another

--- a/cli/src/transport/broker-status.ts
+++ b/cli/src/transport/broker-status.ts
@@ -97,14 +97,22 @@ export function buildBrokerHelloData(
 }
 
 /**
- * The E_NO_PLUGIN message. With a routing filter set (`--file` or FIGMA_AGENT_FILE) AND
- * other files connected, name the KNOB THE CALLER ACTUALLY USED and list the connected
- * files (so the user sees why routing refused); otherwise the plain "no plugin connected"
- * nudge. Naming FIGMA_AGENT_FILE for a `--file` miss would be wrong advice — the caller
- * never set that env var.
+ * The E_NO_PLUGIN message. With a routing filter set (`--instance`, `--file`, or
+ * FIGMA_AGENT_FILE) AND other files connected, name the KNOB THE CALLER ACTUALLY USED and
+ * list the connected files (so the user sees why routing refused); otherwise the plain "no
+ * plugin connected" nudge. Naming FIGMA_AGENT_FILE for a `--file` miss would be wrong advice
+ * — the caller never set that env var.
+ *
+ * `kind:'instance'` gets its OWN message shape rather than the connected-files list: an
+ * instanceId that matches nothing means that specific instance disconnected — "connected
+ * files: [...]" would invite the wrong fix (a name is not the missing key here, the
+ * instanceId is), so the message points at `status` for the current live instanceIds instead.
  */
 export function noPluginMessage(registry: PluginRegistry<RegistrySocket>, filter?: RouteFilter | null): string {
   const f = filter?.value?.trim();
+  if (filter?.kind === 'instance' && f) {
+    return `--instance "${f}" matches no connected plugin — it may have disconnected; run \`status\` for live instanceIds.`;
+  }
   const live = registry.statusList();
   if (f && live.length > 0) {
     const names = live.map((p) => p.fileName ?? '(unnamed)').join(', ');

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -6,6 +6,7 @@
 // / cull / status contract is pure and unit-testable with fake sockets.
 import type { PluginScene, PluginStatusEntry } from '../../../shared/protocol.ts';
 import { fileMatches } from '../../../shared/file-match.ts';
+import type { FilterKind } from './route-filter.ts';
 
 /** WebSocket.OPEN — inlined so the registry needs no `ws` import (kept pure). */
 export const WS_OPEN = 1;
@@ -155,9 +156,22 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     return this.liveEntries().length;
   }
 
-  /** Live entries whose fileName matches (unfiltered → all). Ordering: most-recently-active first. */
-  matching(filter?: string | null, opts?: { exact?: boolean }): PluginEntry<S>[] {
+  /**
+   * Live entries matching the filter. `opts.kind === 'instance'` (instance targeting, spec
+   * 260801-1050) branches to `getByInstanceId` instead of name matching: an instanceId is
+   * exact and unique by construction, so the result is the single live entry or `[]` — NEVER
+   * a name-fuzzy list, even when other entries share the same fileName (the whole reason
+   * `--instance` exists: two unsaved files both named "Untitled" are otherwise indistinguishable).
+   * Default (`kind` omitted or `'name'`): live entries whose fileName matches (unfiltered →
+   * all). Ordering: most-recently-active first.
+   */
+  matching(filter?: string | null, opts?: { exact?: boolean; kind?: FilterKind }): PluginEntry<S>[] {
     const f = filter?.trim();
+    if (opts?.kind === 'instance') {
+      if (!f) return [];
+      const hit = this.getByInstanceId(f);
+      return hit && hit.ws.readyState === WS_OPEN ? [hit] : [];
+    }
     const live = this.liveEntries();
     const hits = f ? live.filter((e) => fileMatches(e.scene.fileName as string | undefined, f, opts?.exact === true)) : live;
     return [...hits].sort((a, b) => b.lastActiveAt - a.lastActiveAt);
@@ -167,10 +181,11 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
    * The routing target: the live plugin with the most-recent `lastSeenAt` — "the
    * file the user touched last". An optional fileName filter (case-insensitive
    * substring by default, or `opts.exact` for a whole-name match — see `matching`)
-   * restricts candidates; no candidate matches → null. Ties keep the most-recent
+   * restricts candidates, or `opts.kind: 'instance'` resolves `filter` as an exact
+   * instanceId instead; no candidate matches → null. Ties keep the most-recent
    * (see `matching`'s sort).
    */
-  selectTarget(filter?: string | null, opts?: { exact?: boolean }): PluginEntry<S> | null {
+  selectTarget(filter?: string | null, opts?: { exact?: boolean; kind?: FilterKind }): PluginEntry<S> | null {
     return this.matching(filter, opts)[0] ?? null;   // unchanged semantics for existing callers
   }
 

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -157,8 +157,8 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
   }
 
   /**
-   * Live entries matching the filter. `opts.kind === 'instance'` (instance targeting, spec
-   * 260801-1050) branches to `getByInstanceId` instead of name matching: an instanceId is
+   * Live entries matching the filter. `opts.kind === 'instance'` (instance targeting)
+   * branches to `getByInstanceId` instead of name matching: an instanceId is
    * exact and unique by construction, so the result is the single live entry or `[]` — NEVER
    * a name-fuzzy list, even when other entries share the same fileName (the whole reason
    * `--instance` exists: two unsaved files both named "Untitled" are otherwise indistinguishable).

--- a/cli/src/transport/route-filter.ts
+++ b/cli/src/transport/route-filter.ts
@@ -1,28 +1,43 @@
-// Which file a request routes to, and how strictly. PURE — the daemon reads env + envelope and
-// asks here, so precedence is a unit test rather than a code path only reachable with two Figma
-// files open.
+// Which file (or instance) a request routes to, and how strictly. PURE — the daemon reads env +
+// envelope and asks here, so precedence is a unit test rather than a code path only reachable
+// with two Figma files open.
 export type FilterSource = 'flag' | 'env' | 'none';
+
+// `value` is a file NAME under kind:'name', or an opaque instanceId under kind:'instance' — the
+// registry needs this to know which comparison to run (name matching vs. instance lookup). The
+// 'none' source always carries kind:'name' (unchanged: value is null, so kind is moot).
+export type FilterKind = 'name' | 'instance';
 
 export interface RouteFilter {
   value: string | null;   // trimmed; null = no restriction
-  exact: boolean;         // --file must match the WHOLE name; the env pin stays a substring pin
+  exact: boolean;         // --file/--instance must match the WHOLE value; the env pin stays a substring pin
   source: FilterSource;
+  kind: FilterKind;
 }
 
 /**
- * Precedence: explicit `--file` (per request) > FIGMA_AGENT_FILE (per daemon) > active plugin.
+ * Precedence: explicit `--instance` (per request, exact, unique) > explicit `--file` (per
+ * request, exact) > FIGMA_AGENT_FILE (per daemon) > active plugin.
  *
- * `--file` is EXACT (case-insensitive, trimmed) on purpose: it is the routing half of a guard the
- * plugin re-checks against `figma.root.name`. A substring filter could route "Design" to
- * "Design System" and then have the plugin refuse it with E_WRONG_FILE — routing and guard must
- * agree, so they use the same comparison.
+ * `--instance` targets a specific plugin instance by its minted, opaque instanceId — it always
+ * matches 0 or 1 entries, so it is exact by construction (no substring mode makes sense for a
+ * unique key). `--file` is EXACT (case-insensitive, trimmed) on purpose: it is the routing half
+ * of a guard the plugin re-checks against `figma.root.name`. A substring filter could route
+ * "Design" to "Design System" and then have the plugin refuse it with E_WRONG_FILE — routing and
+ * guard must agree, so they use the same comparison.
  */
-export function resolveRouteFilter(expectedFile?: string | null, envPin?: string | null): RouteFilter {
+export function resolveRouteFilter(
+  expectedFile?: string | null,
+  envPin?: string | null,
+  instanceFlag?: string | null,
+): RouteFilter {
+  const instance = instanceFlag?.trim();
+  if (instance) return { value: instance, exact: true, source: 'flag', kind: 'instance' };
   const flag = expectedFile?.trim();
-  if (flag) return { value: flag, exact: true, source: 'flag' };
+  if (flag) return { value: flag, exact: true, source: 'flag', kind: 'name' };
   const env = envPin?.trim();
-  if (env) return { value: env, exact: false, source: 'env' };
-  return { value: null, exact: false, source: 'none' };
+  if (env) return { value: env, exact: false, source: 'env', kind: 'name' };
+  return { value: null, exact: false, source: 'none', kind: 'name' };
 }
 
 export { fileMatches } from '../../../shared/file-match.ts';

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -98,6 +98,14 @@ export interface RequestMsg {
    */
   expectedFile?: string;
   /**
+   * The exact plugin instance this command is FOR (`--instance <id>`), spec 260801-1050. Envelope-
+   * level, exactly like `expectedFile`, so the broker routes on it without parsing `params`.
+   * Mutually exclusive with `expectedFile` at the CLI boundary (refused before a request is ever
+   * built) — the broker only ever sees one of the two set. Omitted entirely when unset, same
+   * byte-identical-frame contract as `expectedFile`.
+   */
+  expectedInstance?: string;
+  /**
    * Absolute project root of the CALLER (its cwd, or --dir). The broker records
    * fileIdentity → projectDir from this, so panel/idle sync can apply into the right project
    * instead of the daemon's spawn cwd. Omitted only by a pre-binding CLI.
@@ -350,10 +358,12 @@ export function makeRequestFrame(
   expectedFile?: string,
   projectDir?: string,
   readOnly?: boolean,
+  expectedInstance?: string,
 ): RequestMsg {
   const frame: RequestMsg = { id, cmd, params, v: PROTOCOL_VERSION };
   if (typeof activity === 'string' && activity.trim() !== '') frame.activity = activity;
   if (typeof expectedFile === 'string' && expectedFile.trim() !== '') frame.expectedFile = expectedFile;
+  if (typeof expectedInstance === 'string' && expectedInstance.trim() !== '') frame.expectedInstance = expectedInstance;
   if (typeof projectDir === 'string' && projectDir.trim() !== '') frame.projectDir = projectDir;
   // Concurrency & jobs — omitted (never `readOnly: false`) when unset, exactly like the
   // other optional envelope fields above: an unguarded frame must serialize

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -98,7 +98,7 @@ export interface RequestMsg {
    */
   expectedFile?: string;
   /**
-   * The exact plugin instance this command is FOR (`--instance <id>`), spec 260801-1050. Envelope-
+   * The exact plugin instance this command is FOR (`--instance <id>`). Envelope-
    * level, exactly like `expectedFile`, so the broker routes on it without parsing `params`.
    * Mutually exclusive with `expectedFile` at the CLI boundary (refused before a request is ever
    * built) — the broker only ever sees one of the two set. Omitted entirely when unset, same

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -776,12 +776,12 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
   });
 });
 
-// Spec 260801-1050 (P1) — `--instance <id>` admission. NOT run by the executor: this harness
+// `--instance <id>` admission. NOT run by the executor: this harness
 // spawns a real in-process broker via `runBrokerDaemon`, and per the assigned constraint on
 // this machine a live plugin session is connected and this harness pollutes its broker
 // discovery (issue #32) — written here (the one file that exercises the real `admitRequest`
 // closure) and left for the orchestrator to run post-smoke.
-describe('daemon harness — admitRequest with an `--instance` (expectedInstance) filter (spec 260801-1050 P1)', () => {
+describe('daemon harness — admitRequest with an `--instance` (expectedInstance) filter', () => {
   it('an instanceId matching NO connected plugin → E_NO_PLUGIN names the instanceId, never "open the file panel"', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -775,3 +775,47 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
     }
   });
 });
+
+// Spec 260801-1050 (P1) — `--instance <id>` admission. NOT run by the executor: this harness
+// spawns a real in-process broker via `runBrokerDaemon`, and per the assigned constraint on
+// this machine a live plugin session is connected and this harness pollutes its broker
+// discovery (issue #32) — written here (the one file that exercises the real `admitRequest`
+// closure) and left for the orchestrator to run post-smoke.
+describe('daemon harness — admitRequest with an `--instance` (expectedInstance) filter (spec 260801-1050 P1)', () => {
+  it('an instanceId matching NO connected plugin → E_NO_PLUGIN names the instanceId, never "open the file panel"', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-live', 'FileLive');
+
+    const cli = await connectSocket(port);
+    const reqId = 'req-instance-not-connected';
+    cli.send(JSON.stringify(
+      makeRequestFrame(reqId, 'SET_TEXT', { nodeId: '1:1', text: 'x' }, undefined, undefined, undefined, undefined, 'inst-gone'),
+    ));
+    const reply = await nextFrame<ReplyErr>(cli, (m) => (m as ReplyOk | ReplyErr).id === reqId);
+    expect(reply.ok).toBe(false);
+    expect(reply.error.code).toBe('E_NO_PLUGIN');
+    expect(reply.error.message).toContain('--instance "inst-gone"');
+    expect(reply.error.message).not.toContain('panel');
+  });
+
+  it('two plugins sharing the SAME fileName ("Untitled") → --instance routes to the exact one, never the other', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-a', 'Untitled');
+    await helloPlugin(pluginB, 'inst-b', 'Untitled');
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+
+    const cli = await connectSocket(port);
+    const reqId = 'req-instance-exact';
+    cli.send(JSON.stringify(
+      makeRequestFrame(reqId, 'SET_TEXT', { nodeId: '1:1', text: 'x' }, undefined, undefined, undefined, undefined, 'inst-b'),
+    ));
+    await nextFrame(cli, (m) => (m as EventMsg).type === 'JOB_STATE');
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(framesB.frames.some((f) => (f as { id?: string }).id === reqId)).toBe(true);
+    expect(framesA.frames.some((f) => (f as { id?: string }).id === reqId)).toBe(false);
+  });
+});

--- a/tests/broker-status.test.ts
+++ b/tests/broker-status.test.ts
@@ -130,8 +130,9 @@ describe('buildBrokerHelloData — legacyMigrationDeferred (issue #7 fix round, 
 });
 
 describe('noPluginMessage', () => {
-  const envFilter = (value: string): RouteFilter => ({ value, exact: false, source: 'env' });
-  const flagFilter = (value: string): RouteFilter => ({ value, exact: true, source: 'flag' });
+  const envFilter = (value: string): RouteFilter => ({ value, exact: false, source: 'env', kind: 'name' });
+  const flagFilter = (value: string): RouteFilter => ({ value, exact: true, source: 'flag', kind: 'name' });
+  const instanceFilter = (value: string): RouteFilter => ({ value, exact: true, source: 'flag', kind: 'instance' });
 
   it('no filter → the plain nudge', () => {
     const { reg } = seed();
@@ -164,5 +165,13 @@ describe('noPluginMessage', () => {
   it('filter but nothing connected → falls back to the plain nudge', () => {
     const { reg } = seed();
     expect(noPluginMessage(reg, envFilter('vsf'))).toBe('no Figma plugin connected — open the figma-agent plugin in Figma');
+  });
+
+  it('--instance filter matching nothing → names the instanceId, points at `status`, never lists files', () => {
+    const { reg } = seed();
+    reg.register(sock(), { instanceId: 'a', fileName: 'Design system' });
+    const msg = noPluginMessage(reg, instanceFilter('p_9_999'));
+    expect(msg).toBe('--instance "p_9_999" matches no connected plugin — it may have disconnected; run `status` for live instanceIds.');
+    expect(msg).not.toContain('Design system');
   });
 });

--- a/tests/plugin-registry.test.ts
+++ b/tests/plugin-registry.test.ts
@@ -218,7 +218,7 @@ describe('matching(filter, {exact}) — exact mode + the ambiguity input', () =>
   });
 });
 
-describe('matching/selectTarget(filter, {kind:"instance"}) — instanceId targeting (spec 260801-1050)', () => {
+describe('matching/selectTarget(filter, {kind:"instance"}) — instanceId targeting', () => {
   it('a known live instanceId → the single matching entry, never a name-fuzzy list', () => {
     const { reg, tick } = makeReg();
     reg.register(sock(), { instanceId: 'p_1_100', fileName: 'Design' });

--- a/tests/plugin-registry.test.ts
+++ b/tests/plugin-registry.test.ts
@@ -218,6 +218,48 @@ describe('matching(filter, {exact}) — exact mode + the ambiguity input', () =>
   });
 });
 
+describe('matching/selectTarget(filter, {kind:"instance"}) — instanceId targeting (spec 260801-1050)', () => {
+  it('a known live instanceId → the single matching entry, never a name-fuzzy list', () => {
+    const { reg, tick } = makeReg();
+    reg.register(sock(), { instanceId: 'p_1_100', fileName: 'Design' });
+    tick(5);
+    reg.register(sock(), { instanceId: 'p_2_100', fileName: 'Design' }); // duplicate name on purpose
+    const hits = reg.matching('p_1_100', { kind: 'instance' });
+    expect(hits.map((h) => h.instanceId)).toEqual(['p_1_100']); // exact instance, not the other same-named one
+    expect(reg.selectTarget('p_1_100', { kind: 'instance' })?.instanceId).toBe('p_1_100');
+  });
+
+  it('an unknown instanceId → [] / null, never falls back to a name match', () => {
+    const { reg } = makeReg();
+    reg.register(sock(), { instanceId: 'p_1_100', fileName: 'Design' });
+    expect(reg.matching('nope', { kind: 'instance' })).toEqual([]);
+    expect(reg.selectTarget('nope', { kind: 'instance' })).toBeNull();
+  });
+
+  it('a DISCONNECTED (closed-socket) instanceId → [] / null, not the stale entry', () => {
+    const { reg } = makeReg();
+    const ws = sock(false);
+    reg.register(ws, { instanceId: 'p_1_100', fileName: 'Design' });
+    ws.readyState = CLOSED;
+    expect(reg.matching('p_1_100', { kind: 'instance' })).toEqual([]);
+    expect(reg.selectTarget('p_1_100', { kind: 'instance' })).toBeNull();
+  });
+
+  it('kind:"instance" with two live entries sharing a fileName still isolates by id only', () => {
+    const { reg } = makeReg();
+    reg.register(sock(), { instanceId: 'a', fileName: 'Untitled' });
+    reg.register(sock(), { instanceId: 'b', fileName: 'Untitled' });
+    expect(reg.matching('a', { kind: 'instance' }).map((h) => h.instanceId)).toEqual(['a']);
+    expect(reg.matching('b', { kind: 'instance' }).map((h) => h.instanceId)).toEqual(['b']);
+  });
+
+  it('a blank instanceId filter with kind:"instance" → [] (never "unfiltered = everything")', () => {
+    const { reg } = makeReg();
+    reg.register(sock(), { instanceId: 'a', fileName: 'Design' });
+    expect(reg.matching('   ', { kind: 'instance' })).toEqual([]);
+  });
+});
+
 describe('park → flush decision (what the daemon keys off)', () => {
   it('filter set + only a NON-matching file → no target (park); matching file appears → target (flush)', () => {
     const { reg, tick } = makeReg();

--- a/tests/route-filter.test.ts
+++ b/tests/route-filter.test.ts
@@ -1,29 +1,60 @@
-// Phase 03 — the routing precedence rule, pure: --file (exact) > FIGMA_AGENT_FILE
-// (substring) > active plugin. One comparison (`fileMatches`) backs both routing and
-// the plugin-side guard, so they can never disagree.
+// Phase 03 — the routing precedence rule, pure: --instance (exact, unique) > --file (exact)
+// > FIGMA_AGENT_FILE (substring) > active plugin. One comparison (`fileMatches`) backs both
+// name-routing and the plugin-side guard, so they can never disagree. `kind` on the resolved
+// filter tells the registry whether `value` is a name or an opaque instanceId.
 import { describe, it, expect } from 'vitest';
 import { resolveRouteFilter, fileMatches } from '../cli/src/transport/route-filter.ts';
 
 describe('resolveRouteFilter — precedence', () => {
-  it('--file set + env set → flag wins, exact', () => {
-    expect(resolveRouteFilter('VSF - PCP', 'design')).toEqual({ value: 'VSF - PCP', exact: true, source: 'flag' });
+  it('--instance set (alone) → flag wins, exact, kind:instance', () => {
+    expect(resolveRouteFilter(undefined, undefined, 'p_3_1712345')).toEqual({
+      value: 'p_3_1712345', exact: true, source: 'flag', kind: 'instance',
+    });
   });
 
-  it('only env set → env, substring', () => {
-    expect(resolveRouteFilter(undefined, 'design')).toEqual({ value: 'design', exact: false, source: 'env' });
+  it('--instance + --file both set → instance wins (highest precedence)', () => {
+    expect(resolveRouteFilter('VSF - PCP', undefined, 'p_3_1712345')).toEqual({
+      value: 'p_3_1712345', exact: true, source: 'flag', kind: 'instance',
+    });
   });
 
-  it('neither set → none, unrestricted', () => {
-    expect(resolveRouteFilter(undefined, undefined)).toEqual({ value: null, exact: false, source: 'none' });
-    expect(resolveRouteFilter(null, null)).toEqual({ value: null, exact: false, source: 'none' });
+  it('--instance + env both set → instance wins', () => {
+    expect(resolveRouteFilter(undefined, 'design', 'p_3_1712345')).toEqual({
+      value: 'p_3_1712345', exact: true, source: 'flag', kind: 'instance',
+    });
+  });
+
+  it('--instance + --file + env all set → instance wins over everything', () => {
+    expect(resolveRouteFilter('VSF - PCP', 'design', 'p_3_1712345')).toEqual({
+      value: 'p_3_1712345', exact: true, source: 'flag', kind: 'instance',
+    });
+  });
+
+  it('a whitespace-only --instance is treated as unset — falls through to --file', () => {
+    expect(resolveRouteFilter('VSF - PCP', 'design', '   ')).toEqual({
+      value: 'VSF - PCP', exact: true, source: 'flag', kind: 'name',
+    });
+  });
+
+  it('--file set + env set (no --instance) → --file wins, exact, kind:name', () => {
+    expect(resolveRouteFilter('VSF - PCP', 'design')).toEqual({ value: 'VSF - PCP', exact: true, source: 'flag', kind: 'name' });
+  });
+
+  it('only env set → env, substring, kind:name', () => {
+    expect(resolveRouteFilter(undefined, 'design')).toEqual({ value: 'design', exact: false, source: 'env', kind: 'name' });
+  });
+
+  it('neither set → none, unrestricted, kind:name', () => {
+    expect(resolveRouteFilter(undefined, undefined)).toEqual({ value: null, exact: false, source: 'none', kind: 'name' });
+    expect(resolveRouteFilter(null, null)).toEqual({ value: null, exact: false, source: 'none', kind: 'name' });
   });
 
   it('a whitespace-only --file is treated as unset — falls through to the env pin', () => {
-    expect(resolveRouteFilter('   ', 'design')).toEqual({ value: 'design', exact: false, source: 'env' });
+    expect(resolveRouteFilter('   ', 'design')).toEqual({ value: 'design', exact: false, source: 'env', kind: 'name' });
   });
 
   it('a whitespace-only env pin with no --file → none', () => {
-    expect(resolveRouteFilter(undefined, '   ')).toEqual({ value: null, exact: false, source: 'none' });
+    expect(resolveRouteFilter(undefined, '   ')).toEqual({ value: null, exact: false, source: 'none', kind: 'name' });
   });
 });
 


### PR DESCRIPTION
## Why

With FigJam + Slides + Design all connectable at once, routing keys on **file name** (`--file`, exact). Two unsaved files both report `figma.root.name === "Untitled"`, so the name is not a unique key: `--file "Untitled"` refuses with a collision naming both instanceIds. `instanceId` IS unique (minted per iframe load, survives reconnect) and is already carried on every `PLUGIN_HELLO` and printed in the collision error — but nothing could route by it until now.

This is Phase 1 of a two-phase plan (issue #35): the CLI flag only. A panel "target this plugin" button is a separate follow-up.

## Precedence

| Rank | Filter | Scope | Match |
|---|---|---|---|
| 1 | `--instance <id>` | per request | exact, unique |
| 2 | `--file <name>` | per request | exact |
| 3 | `FIGMA_AGENT_FILE` | per daemon (env) | substring |
| 4 | active | ambient | most-recent |

`--instance` and `--file` on the same request are mutually exclusive — passing both refuses with `E_INVALID_ARGS` naming both flags, it never silently picks one.

## What changed

- `RouteFilter` gains a `kind: 'name' | 'instance'` discriminator so the registry knows whether `value` is a file name or an opaque instanceId.
- `PluginRegistry.matching`/`.selectTarget` branch on `kind:'instance'`, reusing the existing `getByInstanceId()` lookup — an instanceId match is always 0 or 1 entries, never a name-fuzzy list, even when two live entries share a fileName.
- The daemon's `E_NO_PLUGIN` message names the instanceId (not "open the file's panel") when an `--instance` target isn't connected, and the `--file` ambiguity message now also suggests `--instance <id>` as the exact fix.
- CLI: `--instance <id>` documented alongside `--file`, with the same empty-value guard and a boundary-level mutual-exclusion check.

Scope note: the granted file list didn't include `shared/protocol.ts` (the `RequestMsg.expectedInstance` wire field) or `cli/src/transport/broker-client.ts` (the CLI-side `setExpectedInstance` state, mirroring `setExpectedFile`) — both are required plumbing for the flag's value to cross the CLI→broker process boundary at all, so they're included here. `cli/src/transport/broker-status.ts`'s `noPluginMessage` also needed the instance-aware message branch. All four are additive/backward-compatible (new optional field, new optional param appended last).

## Test-first

Added failing-then-passing coverage (each confirmed red on the pre-change code, verified via the diff sequence in the PR history):
- `tests/route-filter.test.ts` — `--instance` beats `--file` beats env beats none; resolved filter carries `kind:'instance'`, `exact:true`.
- `tests/plugin-registry.test.ts` — `matching`/`selectTarget` with `kind:'instance'` return the single live entry for a known id, `[]` for an unknown/dead id, and never a name-fuzzy list even when two live entries share a fileName.
- `tests/broker-status.test.ts` — `noPluginMessage` names the instanceId and never lists connected files for an `--instance` miss.
- `tests/broker-daemon-harness.test.ts` — two new cases (instanceId-not-connected → `E_NO_PLUGIN` naming the id; `--instance` routes to the exact instance among two same-named live plugins). **Written but deliberately not run** — this harness spawns a real in-process broker, and a live plugin session connected on the executing machine made running it unsafe (broker-discovery pollution, tracked separately). Left for a follow-up run once no live session is active.

## Gate

- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run tests/route-filter.test.ts tests/plugin-registry.test.ts` — 49/49 pass
- Also re-ran the other pure suites touched by the `RouteFilter` shape change (`broker-status.test.ts`, `file-guard-plumbing.test.ts`, `activity-labels.test.ts`, `job-table-sender-verification.test.ts`) — 34/34 pass
- Full `npm test` and the broker-daemon-harness suite were intentionally not run (live-broker-safety constraint above)