### PR TITLE
Refuse a --read-only EXEC_JS that mutates the scene

### DIFF
--- a/plugin/code.js
+++ b/plugin/code.js
@@ -2341,7 +2341,7 @@
     if (typeof params.x === "number") node.x = params.x;
     if (typeof params.y === "number") node.y = params.y;
   }
-  function opStatus(bootSkipped2 = []) {
+  function opStatus(bootSkipped2 = [], readOnlyViolations2 = 0) {
     return {
       fileName: figma.root.name,
       page: figma.currentPage.name,
@@ -2365,7 +2365,13 @@
       // knowledge/figjam.md) — the field exists so a FUTURE editor (phase-04 Slides, or
       // a later FigJam finding) has somewhere to report one, without a payload shape
       // change.
-      ...bootSkipped2.length > 0 && { bootSkipped: [...bootSkipped2] }
+      ...bootSkipped2.length > 0 && { bootSkipped: [...bootSkipped2] },
+      // Concurrency & jobs (issue #38) — same "present only once meaningful" contract as
+      // bootSkipped just above and the broker's own senderMismatchCount: a fleet that has
+      // never seen a mis-declared `--read-only` EXEC_JS keeps this payload byte-identical
+      // to before the field existed; a non-zero count makes a real pattern visible instead
+      // of vanishing into a silently-applied mutation.
+      ...readOnlyViolations2 > 0 && { readOnlyViolations: readOnlyViolations2 }
     };
   }
   function opGetSelection(params) {
@@ -4596,6 +4602,23 @@
   var PANEL_WIDTH = 300;
   var PANEL_HEIGHT = 420;
 
+  // plugin/src/main/readonly-guard.ts
+  function createReadOnlyGuardState() {
+    return { soleActorChangeEvents: 0 };
+  }
+  function recordDocumentChangeBatch(state, activeCount2) {
+    if (activeCount2 === 1) state.soleActorChangeEvents += 1;
+  }
+  function snapshotChangeEvents(state) {
+    return state.soleActorChangeEvents;
+  }
+  function violatedSinceSnapshot(state, snapshot) {
+    return state.soleActorChangeEvents > snapshot;
+  }
+  function isReadOnlyExecJs(cmd, readOnly) {
+    return cmd === "EXEC_JS" && readOnly === true;
+  }
+
   // plugin/src/main/main.ts
   figma.showUI(__html__, {
     visible: true,
@@ -4687,6 +4710,8 @@
   function actorState() {
     return { activeCount, lastDrainAt, declared: declaredIds, lastAgentAt };
   }
+  var readOnlyGuard = createReadOnlyGuardState();
+  var readOnlyViolations = 0;
   var idleMs = DEFAULT_IDLE_MS;
   var idleTimer = null;
   var changesSinceCommit = 0;
@@ -4707,6 +4732,7 @@
   }
   function onDocumentChange(event) {
     pruneDeclaredIds(declaredIds, Date.now());
+    recordDocumentChangeBatch(readOnlyGuard, activeCount);
     const raw = [];
     const edits = [];
     for (const dc of event.documentChanges) {
@@ -4823,8 +4849,16 @@
       beginAgentMutation(targetIds);
       activeCount += 1;
       for (const id of targetIds) declaredIds.set(id, Infinity);
+      const enforceReadOnly = isReadOnlyExecJs(req.cmd, req.readOnly);
+      const readOnlySnapshot = enforceReadOnly ? snapshotChangeEvents(readOnlyGuard) : 0;
       try {
         const result = await dispatch(req.cmd, req.params ?? {});
+        if (enforceReadOnly && violatedSinceSnapshot(readOnlyGuard, readOnlySnapshot)) {
+          readOnlyViolations += 1;
+          throw withCode(new Error(
+            "EXEC_JS declared --read-only but mutated the scene \u2014 a read-only-declared script must not write; refused (the mutation already ran and was sealed into its own undo step, not the caller's previous one)"
+          ), "E_READONLY_VIOLATION");
+        }
         const changedIds = [.../* @__PURE__ */ new Set([...targetIds, ...resultMutationIds(req.cmd, result)])];
         const completedAt = Date.now();
         for (const nodeId of changedIds) {
@@ -4882,7 +4916,7 @@
   async function dispatch(cmd, params) {
     switch (cmd) {
       case "STATUS":
-        return opStatus(bootSkipped);
+        return opStatus(bootSkipped, readOnlyViolations);
       case "GET_SELECTION":
         return opGetSelection(params);
       case "SCAN_DESIGN_SYSTEM":

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -2366,7 +2366,7 @@
       // a later FigJam finding) has somewhere to report one, without a payload shape
       // change.
       ...bootSkipped2.length > 0 && { bootSkipped: [...bootSkipped2] },
-      // Concurrency & jobs (issue #38) — same "present only once meaningful" contract as
+      // Concurrency & jobs — same "present only once meaningful" contract as
       // bootSkipped just above and the broker's own senderMismatchCount: a fleet that has
       // never seen a mis-declared `--read-only` EXEC_JS keeps this payload byte-identical
       // to before the field existed; a non-zero count makes a real pattern visible instead

--- a/plugin/src/main/executor-ops.ts
+++ b/plugin/src/main/executor-ops.ts
@@ -84,7 +84,7 @@ async function appendToParent(node: SceneNode, params: Params): Promise<void> {
   if (typeof params.y === 'number') node.y = params.y;
 }
 
-export function opStatus(bootSkipped: readonly string[] = []): Record<string, unknown> {
+export function opStatus(bootSkipped: readonly string[] = [], readOnlyViolations = 0): Record<string, unknown> {
   return {
     fileName: figma.root.name,
     page: figma.currentPage.name,
@@ -109,6 +109,12 @@ export function opStatus(bootSkipped: readonly string[] = []): Record<string, un
     // a later FigJam finding) has somewhere to report one, without a payload shape
     // change.
     ...(bootSkipped.length > 0 && { bootSkipped: [...bootSkipped] }),
+    // Concurrency & jobs (issue #38) — same "present only once meaningful" contract as
+    // bootSkipped just above and the broker's own senderMismatchCount: a fleet that has
+    // never seen a mis-declared `--read-only` EXEC_JS keeps this payload byte-identical
+    // to before the field existed; a non-zero count makes a real pattern visible instead
+    // of vanishing into a silently-applied mutation.
+    ...(readOnlyViolations > 0 && { readOnlyViolations }),
   };
 }
 

--- a/plugin/src/main/executor-ops.ts
+++ b/plugin/src/main/executor-ops.ts
@@ -109,7 +109,7 @@ export function opStatus(bootSkipped: readonly string[] = [], readOnlyViolations
     // a later FigJam finding) has somewhere to report one, without a payload shape
     // change.
     ...(bootSkipped.length > 0 && { bootSkipped: [...bootSkipped] }),
-    // Concurrency & jobs (issue #38) — same "present only once meaningful" contract as
+    // Concurrency & jobs — same "present only once meaningful" contract as
     // bootSkipped just above and the broker's own senderMismatchCount: a fleet that has
     // never seen a mis-declared `--read-only` EXEC_JS keeps this payload byte-identical
     // to before the field existed; a non-zero count makes a real pattern visible instead

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -45,6 +45,10 @@ import {
 } from './correction-edge-store';
 import type { CorrectionEvent } from '../../../shared/supervised-memory';
 import { PANEL_WIDTH, PANEL_HEIGHT } from '../ui/panel-model';
+import {
+  createReadOnlyGuardState, isReadOnlyExecJs, recordDocumentChangeBatch,
+  snapshotChangeEvents, violatedSinceSnapshot,
+} from './readonly-guard';
 
 // Panel IA v2: one opening size — no compact/expanded split, no user-resizable
 // Details toggle left to preserve (the whole PANEL_RESIZE path is gone below).
@@ -236,6 +240,14 @@ function actorState(): ActorState {
   return { activeCount, lastDrainAt, declared: declaredIds, lastAgentAt };
 }
 
+// ─── Read-only EXEC_JS enforcement (issue #38) ──────────────────────
+// See readonly-guard.ts for the full attribution design (why `activeCount === 1` is the
+// signal, and the documented residual gap it accepts). `readOnlyViolations` follows the
+// broker's own senderMismatchCount/legacyMigrationDeferred contract: surfaced in STATUS
+// only once it is actually non-empty (executor-ops.ts's opStatus).
+const readOnlyGuard = createReadOnlyGuardState();
+let readOnlyViolations = 0;
+
 // ─── Idle-commit timer (spec 004 P4) ────────────────────────────────
 // Every captured documentchange resets a debounce; after IDLE_MS of quiet the plugin
 // posts IDLE_READY {count} to its iframe, which shows the "N changes — Sync now /
@@ -274,6 +286,10 @@ function fireIdle(): void {
 
 function onDocumentChange(event: DocumentChangeEvent): void {
   pruneDeclaredIds(declaredIds, Date.now()); // once per batch — nothing reads `declared` between batches
+  // Read-only EXEC_JS enforcement (issue #38) — once per batch, not per node: this
+  // records ATTRIBUTABILITY ("could this batch belong to the one active dispatch"),
+  // not which node changed. See readonly-guard.ts.
+  recordDocumentChangeBatch(readOnlyGuard, activeCount);
   const raw: ComponentChange[] = [];
   const edits: EditInput[] = [];
   for (const dc of event.documentChanges) {
@@ -415,7 +431,14 @@ figma.on('close', () => {
 
 type Params = Record<string, unknown>;
 
-interface UiRequest { requestId: string; cmd: CommandName; params?: Params; expectedFile?: string }
+interface UiRequest {
+  requestId: string; cmd: CommandName; params?: Params; expectedFile?: string;
+  /** Concurrency & jobs — the caller's `--read-only` declaration, carried this far by
+   *  ui-relay.ts (see its own comment). Only EXEC_JS reads it (readonly-guard.ts's
+   *  `isReadOnlyExecJs`) — every other mutating command is already refused this flag
+   *  at the CLI, before a request ever reaches the wire. */
+  readOnly?: boolean;
+}
 
 figma.ui.onmessage = async (msg: unknown) => {
   // Panel IA v2 removed the Details toggle — its PANEL_RESIZE message was the only
@@ -464,8 +487,27 @@ figma.ui.onmessage = async (msg: unknown) => {
     // another still-active dispatch's ids could be cleared alongside.
     activeCount += 1;
     for (const id of targetIds) declaredIds.set(id, Infinity);
+    // Read-only EXEC_JS enforcement (issue #38) — snapshot BEFORE `dispatch`, the same
+    // moment this dispatch starts counting as "active" above, so the window covers its
+    // entire run. See readonly-guard.ts for why `activeCount` is the attribution signal.
+    const enforceReadOnly = isReadOnlyExecJs(req.cmd, req.readOnly);
+    const readOnlySnapshot = enforceReadOnly ? snapshotChangeEvents(readOnlyGuard) : 0;
     try {
       const result = await dispatch(req.cmd, req.params ?? {});
+      if (enforceReadOnly && violatedSinceSnapshot(readOnlyGuard, readOnlySnapshot)) {
+        // The script already ran and already mutated — v1 is detect + refuse + count,
+        // never a silent apply. `commitIfMutating` below (this dispatch's `catch`, via
+        // the throw) still seals the leaked write into its OWN undo step (EXEC_JS is in
+        // MUTATING_COMMANDS), same as any other exec-js failure — a designer can revert
+        // it with a single ⌘Z. Auto-rollback beyond that is deliberately out of scope
+        // for v1 (see the PR description's open-question note).
+        readOnlyViolations += 1;
+        throw withCode(new Error(
+          'EXEC_JS declared --read-only but mutated the scene — a read-only-declared '
+          + 'script must not write; refused (the mutation already ran and was sealed '
+          + 'into its own undo step, not the caller\'s previous one)',
+        ), 'E_READONLY_VIOLATION');
+      }
       const changedIds = [...new Set([...targetIds, ...resultMutationIds(req.cmd as CommandName, result)])];
       const completedAt = Date.now();
       for (const nodeId of changedIds) {
@@ -534,7 +576,7 @@ function mutationTargetIds(cmd: CommandName, params: Params): string[] {
 
 async function dispatch(cmd: CommandName, params: Params): Promise<unknown> {
   switch (cmd) {
-    case 'STATUS': return opStatus(bootSkipped);
+    case 'STATUS': return opStatus(bootSkipped, readOnlyViolations);
     case 'GET_SELECTION': return opGetSelection(params);
     case 'SCAN_DESIGN_SYSTEM': return serializeDesignSystem();
     case 'AUDIT_DS': return auditDs();

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -240,7 +240,7 @@ function actorState(): ActorState {
   return { activeCount, lastDrainAt, declared: declaredIds, lastAgentAt };
 }
 
-// ─── Read-only EXEC_JS enforcement (issue #38) ──────────────────────
+// ─── Read-only EXEC_JS enforcement ──────────────────────
 // See readonly-guard.ts for the full attribution design (why `activeCount === 1` is the
 // signal, and the documented residual gap it accepts). `readOnlyViolations` follows the
 // broker's own senderMismatchCount/legacyMigrationDeferred contract: surfaced in STATUS
@@ -286,7 +286,7 @@ function fireIdle(): void {
 
 function onDocumentChange(event: DocumentChangeEvent): void {
   pruneDeclaredIds(declaredIds, Date.now()); // once per batch — nothing reads `declared` between batches
-  // Read-only EXEC_JS enforcement (issue #38) — once per batch, not per node: this
+  // Read-only EXEC_JS enforcement — once per batch, not per node: this
   // records ATTRIBUTABILITY ("could this batch belong to the one active dispatch"),
   // not which node changed. See readonly-guard.ts.
   recordDocumentChangeBatch(readOnlyGuard, activeCount);
@@ -487,7 +487,7 @@ figma.ui.onmessage = async (msg: unknown) => {
     // another still-active dispatch's ids could be cleared alongside.
     activeCount += 1;
     for (const id of targetIds) declaredIds.set(id, Infinity);
-    // Read-only EXEC_JS enforcement (issue #38) — snapshot BEFORE `dispatch`, the same
+    // Read-only EXEC_JS enforcement — snapshot BEFORE `dispatch`, the same
     // moment this dispatch starts counting as "active" above, so the window covers its
     // entire run. See readonly-guard.ts for why `activeCount` is the attribution signal.
     const enforceReadOnly = isReadOnlyExecJs(req.cmd, req.readOnly);

--- a/plugin/src/main/readonly-guard.ts
+++ b/plugin/src/main/readonly-guard.ts
@@ -1,0 +1,82 @@
+// Read-only EXEC_JS enforcement (issue #38) — attribution for the one command whose
+// target nodes are never known ahead of time. Pure over injected state, no `figma`, no
+// clock read inside — same shape as edit-actor.ts, and for the same reason: main.ts
+// cannot be imported outside a live plugin sandbox (it calls `figma.showUI` at module
+// load), so the part worth trusting has to be testable without one.
+//
+// The six typed mutating commands declare their target ids BEFORE they run
+// (`mutationTargetIds` → `beginAgentMutation`/`declaredIds`, main.ts), so a
+// documentchange landing on one of those ids while its dispatch is in flight is
+// unambiguously that dispatch's own write. EXEC_JS is an opaque script — it can mutate
+// ANY node, so there is no id to pre-declare, and per-node declaration is not an option
+// here (the same limit edit-actor.ts already documents for undeclared creates).
+//
+// What an EXEC_JS dispatch DOES have, like every other command, is `activeCount`
+// (main.ts) — how many dispatches this plugin instance currently has in flight. When
+// that count is exactly 1, the lone active dispatch IS whichever call is asking "did I
+// just mutate?" — no other dispatch exists that could have caused it. A documentchange
+// batch that lands while `activeCount === 1` is therefore attributable to the one
+// dispatch that is, at that moment, the only possible agent-side cause.
+//
+// This is coarser than per-node declaration (a whole batch, not a node) and it goes
+// deliberately narrow rather than deep: a genuinely concurrent SEPARATE dispatch
+// (typed or another EXEC_JS) pushes `activeCount` to 2+ for as long as it runs, and any
+// documentchange landing in that window is excluded here entirely — never attributed
+// to EITHER dispatch. That is the residual gap this module accepts: two EXEC_JS calls
+// racing at once (one of them a `--read-only` read, the other genuinely mutating)
+// cannot be told apart by this signal, so neither is flagged for that overlap. A false
+// NEGATIVE in that narrow, opaque-vs-opaque case is the deliberate trade for never
+// producing a false POSITIVE that would refuse a legitimate read overlapping someone
+// else's real, DECLARED mutation on other nodes — the load-bearing guarantee this
+// module exists to hold (see readonly-guard.test.ts).
+export interface ReadOnlyGuardState {
+  /** Bumped once per documentchange batch that lands while exactly one dispatch is
+   *  active — i.e. a change reliably attributable to that one dispatch. Never reset:
+   *  only ever compared via a before/after snapshot, so it never needs pruning. */
+  soleActorChangeEvents: number;
+}
+
+export function createReadOnlyGuardState(): ReadOnlyGuardState {
+  return { soleActorChangeEvents: 0 };
+}
+
+/**
+ * Call once per documentchange batch (main.ts's `onDocumentChange`, once per fired
+ * event — not once per `event.documentChanges` entry: the question this answers is "did
+ * a change land during my window", not which node changed).
+ */
+export function recordDocumentChangeBatch(state: ReadOnlyGuardState, activeCount: number): void {
+  if (activeCount === 1) state.soleActorChangeEvents += 1;
+}
+
+/**
+ * Snapshot to compare against once a dispatch completes. Call the moment a dispatch
+ * becomes active (main.ts's `activeCount += 1`), before `await dispatch(...)` — so the
+ * window covers this dispatch's entire run, including any change that lands the instant
+ * it starts.
+ */
+export function snapshotChangeEvents(state: ReadOnlyGuardState): number {
+  return state.soleActorChangeEvents;
+}
+
+/**
+ * Whether a change attributable to the sole-active dispatch landed since `snapshot` was
+ * taken. Call after `await dispatch(...)` resolves, before that dispatch's own
+ * `activeCount -= 1` runs — the whole point is that THIS dispatch is still the "1"
+ * being measured for every batch that could possibly belong to it.
+ */
+export function violatedSinceSnapshot(state: ReadOnlyGuardState, snapshot: number): boolean {
+  return state.soleActorChangeEvents > snapshot;
+}
+
+/**
+ * The one gate for this whole feature — EXEC_JS only, and only when the caller declared
+ * `--read-only`. A typed mutating command is never expected here at all: the CLI already
+ * refuses `--read-only` on every one of them (`refusesReadOnlyAssertion`,
+ * cli/src/transport/broker-client.ts) before a request carrying both is ever sent — this
+ * gate exists so main.ts's own enforcement stays scoped to EXEC_JS regardless, rather
+ * than trusting that upstream refusal alone.
+ */
+export function isReadOnlyExecJs(cmd: string, readOnly: boolean | undefined): boolean {
+  return cmd === 'EXEC_JS' && readOnly === true;
+}

--- a/plugin/src/main/readonly-guard.ts
+++ b/plugin/src/main/readonly-guard.ts
@@ -1,4 +1,4 @@
-// Read-only EXEC_JS enforcement (issue #38) — attribution for the one command whose
+// Read-only EXEC_JS enforcement — attribution for the one command whose
 // target nodes are never known ahead of time. Pure over injected state, no `figma`, no
 // clock read inside — same shape as edit-actor.ts, and for the same reason: main.ts
 // cannot be imported outside a live plugin sandbox (it calls `figma.showUI` at module

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -253,7 +253,7 @@ async function handleRequest(req: RequestMsg): Promise<void> {
     } else {
       // Everything else is a main-thread op — forward unchanged. `readOnly` is carried
       // through here (never forwarded before this — main.ts never saw it regardless of
-      // what its own `onmessage` read off `msg`, see issue #38) so main can enforce it
+      // what its own `onmessage` read off `msg`) so main can enforce it
       // for EXEC_JS; omitted entirely when unset, the same byte-identical-frame contract
       // every other optional envelope field on `RequestMsg` already follows.
       parent.postMessage({

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -251,9 +251,16 @@ async function handleRequest(req: RequestMsg): Promise<void> {
         },
       }, '*');
     } else {
-      // Everything else is a main-thread op — forward unchanged
+      // Everything else is a main-thread op — forward unchanged. `readOnly` is carried
+      // through here (never forwarded before this — main.ts never saw it regardless of
+      // what its own `onmessage` read off `msg`, see issue #38) so main can enforce it
+      // for EXEC_JS; omitted entirely when unset, the same byte-identical-frame contract
+      // every other optional envelope field on `RequestMsg` already follows.
       parent.postMessage({
-        pluginMessage: { requestId: req.id, cmd: req.cmd, params: req.params, expectedFile: req.expectedFile },
+        pluginMessage: {
+          requestId: req.id, cmd: req.cmd, params: req.params, expectedFile: req.expectedFile,
+          ...(req.readOnly === true && { readOnly: true }),
+        },
       }, '*');
     }
   } catch (err) {

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "66e4719" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "48035be" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "db3c452" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "66e4719" : "dev"}`;
   setInterval(render, 1e3);
   render();
 
@@ -3036,7 +3036,13 @@ code {
         }, "*");
       } else {
         parent.postMessage({
-          pluginMessage: { requestId: req.id, cmd: req.cmd, params: req.params, expectedFile: req.expectedFile }
+          pluginMessage: {
+            requestId: req.id,
+            cmd: req.cmd,
+            params: req.params,
+            expectedFile: req.expectedFile,
+            ...req.readOnly === true && { readOnly: true }
+          }
         }, "*");
       }
     } catch (err) {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -299,7 +299,13 @@ export type ErrorCode =
   // answers E_JOB_EXPIRED instead, because "aged out" and "the broker forgot everything"
   // are different facts for the caller to act on.
   | 'E_JOB_UNKNOWN'
-  | 'E_JOB_EXPIRED';
+  | 'E_JOB_EXPIRED'
+  // Concurrency & jobs — a `--read-only` EXEC_JS detected to have mutated the scene
+  // anyway (issue #38). `readOnly` on the envelope is TRUSTED, NOT ENFORCED at the wire
+  // layer (see `RequestMsg.readOnly`'s own comment): the plugin is the one place that
+  // can actually observe whether the script wrote anything, so this is where the
+  // mis-declaration turns from a silent breach into a refusal.
+  | 'E_READONLY_VIOLATION';
 
 // ── Timeouts (ms) ───────────────────────────────────────────────────
 export const DEFAULT_TIMEOUT_MS = 15_000;

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -301,7 +301,7 @@ export type ErrorCode =
   | 'E_JOB_UNKNOWN'
   | 'E_JOB_EXPIRED'
   // Concurrency & jobs — a `--read-only` EXEC_JS detected to have mutated the scene
-  // anyway (issue #38). `readOnly` on the envelope is TRUSTED, NOT ENFORCED at the wire
+  // anyway. `readOnly` on the envelope is TRUSTED, NOT ENFORCED at the wire
   // layer (see `RequestMsg.readOnly`'s own comment): the plugin is the one place that
   // can actually observe whether the script wrote anything, so this is where the
   // mis-declaration turns from a silent breach into a refusal.

--- a/tests/executor-ops-status.test.ts
+++ b/tests/executor-ops-status.test.ts
@@ -41,3 +41,20 @@ describe('opStatus — bootSkipped (issue #3, absorption phase-03)', () => {
     expect(result.bootSkipped).toEqual(['variables']); // the reply is unaffected
   });
 });
+
+describe('opStatus — readOnlyViolations (issue #38)', () => {
+  it('no argument → the key is OMITTED, keeping the payload byte-identical to before this field existed', () => {
+    installMockFigma();
+    expect('readOnlyViolations' in opStatus()).toBe(false);
+  });
+
+  it('zero → the key is still OMITTED, same "present only once meaningful" contract as bootSkipped/senderMismatchCount', () => {
+    installMockFigma();
+    expect('readOnlyViolations' in opStatus([], 0)).toBe(false);
+  });
+
+  it('a non-zero count surfaces verbatim', () => {
+    installMockFigma();
+    expect(opStatus([], 3).readOnlyViolations).toBe(3);
+  });
+});

--- a/tests/executor-ops-status.test.ts
+++ b/tests/executor-ops-status.test.ts
@@ -42,7 +42,7 @@ describe('opStatus — bootSkipped (issue #3, absorption phase-03)', () => {
   });
 });
 
-describe('opStatus — readOnlyViolations (issue #38)', () => {
+describe('opStatus — readOnlyViolations', () => {
   it('no argument → the key is OMITTED, keeping the payload byte-identical to before this field existed', () => {
     installMockFigma();
     expect('readOnlyViolations' in opStatus()).toBe(false);

--- a/tests/readonly-exec-js-guard.test.ts
+++ b/tests/readonly-exec-js-guard.test.ts
@@ -1,4 +1,4 @@
-// Read-only EXEC_JS enforcement (issue #38) — the SAME wiring main.ts's `onmessage` uses
+// Read-only EXEC_JS enforcement — the SAME wiring main.ts's `onmessage` uses
 // (readonly-guard.ts's snapshot/record/violated trio), driven against REAL `opExecJs`
 // runs instead of synthetic counters, so a genuinely mutating script and a genuinely
 // read-only one are exercised end to end.

--- a/tests/readonly-exec-js-guard.test.ts
+++ b/tests/readonly-exec-js-guard.test.ts
@@ -1,0 +1,84 @@
+// Read-only EXEC_JS enforcement (issue #38) — the SAME wiring main.ts's `onmessage` uses
+// (readonly-guard.ts's snapshot/record/violated trio), driven against REAL `opExecJs`
+// runs instead of synthetic counters, so a genuinely mutating script and a genuinely
+// read-only one are exercised end to end.
+//
+// main.ts itself cannot be imported here (it calls `figma.showUI` at module load — see
+// shared/mutating-commands.ts's comment), so this test patches the mock's `createFrame`
+// to invoke the documentchange callback the instant it mutates — modeling "Figma fires
+// documentchange for a write" directly at the point of the write, rather than firing
+// unconditionally after every script regardless of whether one happened (which would
+// prove nothing about a genuinely read-only script). Figma's OWN internal batching/
+// timing (whether the real host fires documentchange before this dispatch's `await`
+// resolves) cannot be verified in this sandbox — that is a documented residual: this
+// test proves the ATTRIBUTION LOGIC is correct once a batch arrives, not exactly when
+// the real host delivers it.
+import { describe, it, expect, beforeEach } from 'vitest';
+import { installMockFigma } from './helpers/mock-figma.ts';
+import { opExecJs } from '../plugin/src/main/executor-exec-js.ts';
+import {
+  createReadOnlyGuardState, isReadOnlyExecJs, recordDocumentChangeBatch,
+  snapshotChangeEvents, violatedSinceSnapshot,
+} from '../plugin/src/main/readonly-guard.ts';
+
+/** Minimal `figma.commitUndo`/`triggerUndo` stand-ins the shared mock
+ *  (tests/helpers/mock-figma.ts) does not model — that fixture is built for node-tree
+ *  round-trips, not undo bookkeeping. Added directly here since only this feature needs
+ *  them (none of these scripts pass `undoGroup: true`, so they are never actually
+ *  called — present only so a future test that does pass it does not crash on a
+ *  missing method). Then wraps `createFrame` to call `onMutate` at the exact point a
+ *  mutation happens — the mock's stand-in for "Figma fires documentchange for this
+ *  write", scoped to the one creator these tests' scripts use. */
+function wireMutationSignal(onMutate: () => void): void {
+  const figmaGlobal = globalThis as unknown as {
+    figma: { commitUndo: () => void; triggerUndo: () => void; createFrame: () => unknown };
+  };
+  figmaGlobal.figma.commitUndo = () => { /* no undo-group script in these tests */ };
+  figmaGlobal.figma.triggerUndo = () => { /* no undo-group script in these tests */ };
+  const baseCreateFrame = figmaGlobal.figma.createFrame.bind(figmaGlobal.figma);
+  figmaGlobal.figma.createFrame = () => {
+    const node = baseCreateFrame();
+    onMutate();
+    return node;
+  };
+}
+
+describe('read-only EXEC_JS guard — real opExecJs runs', () => {
+  beforeEach(() => {
+    installMockFigma();
+  });
+
+  it('test-first #1: a --read-only EXEC_JS that mutates (creates a node) is flagged', async () => {
+    const state = createReadOnlyGuardState();
+    // Solo dispatch (activeCount === 1 throughout) is main.ts's own contract for when a
+    // batch is attributable — see readonly-guard.ts.
+    wireMutationSignal(() => recordDocumentChangeBatch(state, 1));
+    const enforceReadOnly = isReadOnlyExecJs('EXEC_JS', true);
+    const snapshot = enforceReadOnly ? snapshotChangeEvents(state) : 0;
+
+    await opExecJs({ code: 'figma.createFrame()' });
+
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(true);
+  });
+
+  it('test-first #3: a genuinely read-only exec-js under --read-only succeeds with no violation', async () => {
+    const state = createReadOnlyGuardState();
+    wireMutationSignal(() => recordDocumentChangeBatch(state, 1)); // never invoked below — nothing mutates
+    const snapshot = snapshotChangeEvents(state);
+
+    const result = await opExecJs({ code: 'figma.currentPage.name' });
+
+    expect(result.result).toBe('Page 1'); // the read actually ran and returned a real value
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(false);
+  });
+
+  it('a script that throws before mutating is an eval error, never a false read-only violation', async () => {
+    const state = createReadOnlyGuardState();
+    wireMutationSignal(() => recordDocumentChangeBatch(state, 1));
+    const snapshot = snapshotChangeEvents(state);
+
+    await expect(opExecJs({ code: 'throw new Error("boom")' })).rejects.toThrow('boom');
+
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(false);
+  });
+});

--- a/tests/readonly-guard.test.ts
+++ b/tests/readonly-guard.test.ts
@@ -1,0 +1,88 @@
+// Read-only EXEC_JS enforcement (issue #38) — attribution unit tests. Pure state, no
+// `figma`: main.ts cannot be imported outside a live plugin sandbox (it calls
+// `figma.showUI` at module load — see shared/mutating-commands.ts's own comment), so
+// the load-bearing guarantee below is proven at the level that IS importable: the
+// per-dispatch attribution logic readonly-guard.ts exports.
+import { describe, it, expect } from 'vitest';
+import {
+  createReadOnlyGuardState, isReadOnlyExecJs, recordDocumentChangeBatch,
+  snapshotChangeEvents, violatedSinceSnapshot,
+} from '../plugin/src/main/readonly-guard.ts';
+
+describe('readOnlyExecJsViolated — solo dispatch (test-first #1: a read-only EXEC_JS that mutates)', () => {
+  it('a documentchange batch landing while activeCount === 1 (only this dispatch active) is a violation', () => {
+    const state = createReadOnlyGuardState();
+    const snapshot = snapshotChangeEvents(state); // taken before this dispatch's own `dispatch()` call
+    // The dispatch is the ONLY thing running (activeCount === 1) and its own script
+    // mutates the scene — Figma fires documentchange for that write.
+    recordDocumentChangeBatch(state, 1);
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(true);
+  });
+
+  it('no documentchange at all (test-first #3: a genuinely read-only exec-js) — never flagged', () => {
+    const state = createReadOnlyGuardState();
+    const snapshot = snapshotChangeEvents(state);
+    // Nothing fires: the script only read.
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(false);
+  });
+});
+
+describe('readOnlyExecJsViolated — the concurrency false-positive case (test-first #2, LOAD-BEARING)', () => {
+  it('a read-only read overlapping a SEPARATE legitimate mutation dispatch is NOT flagged', () => {
+    const state = createReadOnlyGuardState();
+
+    // Dispatch B (--read-only EXEC_JS) starts alone: activeCount 0 → 1.
+    const bSnapshot = snapshotChangeEvents(state);
+
+    // While B is still running, a SEPARATE typed mutating dispatch A arrives and starts:
+    // activeCount 1 → 2. A mutates OTHER nodes — its own documentchange fires while
+    // BOTH dispatches are active (activeCount === 2), so it is excluded from the
+    // "solely attributable to one dispatch" count entirely.
+    recordDocumentChangeBatch(state, 2);
+
+    // A finishes: activeCount 2 → 1. B's own script never touched the scene (a genuine
+    // read), so B's dispatch() now resolves with nothing further recorded.
+    expect(violatedSinceSnapshot(state, bSnapshot)).toBe(false);
+  });
+
+  it('the same overlap, but THIS TIME the read-only dispatch itself also mutates — only IT is flagged', () => {
+    const state = createReadOnlyGuardState();
+    const bSnapshot = snapshotChangeEvents(state);
+
+    // Same concurrent legitimate mutation as above (excluded, activeCount === 2).
+    recordDocumentChangeBatch(state, 2);
+    // A drains; now B is sole-active again (activeCount === 1) and B's OWN script
+    // mutates — THIS is attributable to B alone.
+    recordDocumentChangeBatch(state, 1);
+
+    expect(violatedSinceSnapshot(state, bSnapshot)).toBe(true);
+  });
+
+  it('documented residual gap: two undeclared EXEC_JS dispatches racing (activeCount stays 2) cannot be told apart', () => {
+    const state = createReadOnlyGuardState();
+    const snapshot = snapshotChangeEvents(state);
+    // Two EXEC_JS calls overlap the whole time (activeCount never drops to 1) — one of
+    // them mutates. Neither dispatch's own window ever sees activeCount === 1, so this
+    // module — by design — records nothing attributable to either. A false NEGATIVE,
+    // never a false POSITIVE; see readonly-guard.ts's header for why that trade is
+    // deliberate.
+    recordDocumentChangeBatch(state, 2);
+    expect(violatedSinceSnapshot(state, snapshot)).toBe(false);
+  });
+});
+
+describe('isReadOnlyExecJs — scope gate (EXEC_JS only; never re-gates typed commands)', () => {
+  it('true only for EXEC_JS with readOnly === true', () => {
+    expect(isReadOnlyExecJs('EXEC_JS', true)).toBe(true);
+  });
+
+  it('false for EXEC_JS without readOnly', () => {
+    expect(isReadOnlyExecJs('EXEC_JS', undefined)).toBe(false);
+    expect(isReadOnlyExecJs('EXEC_JS', false)).toBe(false);
+  });
+
+  it('false for a typed mutating command even if readOnly were somehow true — never re-gated here', () => {
+    expect(isReadOnlyExecJs('SET_TEXT', true)).toBe(false);
+    expect(isReadOnlyExecJs('CREATE_FRAME', true)).toBe(false);
+  });
+});

--- a/tests/readonly-guard.test.ts
+++ b/tests/readonly-guard.test.ts
@@ -1,4 +1,4 @@
-// Read-only EXEC_JS enforcement (issue #38) — attribution unit tests. Pure state, no
+// Read-only EXEC_JS enforcement — attribution unit tests. Pure state, no
 // `figma`: main.ts cannot be imported outside a live plugin sandbox (it calls
 // `figma.showUI` at module load — see shared/mutating-commands.ts's own comment), so
 // the load-bearing guarantee below is proven at the level that IS importable: the


### PR DESCRIPTION
## The silent breach

`--read-only` skips the per-file mutation queue so a read can run while a mutation for
the same file is in flight. Every typed mutating command already refuses `--read-only`
(`refusesReadOnlyAssertion`, `cli/src/transport/broker-client.ts`) — except `EXEC_JS`,
whose script the broker can't statically inspect. So a mis-declared `--read-only`
`EXEC_JS` was the one path where a "read" could still write: it skipped the queue and
could interleave with a running mutation in the same plugin instance, with nothing to
show for it afterward.

## Scope

EXEC_JS only — the only command this hole could ever apply to. Typed commands are
untouched.

## The attribution problem (and why a naive check is wrong)

The plugin's `onmessage` handler can have two dispatches in flight at once (interleaved
at `await` points). A check like "any `documentchange` event during this read →
violation" sounds right but isn't: it would blame a read-only read for a *separate*,
legitimate mutation that happens to be running concurrently on other nodes — turning
every overlapping read into a false refusal. That's worse than the silent gap it
replaces.

The six typed mutating commands avoid this by declaring their target node ids *before*
they run (`beginAgentMutation`/`declaredIds`), so a change on a declared id during that
window is unambiguously theirs. `EXEC_JS` can't do this — it's an opaque script that
might touch anything, so there's no id to pre-declare.

What every dispatch DOES have is `activeCount` — how many requests this plugin instance
currently has in flight. The fix: a `documentchange` batch is only ever counted as
attributable to *a* dispatch when `activeCount === 1` at the moment it lands. If exactly
one dispatch is active, that dispatch is provably the only thing that could have caused
it. A concurrent, separate mutation (`activeCount` at 2+) is excluded from consideration
entirely — its own documentchange never gets attributed to anyone else's read.

This is intentionally coarser than per-node attribution, and it accepts a real, narrow
residual gap: two undeclared `EXEC_JS` calls racing each other (one `--read-only`, one
genuinely mutating) can't be told apart by this signal — `activeCount` never drops to 1
during their overlap, so neither gets flagged for that window. That's a false *negative*,
never a false *positive*, and is documented in `plugin/src/main/readonly-guard.ts`.

## What changed

- `plugin/src/main/readonly-guard.ts` (new) — the pure attribution state machine above,
  no `figma` dependency (mirrors `edit-actor.ts`'s own reasoning for why: `main.ts` can't
  be imported outside a live plugin sandbox, so the part worth trusting has to be
  testable without one).
- `plugin/src/main/main.ts` — wires the guard into `onDocumentChange` and the request
  dispatch loop; a violating `--read-only` `EXEC_JS` now replies `E_READONLY_VIOLATION`
  instead of applying silently; `readOnlyViolations` counter added, surfaced via STATUS.
- `plugin/src/ui/ui-relay.ts` — **anchor-drift fix**: `RequestMsg.readOnly` was already on
  the wire protocol, but the UI relay's `handleRequest` never forwarded it into the
  `postMessage` sent to main — so main would never have seen the flag at all regardless
  of anything done in `main.ts`. Fixed alongside the rest of this change; noting it here
  since the original scope only named `main.ts`.
- `shared/protocol.ts` — new `E_READONLY_VIOLATION` error code.
- `plugin/src/main/executor-ops.ts` — `opStatus` takes an optional `readOnlyViolations`
  count, omitted from the payload when zero (same "present only once meaningful"
  contract as `bootSkipped`/the broker's `senderMismatchCount`).

## Test-first

Wrote `tests/readonly-guard.test.ts` and `tests/readonly-exec-js-guard.test.ts` before
implementing `readonly-guard.ts`'s real logic, then verified the load-bearing
concurrency test actually goes red against the naive, spec-forbidden design ("any
documentchange while busy → violation") before implementing the `activeCount === 1`
attribution — confirmed 2 failures on that naive version, both passing once the real
per-dispatch check replaced it.

- `tests/readonly-guard.test.ts` — pure attribution logic, including the load-bearing
  case: a `--read-only` read overlapping a separate declared mutation is never flagged;
  only a dispatch that mutates while it is the sole active one is.
- `tests/readonly-exec-js-guard.test.ts` — the same wiring driven against real
  `opExecJs` runs (a script that actually calls `figma.createFrame()` vs. one that only
  reads), rather than synthetic counters.
- `tests/executor-ops-status.test.ts` — `readOnlyViolations` presence/omission in STATUS.

Both `npm run typecheck` and `npm run build` pass. The full suite was intentionally not
run in this environment (a live plugin session was connected and a broker-spawning test
harness would have polluted its discovery) — the touched/new test files above were run
directly and pass.

## Rollback (open question, resolved as: defer)

A detected violation means the script already mutated. This PR is v1: detect, refuse,
count — never a silent apply. The leaked mutation is still sealed into its own undo step
via the existing commit-on-failure path (`EXEC_JS` is in `MUTATING_COMMANDS`), so a
designer can revert it with one manual undo. Automatic rollback beyond that didn't fall
out cleanly from the existing `--undo-group` sentinel machinery without adding real risk
(the sentinel bracket is opt-in per call, not universal), so it's deferred rather than
built here.

## Deferred

A broker-spawning integration test (plugin ↔ real broker, `--read-only` end to end) was
explicitly out of scope for this environment per the task constraints — left for the
orchestrator to run separately, not included in this PR.