### PR TITLE
Refuse --force-release on a healthy running job unless --force

### DIFF
--- a/cli/src/commands/job.ts
+++ b/cli/src/commands/job.ts
@@ -8,6 +8,8 @@
 //   figma-agent job --list [--file <name>]
 //   figma-agent job <jobId> --cancel            (queued only)
 //   figma-agent job <jobId> --force-release     (unblock a file a wedged script still holds)
+//   figma-agent job <jobId> --force-release --force  (override a HEALTHY still-running job;
+//                                                      discards its result, unverified)
 import type { CommandArgs } from '../figma-agent.ts';
 import type { JobInfo } from '../../../shared/protocol.ts';
 import { CliError, ChunkAssembler, isChunkMsg, parseWireMsg } from '../transport/protocol-helpers.ts';
@@ -148,9 +150,18 @@ export async function run(args: CommandArgs): Promise<unknown> {
   // broker's own refusal reason states that plainly rather than promising a future flag.
   if (args.bool('cancel')) return runCommand('JOB', { mode: 'cancel', jobId });
 
-  // The audited exit from a BLOCKED mutation slot (phase 01's watchdog leaves it held on
-  // purpose) — never automatic.
-  if (args.bool('force-release')) return runCommand('JOB', { mode: 'force-release', jobId });
+  // The audited exit from a BLOCKED mutation slot (the watchdog leaves it held on
+  // purpose) — never automatic. A HEALTHY still-running job is refused unless `--force`
+  // is also passed (the daemon discards its result, unverified); a watchdog-wedged job
+  // keeps unwedging with a bare `--force-release`, no `--force` needed. `activity` labels
+  // this request in the daemon's audit log — who force-released what, and why.
+  if (args.bool('force-release')) {
+    return runCommand(
+      'JOB',
+      { mode: 'force-release', jobId, override: args.bool('force') },
+      { activity: `Force-release · ${jobId}` },
+    );
+  }
 
   if (args.bool('wait')) {
     const waitTimeoutMs = args.num('wait-timeout') ?? DEFAULT_WAIT_TIMEOUT_MS;

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -82,8 +82,11 @@ Commands:
   get-selection        Serialize the current selection [--depth 1]
   inspect              [nodeId|--node id] [--out file.png --scale 1 --timeout ms]
   job                  <jobId> [--wait] [--wait-timeout 60000] | --list [--file name] |
-                       <jobId> --cancel (queued only) | <jobId> --force-release
+                       <jobId> --cancel (queued only) | <jobId> --force-release [--force]
                        poll/wait/cancel/list a job the CLI stopped waiting for (backlog 1.1+2.6+4.3)
+                       --force-release refuses a HEALTHY still-running job unless --force is
+                       also passed — --force overrides the guard and discards its result,
+                       unverified; a watchdog-wedged job still unwedges without --force
   scan-design-system   Components/variables/styles registry [--out file.json --timeout ms]
   scan-node            [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
   mirror-verify        Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -41,7 +41,7 @@ import {
   resolveProjectDir, writeBindCache, writeBindMarker, type Binding,
 } from './project-bind.ts';
 import {
-  JobTable, isFinishedState, isReplyFromDispatchedInstance, toJobInfo, type JobRecord,
+  JobTable, isFinishedState, isHealthyRunningJob, isReplyFromDispatchedInstance, toJobInfo, type JobRecord,
 } from './job-table.ts';
 import {
   completeSkippingStale, emptyQueue, enqueue as enqueueJob, queuePosition, remove as removeFromQueue,
@@ -221,6 +221,20 @@ function sendReplyOk(ws: WebSocket, id: string, result: unknown): void {
   try {
     if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(reply));
   } catch { /* client already gone */ }
+}
+
+/**
+ * The audit line for every force-release (allowed-wedged or `--force` override) — pure
+ * string construction, exported so the "audit log names the requester" invariant is
+ * unit-testable without a live broker. Never silent: `activity` is the label the JOB
+ * command's own request carried, falling back to an explicit "unlabeled request" rather
+ * than omitting the requester entirely when a caller didn't set one.
+ */
+export function buildForceReleaseAuditLine(
+  jobId: string, cmd: string, fileSlug: string, override: boolean, activity: string | undefined,
+): string {
+  const requester = activity ?? 'unlabeled request';
+  return `job ${jobId} (${cmd}) force-released${override ? ' via --force override' : ''} — requested by "${requester}" — "${fileSlug}"'s mutation slot freed; any later reply from that script is discarded`;
 }
 
 /**
@@ -987,7 +1001,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    * it RELAYS; a request addressed TO the broker is not a request being relayed.
    */
   const handleJobCommand = (ws: WebSocket, msg: RequestMsg): void => {
-    const params = msg.params as { mode?: unknown; jobId?: unknown; file?: unknown } | null;
+    const params = msg.params as { mode?: unknown; jobId?: unknown; file?: unknown; override?: unknown } | null;
     const mode = typeof params?.mode === 'string' ? params.mode : 'poll';
     const jobId = typeof params?.jobId === 'string' ? params.jobId : undefined;
 
@@ -1029,6 +1043,22 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         sendReplyOk(ws, msg.id, { ok: false, reason: `job '${jobId}' is not the one blocking "${rec.fileSlug}"'s mutation slot` });
         return;
       }
+      // A healthy still-running job (the watchdog has not declared it wedged) is refused
+      // unless the requester passes `--force`: freeing its slot while its script may still
+      // be mid-mutation lets the NEXT queued mutation dispatch into the same file while the
+      // first is still executing — genuinely concurrent writes. A watchdog-wedged job
+      // (`state !== 'running'`, because the watchdog already called `finish()`) is not
+      // healthy and keeps unwedging with a bare `--force-release`, exactly as before.
+      const now = Date.now();
+      const override = params?.override === true;
+      if (isHealthyRunningJob(rec, now, WATCHDOG_TIMEOUT_MS) && !override) {
+        const elapsedS = Math.floor((now - (rec.startedAt ?? now)) / 1000);
+        sendReplyOk(ws, msg.id, {
+          ok: false,
+          reason: `job '${jobId}' is still running (${elapsedS}s, watchdog fires at ${Math.floor(WATCHDOG_TIMEOUT_MS / 1000)}s) — its script may be mid-mutation. Wait for the watchdog to declare it wedged, or re-run with --force to override (its result will be discarded, unverified).`,
+        });
+        return;
+      }
       // The audited exit from a BLOCKED slot (phase 01's watchdog leaves it held on
       // purpose): record the override on the job, finish it for reporting if it was
       // still `running` (the watchdog may not have fired yet), then advance the queue —
@@ -1046,7 +1076,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.pending.delete(rec.requestId);
       st.dispatchedTo.delete(rec.requestId);
       advanceQueue(rec);
-      log(`job ${jobId} (${rec.cmd}) force-released — "${rec.fileSlug}"'s mutation slot freed; any later reply from that script is discarded`);
+      // Audited: every force-release (allowed-wedged or `--force` override) logs WHO asked
+      // and WHY, never silently — the requester's own `activity` label on this request.
+      log(buildForceReleaseAuditLine(jobId, rec.cmd, rec.fileSlug, override, msg.activity));
       sendReplyOk(ws, msg.id, { ok: true });
       return;
     }

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -29,6 +29,22 @@ export function isFinishedState(state: JobInfo['state']): boolean {
 }
 
 /**
+ * Whether a job is a HEALTHY, still-running slot holder — the watchdog has not (yet)
+ * declared it wedged. A job the watchdog already timed out has `state !== 'running'`
+ * (the watchdog calls `finish()`) even though it may still hold its file's mutation
+ * slot; that job is NOT healthy, and force-releasing it is the legitimate unwedge path.
+ * Only a job still genuinely `running`, with a `startedAt` inside the watchdog window,
+ * counts as healthy — the one case `job --force-release` (without `--force`) must refuse.
+ */
+export function isHealthyRunningJob(
+  job: Pick<JobRecord, 'state' | 'startedAt'>,
+  now: number,
+  watchdogTimeoutMs: number,
+): boolean {
+  return job.state === 'running' && job.startedAt !== undefined && now - job.startedAt < watchdogTimeoutMs;
+}
+
+/**
  * Sender verification (backlog 2.10) — whether a reply frame's ACTUAL sender is the
  * plugin instance a job was dispatched to. `routeFromPlugin` (broker-daemon.ts) used to
  * accept a reply keyed on `id` alone: it never checked which socket sent it against

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -819,3 +819,104 @@ describe('daemon harness — admitRequest with an `--instance` (expectedInstance
     expect(framesA.frames.some((f) => (f as { id?: string }).id === reqId)).toBe(false);
   });
 });
+
+// `job --force-release` guard (a HEALTHY still-running job is refused unless `--force`
+// overrides it; a watchdog-wedged job keeps unwedging with a bare `--force-release`). NOT
+// run by the executor: this harness spawns a real in-process broker via `runBrokerDaemon`,
+// and per the assigned constraint on this machine a live plugin session is connected and
+// this harness pollutes its broker discovery (issue #32) — written here (the one file that
+// exercises the real `handleJobCommand`/`advanceQueue` closures) and left for the
+// orchestrator to run post-smoke.
+describe('daemon harness — force-release refuses a HEALTHY running job, allows `--force`, never regresses the wedged-unwedge path', () => {
+  it('a bare `--force-release` on a job still `running` inside the watchdog window is REFUSED — the slot stays held, nothing advances', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-fr1', 'FFR1');
+    const pluginFrames = collectFrames(plugin);
+
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-fr1-a'); // dispatched immediately — RUNNING
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr1-a'));
+
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-fr1-b'); // QUEUED behind job A — plugin still busy
+
+    cliA.send(JSON.stringify(makeRequestFrame('req-fr1-release', 'JOB', { mode: 'force-release', jobId: jobA })));
+    const reply = await nextFrame<ReplyOk>(cliA, (m) => (m as ReplyOk).id === 'req-fr1-release');
+    expect(reply.ok).toBe(true); // the ENVELOPE always replies ok — the refusal is IN the result
+    const result = reply.result as { ok: boolean; reason?: string };
+    expect(result.ok).toBe(false);
+    expect(result.reason).toContain('still running');
+    expect(result.reason).toContain('--force');
+
+    // The slot was never freed — job A is still `running`, job B is still `queued`
+    // (never dispatched), and the plugin received exactly ONE request frame (job A's).
+    const polledA = await pollJob(cliA, jobA, 'req-fr1-poll-a');
+    expect(polledA.job.state).toBe('running');
+    const polledB = await pollJob(cliB, jobB, 'req-fr1-poll-b');
+    expect(polledB.job.state).toBe('queued');
+    const requestFrames = pluginFrames.frames.filter((f) => 'cmd' in (f as Record<string, unknown>));
+    expect(requestFrames).toHaveLength(1);
+    expect((requestFrames[0] as { id: string }).id).toBe('req-fr1-a');
+  });
+
+  it('`--force-release` + `override:true` (the CLI\'s `--force`) overrides the guard — the slot frees, the queued job advances, its result is discarded', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-fr2', 'FFR2');
+    const pluginFrames = collectFrames(plugin);
+
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-fr2-a');
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr2-a'));
+
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-fr2-b'); // QUEUED behind job A
+
+    cliA.send(JSON.stringify(
+      makeRequestFrame('req-fr2-release', 'JOB', { mode: 'force-release', jobId: jobA, override: true }, 'Force-release · override'),
+    ));
+    const reply = await nextFrame<ReplyOk>(cliA, (m) => (m as ReplyOk).id === 'req-fr2-release');
+    expect(reply.ok).toBe(true);
+    expect((reply.result as { ok: boolean }).ok).toBe(true);
+
+    // Job A's own outcome is now terminal (its running result is discarded/unverified),
+    // and job B — previously queued — was dispatched to the plugin.
+    const polledA = await pollJob(cliA, jobA, 'req-fr2-poll-a');
+    expect(polledA.job.state).toBe('failed');
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr2-b'));
+    const polledB = await pollJob(cliB, jobB, 'req-fr2-poll-b');
+    expect(polledB.job.state).toBe('running');
+  });
+
+  it('regression: a watchdog-wedged job (state !== "running") still force-releases with a BARE `--force-release`, no `--force` needed', async () => {
+    const port = await startTestBroker({ [WATCHDOG_MS_KEY]: '150' }); // real watchdog, shrunk
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-fr3', 'FFR3');
+    const pluginFrames = collectFrames(plugin);
+
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-fr3-a');
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr3-a'));
+    // Plugin stays silent — the watchdog (min cadence 1s regardless of how small
+    // WATCHDOG_TIMEOUT_MS is set) declares job A wedged, `state` flips to 'failed', but
+    // the slot stays held on purpose (broker-daemon.ts's own watchdog comment).
+    let seq = 0;
+    await waitFor(async () => {
+      const p = await pollJob(cliA, jobA, `req-fr3-poll-${seq++}`);
+      return p.job.state === 'failed';
+    }, 5_000, 150);
+
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-fr3-b'); // QUEUED — slot still held by wedged job A
+
+    cliA.send(JSON.stringify(makeRequestFrame('req-fr3-release', 'JOB', { mode: 'force-release', jobId: jobA })));
+    const reply = await nextFrame<ReplyOk>(cliA, (m) => (m as ReplyOk).id === 'req-fr3-release');
+    expect(reply.ok).toBe(true);
+    expect((reply.result as { ok: boolean }).ok).toBe(true); // allowed WITHOUT --force — the legitimate unwedge path, unregressed
+
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr3-b'));
+    const polledB = await pollJob(cliB, jobB, 'req-fr3-poll-b');
+    expect(polledB.job.state).toBe('running');
+  });
+});

--- a/tests/force-release-guard.test.ts
+++ b/tests/force-release-guard.test.ts
@@ -1,0 +1,30 @@
+// The force-release guard: a HEALTHY still-running job is refused unless the requester
+// passes `--force`; a watchdog-wedged job keeps unwedging with a bare `--force-release`.
+// Pure logic only — `buildForceReleaseAuditLine` is exported from broker-daemon.ts
+// specifically so the "every force-release is audited with the requester's activity"
+// invariant is unit-testable without a live broker; the full handler wiring (queue
+// mechanics, advanceQueue) is exercised by the daemon harness (tests/broker-daemon-
+// harness.test.ts) instead, since it needs the real closures.
+import { describe, expect, it } from 'vitest';
+import { buildForceReleaseAuditLine } from '../cli/src/transport/broker-daemon.ts';
+
+describe('buildForceReleaseAuditLine — the requester is never silent', () => {
+  it('includes the requester\'s activity label', () => {
+    const line = buildForceReleaseAuditLine('j_1_1', 'EXEC_JS', 'fileA', false, 'Force-release · j_1_1');
+    expect(line).toContain('Force-release · j_1_1');
+    expect(line).toContain('j_1_1');
+    expect(line).toContain('fileA');
+  });
+
+  it('an unlabeled request still names itself explicitly, never omitted', () => {
+    const line = buildForceReleaseAuditLine('j_1_1', 'EXEC_JS', 'fileA', false, undefined);
+    expect(line).toContain('unlabeled request');
+  });
+
+  it('marks a `--force` override distinctly from a bare (wedged-unwedge) force-release', () => {
+    const overridden = buildForceReleaseAuditLine('j_1_1', 'EXEC_JS', 'fileA', true, 'Force-release · j_1_1');
+    const bare = buildForceReleaseAuditLine('j_1_1', 'EXEC_JS', 'fileA', false, 'Force-release · j_1_1');
+    expect(overridden).toContain('--force override');
+    expect(bare).not.toContain('--force override');
+  });
+});

--- a/tests/job-command.test.ts
+++ b/tests/job-command.test.ts
@@ -2,7 +2,16 @@
 // logic: unwrapping a finished job's stored reply, formatting a poll, and the `--wait`
 // cadence/timeout composition (injected poll/wait so no live broker is needed).
 import { describe, expect, it, vi } from 'vitest';
-import { formatPoll, isTerminal, unwrapResult, waitForJob, type PollReply } from '../cli/src/commands/job.ts';
+
+// `runCommand` (the broker round trip) is mocked for the `--force-release`/`--force`
+// wiring tests below — everything under test there is `run()`'s own param/opts
+// composition, not the transport. The rest of this file never calls the real
+// implementation either (`waitForJob`'s tests inject their own poll/wait).
+vi.mock('../cli/src/transport/broker-client.ts', () => ({ runCommand: vi.fn() }));
+
+import { formatPoll, isTerminal, run, unwrapResult, waitForJob, type PollReply } from '../cli/src/commands/job.ts';
+import { runCommand } from '../cli/src/transport/broker-client.ts';
+import { parseArgs } from '../cli/src/arg-parse.ts';
 import { CliError } from '../cli/src/transport/protocol-helpers.ts';
 import type { JobInfo } from '../shared/protocol.ts';
 
@@ -158,5 +167,40 @@ describe('waitForJob — cadence + timeout composition (injected poll/wait, no l
     } finally {
       Date.now = realNow;
     }
+  });
+});
+
+describe('run — `--force-release` wiring (guard override + audit activity)', () => {
+  it('a bare `--force-release` sends override:false, never omitting the flag', async () => {
+    const mocked = vi.mocked(runCommand);
+    mocked.mockClear();
+    mocked.mockResolvedValue({ ok: true });
+    await run(parseArgs(['j_1_1', '--force-release']));
+    expect(mocked).toHaveBeenCalledWith(
+      'JOB',
+      { mode: 'force-release', jobId: 'j_1_1', override: false },
+      { activity: 'Force-release · j_1_1' },
+    );
+  });
+
+  it('`--force-release --force` sends override:true — the healthy-job guard override', async () => {
+    const mocked = vi.mocked(runCommand);
+    mocked.mockClear();
+    mocked.mockResolvedValue({ ok: true });
+    await run(parseArgs(['j_1_1', '--force-release', '--force']));
+    expect(mocked).toHaveBeenCalledWith(
+      'JOB',
+      { mode: 'force-release', jobId: 'j_1_1', override: true },
+      { activity: 'Force-release · j_1_1' },
+    );
+  });
+
+  it('the audit activity names the jobId, never a generic unlabeled call', async () => {
+    const mocked = vi.mocked(runCommand);
+    mocked.mockClear();
+    mocked.mockResolvedValue({ ok: true });
+    await run(parseArgs(['j_9_9', '--force-release']));
+    const [, , opts] = mocked.mock.calls[0]!;
+    expect((opts as { activity?: string }).activity).toBe('Force-release · j_9_9');
   });
 });

--- a/tests/job-table.test.ts
+++ b/tests/job-table.test.ts
@@ -3,7 +3,7 @@
 // without a socket or a real timer.
 import { describe, expect, it } from 'vitest';
 import {
-  JobTable, JOB_TTL_MS, JOB_FINISHED_CAP, JOB_FRAME_BYTES_CAP,
+  JobTable, JOB_TTL_MS, JOB_FINISHED_CAP, JOB_FRAME_BYTES_CAP, isHealthyRunningJob,
   type CreateJobInput,
 } from '../cli/src/transport/job-table.ts';
 
@@ -323,5 +323,27 @@ describe('JobTable — list (`figma-agent job --list`, phase 02 §2)', () => {
     const t = new JobTable();
     t.create(input({ requestId: 'a' }));
     for (const job of t.list()) expect('from' in job).toBe(false);
+  });
+});
+
+describe('isHealthyRunningJob — the force-release guard predicate', () => {
+  const WATCHDOG_TIMEOUT_MS = 1_000;
+
+  it('a running job started just now, inside the watchdog window, is healthy', () => {
+    expect(isHealthyRunningJob({ state: 'running', startedAt: 500 }, 500, WATCHDOG_TIMEOUT_MS)).toBe(true);
+    expect(isHealthyRunningJob({ state: 'running', startedAt: 500 }, 999, WATCHDOG_TIMEOUT_MS)).toBe(true);
+  });
+
+  it('a running job at/past the watchdog window is NOT healthy — the watchdog is about to (or already did) fire', () => {
+    expect(isHealthyRunningJob({ state: 'running', startedAt: 500 }, 1500, WATCHDOG_TIMEOUT_MS)).toBe(false);
+  });
+
+  it('a watchdog-wedged job (state !== "running") is NOT healthy even with a recent startedAt — the legitimate unwedge target', () => {
+    expect(isHealthyRunningJob({ state: 'failed', startedAt: 500 }, 600, WATCHDOG_TIMEOUT_MS)).toBe(false);
+    expect(isHealthyRunningJob({ state: 'queued', startedAt: undefined }, 600, WATCHDOG_TIMEOUT_MS)).toBe(false);
+  });
+
+  it('a "running" job with no startedAt is NOT healthy — nothing to measure elapsed time against', () => {
+    expect(isHealthyRunningJob({ state: 'running', startedAt: undefined }, 600, WATCHDOG_TIMEOUT_MS)).toBe(false);
   });
 });


### PR DESCRIPTION
## The hole

`figma-agent job <id> --force-release` freed ANY slot-holding job as long as it was the
current slot holder — it never checked whether the job was still healthily running. An
impatient caller could free another job's slot while its script was still mid-mutation,
letting the next queued mutation dispatch into the same file while the first was still
executing: genuinely concurrent writes to one file.

## The health signal (already in the code)

The watchdog marks a job `state !== 'running'` once it declares the job wedged (no reply
within the watchdog window) — the slot stays held on purpose so the caller can still
force-release it. That's the whole distinction: a job is "healthy" only while
`state === 'running'` AND its elapsed time is still inside the watchdog window.

## The fix

- `cli/src/transport/job-table.ts` — a pure `isHealthyRunningJob(job, now, watchdogTimeoutMs)`
  predicate, unit-tested directly.
- `cli/src/transport/broker-daemon.ts` — the force-release handler now refuses a healthy
  job unless the request carries `override: true`; a wedged job is unaffected. Every
  force-release (wedged or `--force` override) now logs the requester's `activity` label
  via a new pure `buildForceReleaseAuditLine` helper — no force-release is silent anymore.
- `cli/src/commands/job.ts` — `--force-release` now threads `override: args.bool('force')`
  and labels the request `Force-release · <jobId>` for the audit log.
- `cli/src/figma-agent.ts` — `job` help block documents `--force`.

## Test-first

- `tests/job-table.test.ts` — `isHealthyRunningJob` unit tests (red before the predicate
  existed; the daemon had no health check at all).
- `tests/force-release-guard.test.ts` — the audit-line builder always names the requester.
- `tests/job-command.test.ts` — `run()` threads `override`/`activity` into `runCommand`
  correctly for both a bare `--force-release` and `--force-release --force`.
- `tests/broker-daemon-harness.test.ts` — three end-to-end cases against the real
  `handleJobCommand`/`advanceQueue` closures: (1) a healthy running job is refused, slot
  stays held, nothing advances; (2) the same job with `--force` proceeds, the queued job
  advances; (3) regression — a watchdog-wedged job still force-releases with a bare
  `--force-release`, unchanged. **Not run in this session** — this machine has a live
  Figma plugin connected and this harness's own daemon log write isn't scratch-redirected
  (issue #32), matching the file's own existing precedent for its `--instance` tests a few
  lines above. `vitest list` confirms all three collect cleanly with no syntax/import
  errors; left for a machine without a live session (or CI) to execute.

## Gate tails

- `npm run typecheck` — pass, clean.
- `npm run build` — pass (both bundles built).
- `npx vitest run tests/job-table.test.ts tests/force-release-guard.test.ts tests/job-command.test.ts` — 53/53 pass.

## Deferred

The 3 harness-based force-release tests are written but not executed here — see above.
