### PR TITLE
Refuse design-file-only ui.* commands cleanly outside Figma

### DIFF
--- a/knowledge/figjam.md
+++ b/knowledge/figjam.md
@@ -41,30 +41,49 @@ Audited, not assumed: the bar is "would raw-throw a confusing platform error, or
 fabricate/mutate wrongly" — a helper that already refuses cleanly via its own
 existing type check does NOT need a new guard.
 
-- **`ui.componentSet` / `ui.slot.*` — already safe.** `figma.createComponent()` /
-  `figma.combineAsVariants()` ARE documented `"Note: This API is only available in
-  Figma Design"` in the typings, but every call site (`exec-stdlib-component-build.ts`,
-  `exec-stdlib-slot.ts`) checks `node.type !== 'COMPONENT'` on every input BEFORE
-  reaching those APIs — since no FigJam node can ever be type `COMPONENT`, that check
-  always fires first, with an already-clear message. The raw Figma-Design-only API is
-  never reached with a bad type.
-- **`ui.setProps` — already safe.** Explicit `inst.type !== 'INSTANCE'` check before
-  any INSTANCE-only call.
-- **`ui.swapInstance` — the one real gap, fixed generally, not with an editor guard.**
-  Had NO type check on `inst` at all — a caller passing any non-INSTANCE node hit a
-  raw, uncoded platform error (`in swapComponent: node is not an instance`). This
-  pre-dates FigJam (already reachable in a design file with e.g. a FRAME); FigJam just
-  makes it far more likely. Fixed with the same `inst.type !== 'INSTANCE'` check
-  `setProps` already had — a general fix, not an editor guard, since an editor guard
-  would leave the same hole open for a wrong-type node in Figma itself.
-- **`ui.annotate.*` — already safe.** `get`/`set` gate via `requireAnnotatable`'s
-  `'annotations' in node` check first; `categories()`'s only call to the file-level
-  `figma.annotations.getAnnotationCategoriesAsync()` is already wrapped in try/catch →
-  clean `E_EVAL` (issue #2's own BLOCKER 1 fix). Whether annotations are actually
-  available in FigJam at all is `[re-verify]` — no editor-type note found in the
-  typings either way.
-- **`ui.vars.*` — likely already safe, `[re-verify]`.** Variable CRUD operates
-  entirely through `figma.variables.*` (document-level, not node-type-dependent) — no
+**Update — a second pass front-loaded a clean refusal ahead of the type checks
+below.** "Already safe" (below) meant non-crashing, not clean: a caller in FigJam
+still saw a raw `not found: X` once a bogus id failed the type check, which reads
+like a bad id rather than "wrong editor". `ui.componentSet`, `ui.slot.*` (create/
+list/append/reset/addProperty), `ui.setProps`, and `ui.swapInstance` now each call
+`requireDesignFile(capability)` (`exec-stdlib-editor.ts`) as their FIRST line —
+before any arg validation or node lookup — so the refusal names the capability, the
+wrong editor, and the fix, the same shape `ui.figjam.*`'s own forward guard uses.
+The type checks below are unchanged and still guard the orthogonal bug they always
+did (a wrong-type node passed IN Figma itself, where the new gate is a no-op).
+
+- **`ui.componentSet` / `ui.slot.*` — gated, on top of the existing type checks.**
+  `figma.createComponent()` / `figma.combineAsVariants()` ARE documented `"Note:
+  This API is only available in Figma Design"` in the typings, but every call site
+  (`exec-stdlib-component-build.ts`, `exec-stdlib-slot.ts`) also checks
+  `node.type !== 'COMPONENT'` on every input BEFORE reaching those APIs — since no
+  FigJam node can ever be type `COMPONENT`, that check always fires, with an
+  already-clear message. Both checks now run: the design-file gate first, the type
+  check as a second line of defense.
+- **`ui.setProps` — gated, on top of the existing type check.** Explicit
+  `inst.type !== 'INSTANCE'` check still runs before any INSTANCE-only call.
+- **`ui.swapInstance` — gated, on top of the general fix.** Had NO type check on
+  `inst` at all — a caller passing any non-INSTANCE node hit a raw, uncoded platform
+  error (`in swapComponent: node is not an instance`). This pre-dates FigJam
+  (already reachable in a design file with e.g. a FRAME); FigJam just makes it far
+  more likely. Fixed with the same `inst.type !== 'INSTANCE'` check `setProps`
+  already had — a general fix, not an editor guard, since an editor guard alone
+  would leave the same hole open for a wrong-type node in Figma itself. The new
+  design-file gate is additive, not a replacement for that fix.
+- **`ui.annotate.*` — deliberately left ungated.** `get`/`set` gate via
+  `requireAnnotatable`'s `'annotations' in node` check first; `categories()`'s only
+  call to the file-level `figma.annotations.getAnnotationCategoriesAsync()` is
+  already wrapped in try/catch → clean `E_EVAL`. Checked again for the design-file
+  gate specifically: `AnnotationsMixin` (per `@figma/plugin-typings`) is implemented
+  by base shape/text node types (`RECTANGLE`, `TEXT`, `VECTOR`, …) that also exist
+  in FigJam, and neither `AnnotationsAPI` nor `setBoundVariable`-adjacent APIs carry
+  a "Figma Design only" note anywhere in the typings (unlike `createComponent`/
+  `combineAsVariants`, which do). Gating this would risk refusing a legitimate FigJam
+  annotation read/write — an over-gating regression, not a fix. Still `[re-verify]`
+  on a live canvas either way.
+- **`ui.vars.*` — deliberately left ungated, same reasoning as `ui.annotate.*`.**
+  Variable CRUD operates entirely through `figma.variables.*` (document-level, not
+  node-type-dependent) — no
   "wrong node type" risk applies. No editor-scoping note found in `VariablesAPI`'s
   typings either.
 

--- a/knowledge/slides.md
+++ b/knowledge/slides.md
@@ -57,15 +57,28 @@ The bar: a helper needs a Slides refusal if it would raw-throw a confusing platf
 error or fabricate/mutate wrongly in a Slides deck; one that already refuses cleanly
 via its own type check does not need a new guard.
 
-- **`ui.componentSet` / `ui.slot.*` / `ui.setProps` / `ui.swapInstance` — already
-  safe, same reasoning as FigJam.** No `SLIDE` node is ever type `COMPONENT` or
-  `INSTANCE`, so the existing type-checks (not editor-specific, just type-specific)
-  fire first regardless of which non-design editor is open.
-- **`ui.annotate.*` / `ui.vars.*` — `[re-verify]`, checked fresh for Slides, not
-  assumed identical to FigJam.** Searched official docs and typings-adjacent sources
-  specifically for Slides + annotations/variables availability — found nothing
-  confirming or denying either way. Same unverified status as FigJam; do not assert
-  availability that was not confirmed.
+**Update — the same front-loaded design-file gate FigJam got also covers Slides.**
+`requireDesignFile(capability)` (`exec-stdlib-editor.ts`) checks for `'figma'`
+specifically, so it refuses in EITHER non-design editor with the same message shape,
+not one gate per editor. "Already safe" below still means non-crashing, not clean —
+the gate now front-loads a message that names the capability and the wrong editor
+before the type checks ever run.
+
+- **`ui.componentSet` / `ui.slot.*` / `ui.setProps` / `ui.swapInstance` — gated, on
+  top of the existing type checks, same reasoning as FigJam.** No `SLIDE` node is
+  ever type `COMPONENT` or `INSTANCE`, so the existing type-checks (not
+  editor-specific, just type-specific) still fire second, as a general-correctness
+  backstop for a wrong-type node passed IN Figma itself.
+- **`ui.annotate.*` / `ui.vars.*` — deliberately left ungated, checked fresh for
+  Slides, not assumed identical to FigJam.** Searched official docs and
+  typings-adjacent sources specifically for Slides + annotations/variables
+  availability — found nothing confirming or denying either way, and (same as the
+  FigJam finding) `AnnotationsMixin`/`VariablesAPI` carry no "Figma Design only" note
+  anywhere in the typings, unlike `combineAsVariants`/`createComponent`, which do.
+  Gating an API with no documented restriction would risk refusing a legitimate
+  Slides read — an over-gating regression. Same unverified-availability status as
+  FigJam; do not assert availability that was not confirmed, and do not gate on an
+  unconfirmed guess either.
 
 ## `ui.slides.*` reference
 

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -2483,6 +2483,40 @@
     };
   }
 
+  // shared/editor-surface.ts
+  var EDITOR_LABEL = {
+    figma: "a Figma design file",
+    figjam: "a FigJam board",
+    slides: "a Figma Slides deck",
+    dev: "Dev Mode"
+  };
+  var NEXT_ACTION = {
+    figma: "open this file in Figma (design mode) and re-run",
+    figjam: "open this board in FigJam and re-run",
+    slides: "open this deck in Figma Slides and re-run",
+    dev: "switch to Dev Mode and re-run"
+  };
+  function editorRefusal(opts) {
+    const { capability, required, found } = opts;
+    if (found !== null && required.includes(found)) return null;
+    const foundLabel = found === null ? "the host did not report an editor type" : EDITOR_LABEL[found];
+    const requiredLabels = required.filter((r) => r !== null).map((r) => EDITOR_LABEL[r]);
+    const requiredList = requiredLabels.length === 1 ? requiredLabels[0] : `one of: ${requiredLabels.join(", ")}`;
+    const firstRequired = required.find((r) => r !== null);
+    const nextAction = firstRequired ? NEXT_ACTION[firstRequired] : "reopen the file the capability needs";
+    return `${capability} needs ${requiredList}, but ${foundLabel} is open \u2014 ${nextAction}.`;
+  }
+
+  // plugin/src/main/exec-stdlib-editor.ts
+  function requireEditor(capability, required) {
+    const found = figma.editorType ?? null;
+    const message = editorRefusal({ capability, required, found });
+    if (message !== null) throw withCode(new Error(message), "E_INVALID_ARGS");
+  }
+  function requireDesignFile(capability) {
+    requireEditor(capability, ["figma"]);
+  }
+
   // plugin/src/main/exec-stdlib-instance.ts
   function resolvePropKey(keys, name) {
     if (keys.includes(name)) return name;
@@ -2496,6 +2530,7 @@
     return matches[0];
   }
   async function setProps(inst, props) {
+    requireDesignFile("ui.setProps");
     if (inst.type !== "INSTANCE") {
       throw withCode(new Error(`setProps expects an INSTANCE, got ${inst.type}`), "E_EVAL");
     }
@@ -2540,6 +2575,7 @@
     return out;
   }
   async function swapInstance(inst, ref) {
+    requireDesignFile("ui.swapInstance");
     if (inst.type !== "INSTANCE") {
       throw withCode(new Error(`swapInstance expects an INSTANCE, got ${inst.type}`), "E_EVAL");
     }
@@ -2852,6 +2888,7 @@
     return node;
   }
   async function componentSet(opts) {
+    requireDesignFile("ui.componentSet");
     const hasBase = typeof opts.base === "string";
     const hasComponents = Array.isArray(opts.components) && opts.components.length > 0;
     if (hasBase === hasComponents) {
@@ -2987,6 +3024,7 @@
     return node;
   }
   async function append(target, content2, opts = {}) {
+    requireDesignFile("ui.slot.append");
     const slotNode = await resolveSlot(target);
     let appendedNode;
     if (content2.sourceNodeId) {
@@ -3027,6 +3065,7 @@
     };
   }
   async function reset(target) {
+    requireDesignFile("ui.slot.reset");
     const slotNode = await resolveSlot(target);
     const typed = slotNode;
     if (typeof typed.resetSlot !== "function") {
@@ -3046,6 +3085,7 @@
     return false;
   }
   async function addSlotProperty(componentId, propertyName, frameNodeId, opts = {}) {
+    requireDesignFile("ui.slot.addProperty");
     const component = await figma.getNodeByIdAsync(componentId);
     if (!component || component.type !== "COMPONENT" && component.type !== "COMPONENT_SET") {
       throw withCode(new Error(`componentId must be a COMPONENT or COMPONENT_SET, got ${component?.type ?? "not found"}: ${componentId}`), "E_INVALID_ARGS");
@@ -3108,6 +3148,7 @@
   // plugin/src/main/exec-stdlib-slot.ts
   var CREATE_LAYOUT_MODES = /* @__PURE__ */ new Set(["NONE", "HORIZONTAL", "VERTICAL"]);
   async function create(componentId, opts = {}) {
+    requireDesignFile("ui.slot.create");
     const node = await figma.getNodeByIdAsync(componentId);
     if (!node || node.type !== "COMPONENT") {
       throw withCode(new Error(`componentId must be a COMPONENT node id (standalone or a variant inside a COMPONENT_SET \u2014 call once per variant), got ${node?.type ?? "not found"}: ${componentId}`), "E_INVALID_ARGS");
@@ -3144,6 +3185,7 @@
     };
   }
   async function list(nodeId) {
+    requireDesignFile("ui.slot.list");
     const node = await figma.getNodeByIdAsync(nodeId);
     if (!node || node.type !== "COMPONENT" && node.type !== "INSTANCE" && node.type !== "COMPONENT_SET") {
       throw withCode(new Error(`nodeId must be a COMPONENT, COMPONENT_SET, or INSTANCE, got ${node?.type ?? "not found"}: ${nodeId}`), "E_INVALID_ARGS");
@@ -3316,37 +3358,6 @@
   }
   function createExecStdlibAnnotate() {
     return { get, set, categories };
-  }
-
-  // shared/editor-surface.ts
-  var EDITOR_LABEL = {
-    figma: "a Figma design file",
-    figjam: "a FigJam board",
-    slides: "a Figma Slides deck",
-    dev: "Dev Mode"
-  };
-  var NEXT_ACTION = {
-    figma: "open this file in Figma (design mode) and re-run",
-    figjam: "open this board in FigJam and re-run",
-    slides: "open this deck in Figma Slides and re-run",
-    dev: "switch to Dev Mode and re-run"
-  };
-  function editorRefusal(opts) {
-    const { capability, required, found } = opts;
-    if (found !== null && required.includes(found)) return null;
-    const foundLabel = found === null ? "the host did not report an editor type" : EDITOR_LABEL[found];
-    const requiredLabels = required.filter((r) => r !== null).map((r) => EDITOR_LABEL[r]);
-    const requiredList = requiredLabels.length === 1 ? requiredLabels[0] : `one of: ${requiredLabels.join(", ")}`;
-    const firstRequired = required.find((r) => r !== null);
-    const nextAction = firstRequired ? NEXT_ACTION[firstRequired] : "reopen the file the capability needs";
-    return `${capability} needs ${requiredList}, but ${foundLabel} is open \u2014 ${nextAction}.`;
-  }
-
-  // plugin/src/main/exec-stdlib-editor.ts
-  function requireEditor(capability, required) {
-    const found = figma.editorType ?? null;
-    const message = editorRefusal({ capability, required, found });
-    if (message !== null) throw withCode(new Error(message), "E_INVALID_ARGS");
   }
 
   // plugin/src/main/exec-stdlib-figjam-types.ts

--- a/plugin/src/main/exec-stdlib-component-set.ts
+++ b/plugin/src/main/exec-stdlib-component-set.ts
@@ -15,6 +15,7 @@ import { withCode } from './executor-styles';
 import { WARN_ABOVE, parseComboName, sameAxisMap } from './exec-stdlib-component-matrix';
 import { buildModeA, buildModeB } from './exec-stdlib-component-build';
 import { safeCleanup } from '../../../shared/safe-cleanup';
+import { requireDesignFile } from './exec-stdlib-editor';
 
 export interface ComponentSetOpts {
   base?: string;
@@ -58,6 +59,11 @@ async function resolveParent(ref: string | undefined): Promise<BaseNode & Childr
 }
 
 async function componentSet(opts: ComponentSetOpts): Promise<ComponentSetResult> {
+  // Design-file-only capability: refuse outside the Figma design editor before
+  // touching a node — `figma.combineAsVariants` only exists there, and a caller
+  // that opened the wrong editor deserves that answer before its args are even
+  // validated, not a downstream "not found" once a node lookup already ran.
+  requireDesignFile('ui.componentSet');
   const hasBase = typeof opts.base === 'string';
   const hasComponents = Array.isArray(opts.components) && opts.components.length > 0;
   if (hasBase === hasComponents) {

--- a/plugin/src/main/exec-stdlib-editor.ts
+++ b/plugin/src/main/exec-stdlib-editor.ts
@@ -20,3 +20,16 @@ export function requireEditor(capability: string, required: readonly EditorType[
   const message = editorRefusal({ capability, required, found });
   if (message !== null) throw withCode(new Error(message), 'E_INVALID_ARGS');
 }
+
+/**
+ * The reverse of the per-editor guards above: a capability that depends on a Figma
+ * design-file concept (components, variants, instances, variables, slots,
+ * annotations) must refuse cleanly outside the Figma design editor, BEFORE any arg
+ * validation or node lookup — the same "capability, found, required, next action"
+ * message shape as `requireEditor`, never a downstream "node not found" once the
+ * caller is already in the wrong editor. One helper so every design-file-only site
+ * shares this classification instead of each re-deriving `['figma']` on its own.
+ */
+export function requireDesignFile(capability: string): void {
+  requireEditor(capability, ['figma']);
+}

--- a/plugin/src/main/exec-stdlib-instance.ts
+++ b/plugin/src/main/exec-stdlib-instance.ts
@@ -4,6 +4,7 @@
 // second copy of ref-resolution here would be the mistake that module exists to avoid.
 import { resolveMainComponent } from './resolve-main-component';
 import { withCode } from './executor-styles';
+import { requireDesignFile } from './exec-stdlib-editor';
 
 /**
  * PURE — exported for unit tests: base name → the instance's actual `Name#12:34` key.
@@ -26,6 +27,10 @@ export async function setProps(
   inst: InstanceNode,
   props: Record<string, string | boolean>,
 ): Promise<Record<string, unknown>> {
+  // Design-file-only capability: refuse outside the Figma design editor before
+  // the type check below — an INSTANCE never exists in FigJam or Slides, so a
+  // caller there deserves the editor-named refusal, not a generic type error.
+  requireDesignFile('ui.setProps');
   if (inst.type !== 'INSTANCE') {
     throw withCode(new Error(`setProps expects an INSTANCE, got ${inst.type}`), 'E_EVAL');
   }
@@ -86,6 +91,12 @@ export async function swapInstance(
   inst: InstanceNode,
   ref: string,
 ): Promise<{ id: string; mainComponent: { id: string; name: string } }> {
+  // Design-file-only capability: refuse outside the Figma design editor FIRST, so a
+  // caller there gets the editor-named refusal instead of the general wrong-type
+  // message below. This does not replace the type check that follows — that check
+  // guards a DIFFERENT bug (a wrong-type node passed inside Figma itself, where this
+  // gate is a no-op).
+  requireDesignFile('ui.swapInstance');
   // Phase-03 (FigJam) reverse-guard audit finding: this had NO runtime check at all —
   // only the TS type `InstanceNode`, zero protection once a caller (an exec-js script,
   // or any wrong-type node reference) hands it a real non-instance node. Pre-dates

--- a/plugin/src/main/exec-stdlib-slot-content.ts
+++ b/plugin/src/main/exec-stdlib-slot-content.ts
@@ -18,6 +18,7 @@
 import { withCode } from './executor-styles';
 import type { SlotAppendContent, SlotTarget } from './exec-stdlib-slot-types';
 import { resolveSlot } from './exec-stdlib-slot-resolve';
+import { requireDesignFile } from './exec-stdlib-editor';
 
 async function createSlotContentNode(nodeType: string, props: Record<string, string | number>): Promise<SceneNode> {
   let node: SceneNode;
@@ -49,6 +50,9 @@ export async function append(
   content: SlotAppendContent,
   opts: { clearExisting?: boolean } = {},
 ): Promise<{ slot: { id: string; name: string }; appended: { id: string; name: string; type: string; width: number; height: number } }> {
+  // Design-file-only capability: a SLOT node only exists on a COMPONENT, never
+  // in FigJam or Slides — refuse before resolving the target.
+  requireDesignFile('ui.slot.append');
   const slotNode = await resolveSlot(target);
 
   // Prepare content FIRST — a validation failure must not leave the slot
@@ -95,6 +99,8 @@ export async function append(
 }
 
 export async function reset(target: SlotTarget): Promise<{ slot: { id: string; name: string; childCount: number } }> {
+  // Design-file-only capability: same reasoning as `append`.
+  requireDesignFile('ui.slot.reset');
   const slotNode = await resolveSlot(target);
   const typed = slotNode as SlotNode & { resetSlot?: () => void };
   if (typeof typed.resetSlot !== 'function') {

--- a/plugin/src/main/exec-stdlib-slot-property.ts
+++ b/plugin/src/main/exec-stdlib-slot-property.ts
@@ -11,6 +11,7 @@
 //    claims this but its code never actually checks it; enforced here for real, by
 //    walking the frame's ancestors up to (not including) the component/set.
 import { withCode } from './executor-styles';
+import { requireDesignFile } from './exec-stdlib-editor';
 
 function isNestedInsideAnotherSlot(frame: SceneNode, stopAt: BaseNode): boolean {
   let n: BaseNode | null = frame.parent;
@@ -27,6 +28,10 @@ export async function addSlotProperty(
   frameNodeId: string,
   opts: { description?: string; preferredValues?: { type: 'COMPONENT' | 'COMPONENT_SET'; key: string }[] } = {},
 ): Promise<{ propertyKey: string; frameId: string; frameName: string }> {
+  // Design-file-only capability: `addComponentProperty` only exists on a
+  // COMPONENT/COMPONENT_SET, neither of which any FigJam board or Slides deck
+  // can ever contain — refuse before either node lookup.
+  requireDesignFile('ui.slot.addProperty');
   const component = await figma.getNodeByIdAsync(componentId);
   if (!component || (component.type !== 'COMPONENT' && component.type !== 'COMPONENT_SET')) {
     throw withCode(new Error(`componentId must be a COMPONENT or COMPONENT_SET, got ${component?.type ?? 'not found'}: ${componentId}`), 'E_INVALID_ARGS');

--- a/plugin/src/main/exec-stdlib-slot.ts
+++ b/plugin/src/main/exec-stdlib-slot.ts
@@ -22,12 +22,17 @@ import type { SlotAppendContent, SlotCreateOpts, SlotInfo, SlotTarget } from './
 import { resolveSlot, serializeSlotsFromNode } from './exec-stdlib-slot-resolve';
 import { append, reset } from './exec-stdlib-slot-content';
 import { addSlotProperty } from './exec-stdlib-slot-property';
+import { requireDesignFile } from './exec-stdlib-editor';
 
 const CREATE_LAYOUT_MODES = new Set(['NONE', 'HORIZONTAL', 'VERTICAL']);
 
 async function create(componentId: string, opts: SlotCreateOpts = {}): Promise<{
   id: string; name: string; type: 'SLOT'; propertyKey: string | null; width: number; height: number; layoutMode: string;
 }> {
+  // Design-file-only capability: a Figma Slot only exists on a COMPONENT node,
+  // which no FigJam board or Slides deck can ever contain — refuse before the
+  // node lookup, not after.
+  requireDesignFile('ui.slot.create');
   const node = await figma.getNodeByIdAsync(componentId);
   if (!node || node.type !== 'COMPONENT') {
     throw withCode(new Error(`componentId must be a COMPONENT node id (standalone or a variant inside a COMPONENT_SET — call once per variant), got ${node?.type ?? 'not found'}: ${componentId}`), 'E_INVALID_ARGS');
@@ -68,6 +73,10 @@ async function create(componentId: string, opts: SlotCreateOpts = {}): Promise<{
 }
 
 async function list(nodeId: string): Promise<{ nodeId: string; nodeType: string; slots: SlotInfo[]; count: number }> {
+  // Design-file-only capability: same reasoning as `create` — a SLOT only lives
+  // under a COMPONENT/COMPONENT_SET/INSTANCE, none of which exist outside Figma
+  // design files.
+  requireDesignFile('ui.slot.list');
   const node = await figma.getNodeByIdAsync(nodeId);
   if (!node || (node.type !== 'COMPONENT' && node.type !== 'INSTANCE' && node.type !== 'COMPONENT_SET')) {
     throw withCode(new Error(`nodeId must be a COMPONENT, COMPONENT_SET, or INSTANCE, got ${node?.type ?? 'not found'}: ${nodeId}`), 'E_INVALID_ARGS');

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "48035be" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "d2cc78a" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/tests/exec-stdlib-component-set.test.ts
+++ b/tests/exec-stdlib-component-set.test.ts
@@ -3,7 +3,7 @@
 // throw, bad-input throws, cartesian-order determinism, `=`/`,` rejection, and the
 // over-cap rejection (plan §8 Definition of Done).
 import { describe, it, expect } from 'vitest';
-import { installMockFigma, setMockComponents, FakeNode } from './helpers/mock-figma.ts';
+import { installMockFigma, setMockComponents, setMockEditorType, FakeNode } from './helpers/mock-figma.ts';
 import { createExecStdlibComponentSet } from '../plugin/src/main/exec-stdlib-component-set.ts';
 import {
   cartesianProduct, comboName, assertCleanToken, parseComboName, sameAxisMap,
@@ -21,18 +21,21 @@ function makeComponent(name: string): FakeNode {
 describe('componentSet — mode selection', () => {
   it('throws E_INVALID_ARGS when neither base nor components is given', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     await expect(createExecStdlibComponentSet().componentSet({}))
       .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
   });
 
   it('throws E_INVALID_ARGS when both base and components are given', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     await expect(createExecStdlibComponentSet().componentSet({ base: '1:1', components: ['1:2'] }))
       .rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
   });
 
   it('throws E_INVALID_ARGS when base is given without axes', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     await expect(createExecStdlibComponentSet().componentSet({ base: base.id }))
@@ -43,6 +46,7 @@ describe('componentSet — mode selection', () => {
 describe('componentSet — mode 1 (base + axes)', () => {
   it('builds the cartesian product, keeps the base id as the first variant, and reads back propertyDefinitions', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
 
@@ -66,6 +70,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('rejects a base already inside a COMPONENT_SET', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     const other = makeComponent('State=default');
     setMockComponents([base, other]);
@@ -78,6 +83,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('rejects an axis or value containing "=" or ","', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { 'Sta=te': ['default'] } }))
@@ -88,6 +94,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('rejects a matrix over the 100-combination cap', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     const many = Array.from({ length: 11 }, (_, i) => `v${i}`); // 11 * 11 = 121 > 100
@@ -97,6 +104,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('carries a sizeWarning above 40 variants, without rejecting', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     const values = Array.from({ length: 41 }, (_, i) => `v${i}`);
@@ -107,6 +115,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('throws E_EVAL when the combined set disagrees with what we intended, AND self-cleans up: base name restored, its own clone removed', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     const originalCombine = figma.combineAsVariants.bind(figma);
@@ -131,6 +140,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('restores the base name AND removes its own clone when the failure is UNRELATED to verification (e.g. combineAsVariants itself throws) — ruled independently of issue 2', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const frame = figma.createFrame(); // a real parent, so clone() actually attaches — proves removal
     const base = makeComponent('Base');
     frame.appendChild(base);
@@ -148,6 +158,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('surfaces the ORIGINAL error even when cleanup() itself throws — a throwing cleanup must never mask the failure that triggered it (issue #11 item 1)', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     setMockComponents([base]);
     const originalCombine = figma.combineAsVariants.bind(figma);
@@ -175,6 +186,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 
   it('rejects a parent that cannot sensibly hold a component set (a COMPONENT, not PAGE/FRAME/SECTION/GROUP)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Base');
     const notAContainer = makeComponent('NotAContainer');
     setMockComponents([base, notAContainer]);
@@ -188,6 +200,7 @@ describe('componentSet — mode 1 (base + axes)', () => {
 describe('componentSet — mode 2 (combine existing components)', () => {
   it('renames each component via variantProps before combining', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('CompA');
     const b = makeComponent('CompB');
     setMockComponents([a, b]);
@@ -203,6 +216,7 @@ describe('componentSet — mode 2 (combine existing components)', () => {
 
   it('warns (never rejects) when a component name lacks "=" and no variantProps is given', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('Plain Name');
     setMockComponents([a]);
 
@@ -212,6 +226,7 @@ describe('componentSet — mode 2 (combine existing components)', () => {
 
   it('rejects a component already inside a COMPONENT_SET', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('State=default');
     setMockComponents([a]);
     figma.combineAsVariants([a], figma.currentPage);
@@ -222,6 +237,7 @@ describe('componentSet — mode 2 (combine existing components)', () => {
 
   it('rejects a variantProps length mismatch', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('CompA');
     setMockComponents([a]);
     await expect(createExecStdlibComponentSet().componentSet({ components: [a.id], variantProps: [] }))
@@ -230,6 +246,7 @@ describe('componentSet — mode 2 (combine existing components)', () => {
 
   it('validates ALL inputs before renaming ANY of them — a later validation failure must not leave an earlier component renamed with no closure (issue #11 item 3)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('CompA');
     const b = makeComponent('CompB');
     setMockComponents([a, b]);
@@ -247,6 +264,7 @@ describe('componentSet — mode 2 (combine existing components)', () => {
 
   it('restores each component\'s original name when a later step throws — mode 2\'s own rollback', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('CompA');
     const b = makeComponent('CompB');
     setMockComponents([a, b]);
@@ -295,17 +313,20 @@ describe('exec-stdlib-component-matrix — pure helpers', () => {
 describe('mock-figma — figma.combineAsVariants refusals', () => {
   it('refuses an empty node list', () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     expect(() => figma.combineAsVariants([], figma.currentPage)).toThrow(/at least one node/);
   });
 
   it('refuses a non-COMPONENT node', () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const frame = figma.createFrame();
     expect(() => figma.combineAsVariants([frame], figma.currentPage)).toThrow(/not a COMPONENT/);
   });
 
   it('refuses a component already inside a COMPONENT_SET', () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const a = makeComponent('State=default');
     figma.combineAsVariants([a], figma.currentPage);
     const b = makeComponent('State=hover');

--- a/tests/exec-stdlib-design-file-guard.test.ts
+++ b/tests/exec-stdlib-design-file-guard.test.ts
@@ -1,0 +1,239 @@
+// Reverse editor-guard: design-file-only `ui.*` capabilities (components, variants,
+// instances, slots) must refuse cleanly outside the Figma design editor, BEFORE any
+// arg validation or node lookup — the forward guards (`ui.figjam.*`/`ui.slides.*`)
+// already refuse cleanly in the wrong editor; this is the missing reverse direction.
+//
+// Classification is by ACTUAL API dependency, verified against `@figma/plugin-typings`
+// and this repo's own prior reverse-guard audits (knowledge/figjam.md, knowledge/
+// slides.md), not assumed:
+//
+// GATED (design-file concepts with a documented or type-level Figma-Design-only
+// dependency): `ui.componentSet` (figma.combineAsVariants — typings say "only
+// available in Figma Design"), `ui.slot.*` (createSlot/resetSlot/
+// addComponentProperty only exist on a COMPONENT/COMPONENT_SET/SLOT node, which no
+// FigJam or Slides node type can ever be), `ui.setProps`/`ui.swapInstance`
+// (componentProperties/swapComponent — INSTANCE-only, and no FigJam/Slides node
+// type is ever INSTANCE).
+//
+// DELIBERATELY LEFT UNGATED (checked, not assumed): `ui.vars.*`, `ui.boundFill`, and
+// `ui.annotate.*` all resolve to `figma.variables.*` / `node.setBoundVariable` /
+// `figma.annotations.*` — none of these carry a "only available in Figma Design"
+// note anywhere in the typings (unlike `combineAsVariants`/`createComponent`, which
+// do), and `AnnotationsMixin` is implemented by base shape/text node types that also
+// exist in FigJam and Slides. Gating an API with no documented editor restriction
+// would be exactly the over-gating regression this task exists to avoid; this suite
+// locks that decision in so a future change cannot silently narrow it without a
+// failing test naming why.
+import { describe, it, expect } from 'vitest';
+import {
+  installMockFigma, setMockEditorType, setMockComponents, makeMockComponent,
+  setMockLocalVariables, makeMockVariable, setMockAnnotationCategories, type FakeNode,
+} from './helpers/mock-figma.ts';
+import { requireDesignFile } from '../plugin/src/main/exec-stdlib-editor.ts';
+import { createExecStdlibComponentSet } from '../plugin/src/main/exec-stdlib-component-set.ts';
+import { createExecStdlibSlot } from '../plugin/src/main/exec-stdlib-slot.ts';
+import { setProps, swapInstance } from '../plugin/src/main/exec-stdlib-instance.ts';
+import { createExecStdlib } from '../plugin/src/main/exec-stdlib.ts';
+import { createExecStdlibVars } from '../plugin/src/main/exec-stdlib-variables.ts';
+import { createExecStdlibAnnotate } from '../plugin/src/main/exec-stdlib-annotate.ts';
+
+function refusalAssertions(err: unknown, capability: string): void {
+  expect((err as { code?: string }).code).toBe('E_INVALID_ARGS');
+  const message = (err as Error).message;
+  expect(message).toContain(capability);
+  expect(message).toContain('Figma design file');
+  expect(message).toContain('FigJam board');
+}
+
+describe('requireDesignFile (shared helper)', () => {
+  it('allows a capability when a Figma design file is open', () => {
+    installMockFigma();
+    setMockEditorType('figma');
+    expect(() => requireDesignFile('ui.componentSet')).not.toThrow();
+  });
+
+  it('refuses naming the capability, the wrong editor, and the fix, when FigJam is open', () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    try {
+      requireDesignFile('ui.componentSet');
+      expect.fail('expected requireDesignFile to throw');
+    } catch (err) {
+      refusalAssertions(err, 'ui.componentSet');
+    }
+  });
+
+  it('refuses when Slides is open', () => {
+    installMockFigma();
+    setMockEditorType('slides');
+    expect(() => requireDesignFile('ui.componentSet')).toThrow(/Figma design file/);
+  });
+});
+
+describe('ui.componentSet — refuses outside a Figma design file before arg validation', () => {
+  it('refuses in FigJam with the editor message, never the "needs exactly one of" arg error', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    try {
+      // Deliberately invalid args (neither base nor components) — if the gate did
+      // not fire FIRST, this would throw the arg-validation error instead.
+      await createExecStdlibComponentSet().componentSet({});
+      expect.fail('expected componentSet to throw');
+    } catch (err) {
+      refusalAssertions(err, 'ui.componentSet');
+    }
+  });
+
+  it('runs (past the gate) in a Figma design file', async () => {
+    installMockFigma();
+    setMockEditorType('figma');
+    const base = makeMockComponent('Base');
+    setMockComponents([base]);
+    await expect(createExecStdlibComponentSet().componentSet({ base: base.id, axes: { State: ['default'] } }))
+      .resolves.toMatchObject({ variantCount: 1 });
+  });
+});
+
+describe('ui.slot.* — refuses outside a Figma design file before arg validation', () => {
+  it('create() refuses in FigJam, never the "must be a COMPONENT" arg error', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    try {
+      await createExecStdlibSlot().create('not-a-real-id');
+      expect.fail('expected slot.create to throw');
+    } catch (err) {
+      refusalAssertions(err, 'ui.slot.create');
+    }
+  });
+
+  it('list() refuses in FigJam', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    await expect(createExecStdlibSlot().list('not-a-real-id'))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('ui.slot.list') });
+  });
+
+  it('append() refuses in FigJam', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    await expect(createExecStdlibSlot().append({ slotId: 'not-a-real-id' }, {}))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('ui.slot.append') });
+  });
+
+  it('reset() refuses in FigJam', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    await expect(createExecStdlibSlot().reset({ slotId: 'not-a-real-id' }))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('ui.slot.reset') });
+  });
+
+  it('addProperty() refuses in FigJam', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    await expect(createExecStdlibSlot().addProperty('not-a-real-id', 'Content', 'also-not-real'))
+      .rejects.toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('ui.slot.addProperty') });
+  });
+
+  it('create() runs (past the gate) in a Figma design file', async () => {
+    installMockFigma();
+    setMockEditorType('figma');
+    const base = makeMockComponent('Card');
+    setMockComponents([base]);
+    await expect(createExecStdlibSlot().create(base.id)).resolves.toMatchObject({ type: 'SLOT' });
+  });
+});
+
+describe('ui.setProps / ui.swapInstance — refuse outside a Figma design file before arg validation', () => {
+  it('setProps refuses in FigJam, never the "expects an INSTANCE" type error', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const notAnInstance = {} as unknown as InstanceNode;
+    try {
+      await setProps(notAnInstance, { Label: 'x' });
+      expect.fail('expected setProps to throw');
+    } catch (err) {
+      refusalAssertions(err, 'ui.setProps');
+    }
+  });
+
+  it('swapInstance refuses in FigJam, never the "expects an INSTANCE" type error', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const notAnInstance = {} as unknown as InstanceNode;
+    try {
+      await swapInstance(notAnInstance, 'not-a-real-ref');
+      expect.fail('expected swapInstance to throw');
+    } catch (err) {
+      refusalAssertions(err, 'ui.swapInstance');
+    }
+  });
+
+  it('setProps runs (past the gate) in a Figma design file', async () => {
+    installMockFigma();
+    setMockEditorType('figma');
+    const main = makeMockComponent('Button');
+    main.componentPropertyDefinitions = { Label: { type: 'TEXT' } };
+    setMockComponents([main]);
+    const inst = main.createInstance() as unknown as FakeNode & { componentProperties: unknown };
+    inst.componentProperties = { Label: { type: 'TEXT', value: 'hi' } };
+    await expect(setProps(inst as never, { Label: 'hello' })).resolves.toMatchObject({ Label: 'hello' });
+  });
+});
+
+describe('regression guard — editor-agnostic node reads must NOT be gated', () => {
+  it('byPath still executes in FigJam (no design-file gate on generic traversal)', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
+    const root = figma.createFrame();
+    const child = figma.createFrame();
+    child.name = 'Child';
+    root.appendChild(child as never);
+
+    const result = await createExecStdlib().byPath(root.id, ['Child']);
+    expect(result.id).toBe(child.id);
+  });
+
+  it('q still executes in FigJam (no design-file gate on generic serialization)', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
+    const node = figma.createFrame();
+
+    const result = await createExecStdlib().q(node.id) as { id: string };
+    expect(result.id).toBe(node.id);
+  });
+
+  it('ui.vars.* still executes in FigJam — no documented editor restriction on figma.variables.*', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const variable = makeMockVariable('color/old');
+    setMockLocalVariables([variable]);
+
+    const result = await createExecStdlibVars().rename(variable.name, 'color/new');
+    expect(result.name).toBe('color/new');
+  });
+
+  it('ui.boundFill still executes in FigJam — same undocumented-restriction reasoning as vars', async () => {
+    const figma = installMockFigma();
+    setMockEditorType('figjam');
+    const variable = makeMockVariable('Brand/Primary', 'COLOR');
+    setMockLocalVariables([variable]);
+    const node = figma.createFrame() as unknown as FakeNode;
+
+    const result = await createExecStdlib().boundFill(node as never, variable.name);
+    expect(result.variable).toBe(variable.name);
+  });
+
+  it('ui.annotate.* still executes in FigJam — AnnotationsMixin covers base shape/text nodes there too', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    setMockAnnotationCategories([]);
+    const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
+    const node = figma.createFrame();
+    node.annotations = [{ label: 'Hello' }];
+
+    const result = await createExecStdlibAnnotate().get(node.id);
+    expect(result.annotationCount).toBe(1);
+  });
+});

--- a/tests/exec-stdlib-instance-swap.test.ts
+++ b/tests/exec-stdlib-instance-swap.test.ts
@@ -9,7 +9,7 @@
 // (never an editor guard — the same hole would stay open for a wrong-type node IN
 // Figma itself).
 import { describe, it, expect } from 'vitest';
-import { installMockFigma, setMockComponents, type FakeNode } from './helpers/mock-figma.ts';
+import { installMockFigma, setMockComponents, setMockEditorType, type FakeNode } from './helpers/mock-figma.ts';
 import { swapInstance } from '../plugin/src/main/exec-stdlib-instance.ts';
 
 let keySeq = 0;
@@ -24,6 +24,7 @@ function makeComponent(name: string): FakeNode {
 describe('ui.swapInstance', () => {
   it('rejects a non-INSTANCE node with a clear message naming expected vs. found — never a raw "swapComponent is not a function"', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const target = makeComponent('Target');
     setMockComponents([target]);
     const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
@@ -38,6 +39,7 @@ describe('ui.swapInstance', () => {
 
   it('the rejection names the ACTUAL type found, not a generic message', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const target = makeComponent('Target');
     setMockComponents([target]);
     const figma = (globalThis as unknown as { figma: { createRectangle(): FakeNode } }).figma;
@@ -49,6 +51,7 @@ describe('ui.swapInstance', () => {
 
   it('never reaches swapComponent for a wrong-type node — the type check runs BEFORE ref resolution', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
     const frame = figma.createFrame();
     // A ref that would ALSO fail resolution (no components registered at all) — if the

--- a/tests/exec-stdlib-props.test.ts
+++ b/tests/exec-stdlib-props.test.ts
@@ -3,7 +3,7 @@
 // component KEY (not just a node id) and is verified through the mock's STRICT
 // setProperties (mock-figma.ts:442-470) — never a permissive stub.
 import { describe, it, expect, beforeEach } from 'vitest';
-import { installMockFigma, setMockComponents, makeMockComponent, FakeNode } from './helpers/mock-figma.ts';
+import { installMockFigma, setMockComponents, setMockEditorType, makeMockComponent, FakeNode } from './helpers/mock-figma.ts';
 import { resolvePropKey, setProps } from '../plugin/src/main/exec-stdlib-instance.ts';
 
 describe('resolvePropKey (pure)', () => {
@@ -26,7 +26,7 @@ describe('resolvePropKey (pure)', () => {
 });
 
 describe('setProps — INSTANCE_SWAP by component key (integration, strict mock)', () => {
-  beforeEach(() => { installMockFigma(); });
+  beforeEach(() => { installMockFigma(); setMockEditorType('figma'); });
 
   it('resolves a component KEY to the target main\'s id via importComponentByKeyAsync', async () => {
     const iconStar = makeMockComponent('Icon Star', 'KEY-ICON-STAR');

--- a/tests/exec-stdlib-slot.test.ts
+++ b/tests/exec-stdlib-slot.test.ts
@@ -4,7 +4,7 @@
 // stricter-than-the-fork ambiguous-slot-name rule.
 import { describe, it, expect } from 'vitest';
 import {
-  installMockFigma, setMockComponents, type FakeNode,
+  installMockFigma, setMockComponents, setMockEditorType, type FakeNode,
 } from './helpers/mock-figma.ts';
 import { createExecStdlibSlot } from '../plugin/src/main/exec-stdlib-slot.ts';
 
@@ -20,6 +20,7 @@ function makeComponent(name: string): FakeNode {
 describe('ui.slot.create', () => {
   it('creates a slot, verifies its own state, and never synthesises a propertyKey', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
 
@@ -33,6 +34,7 @@ describe('ui.slot.create', () => {
 
   it('resizes when width/height are given', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const result = await createExecStdlibSlot().create(base.id, { width: 200, height: 80 });
@@ -42,6 +44,7 @@ describe('ui.slot.create', () => {
 
   it('rejects GRID layoutMode BEFORE creating anything (fact 4)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
 
@@ -52,6 +55,7 @@ describe('ui.slot.create', () => {
 
   it('rejects a non-COMPONENT node', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const figma = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma;
     const frame = figma.createFrame();
     await expect(createExecStdlibSlot().create(frame.id, {})).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
@@ -59,6 +63,7 @@ describe('ui.slot.create', () => {
 
   it('rejects when createSlot() is unavailable (host too old, fact 3) — even though Slots is GA', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     (base as unknown as { createSlot?: unknown }).createSlot = undefined;
@@ -71,6 +76,7 @@ describe('ui.slot.create', () => {
 describe('ui.slot.list', () => {
   it('lists slots on a COMPONENT directly', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     await createExecStdlibSlot().create(base.id, { name: 'Content' });
@@ -82,6 +88,7 @@ describe('ui.slot.list', () => {
 
   it('groups a COMPONENT_SET\'s slots by variant (fact 6)', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const v1 = makeComponent('State=default');
     const v2 = makeComponent('State=hover');
     setMockComponents([v1, v2]);
@@ -96,6 +103,7 @@ describe('ui.slot.list', () => {
 
   it('rejects a node type that cannot hold slots', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const figma = (globalThis as unknown as { figma: { createRectangle(): FakeNode } }).figma;
     const rect = figma.createRectangle();
     await expect(createExecStdlibSlot().list(rect.id)).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
@@ -105,6 +113,7 @@ describe('ui.slot.list', () => {
 describe('ui.slot.append', () => {
   it('clones an existing node into the slot and verifies it landed', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -119,6 +128,7 @@ describe('ui.slot.append', () => {
 
   it('moves (does not clone) when clone:false', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -130,6 +140,7 @@ describe('ui.slot.append', () => {
 
   it('rejects a raw COMPONENT as source BEFORE cloning (fact 7) — no orphan component is left', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     const other = makeComponent('Icon');
     setMockComponents([base, other]);
@@ -148,6 +159,7 @@ describe('ui.slot.append', () => {
 
   it('creates new content via nodeType when no sourceNodeId is given', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -158,6 +170,7 @@ describe('ui.slot.append', () => {
 
   it('rejects an unsupported nodeType, naming the supported ones', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -167,6 +180,7 @@ describe('ui.slot.append', () => {
 
   it('clearExisting runs ONLY after content resolves — a bad sourceNodeId leaves existing children untouched (fact 8)', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -182,6 +196,7 @@ describe('ui.slot.append', () => {
 
   it('snaps a cloned node to 0,0 in a NONE-layout slot (fact 9)', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -198,6 +213,7 @@ describe('ui.slot.append', () => {
 describe('ui.slot.reset', () => {
   it('clears the slot\'s children', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -211,6 +227,7 @@ describe('ui.slot.reset', () => {
 
   it('throws when resetSlot() is unavailable on the node', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     const slot = await createExecStdlibSlot().create(base.id, {});
@@ -226,6 +243,7 @@ describe('ui.slot.reset', () => {
 describe('ui.slot target resolution — stricter than the fork (fact 10)', () => {
   it('resolves by instanceId + slotName when exactly one direct match exists', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     await createExecStdlibSlot().create(base.id, { name: 'Content' });
@@ -237,6 +255,7 @@ describe('ui.slot target resolution — stricter than the fork (fact 10)', () =>
 
   it('throws ambiguous when TWO direct children share the slot name — never silently takes [0]', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     await createExecStdlibSlot().create(base.id, { name: 'Content' });
@@ -249,6 +268,7 @@ describe('ui.slot target resolution — stricter than the fork (fact 10)', () =>
 
   it('lists the available slot names when none match', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const base = makeComponent('Card');
     setMockComponents([base]);
     await createExecStdlibSlot().create(base.id, { name: 'Content' });
@@ -262,6 +282,7 @@ describe('ui.slot target resolution — stricter than the fork (fact 10)', () =>
 describe('ui.slot.addProperty', () => {
   it('binds a direct-child frame and merges componentPropertyReferences (never wipes an existing binding)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const frame = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma.createFrame();
@@ -277,6 +298,7 @@ describe('ui.slot.addProperty', () => {
 
   it('rejects a frame not a direct child of the component', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     const other = makeComponent('Unrelated');
     setMockComponents([component, other]);
@@ -289,6 +311,7 @@ describe('ui.slot.addProperty', () => {
 
   it('rejects a GRID-layout frame', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const frame = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma.createFrame();
@@ -301,6 +324,7 @@ describe('ui.slot.addProperty', () => {
 
   it('rejects a frame nested inside another slot', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const outerSlot = await createExecStdlibSlot().create(component.id, {});
@@ -314,6 +338,7 @@ describe('ui.slot.addProperty', () => {
 
   it('accepts a frame that is a direct child of a COMPONENT_SET\'s variant', async () => {
     const figma = installMockFigma();
+    setMockEditorType('figma');
     const v1 = makeComponent('State=default');
     setMockComponents([v1]);
     const frame = figma.createFrame();
@@ -326,6 +351,7 @@ describe('ui.slot.addProperty', () => {
 
   it('rejects when addComponentProperty() is unavailable (host too old, stage-4 minor m1)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const frame = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma.createFrame();
@@ -338,6 +364,7 @@ describe('ui.slot.addProperty', () => {
 
   it('deletes the freshly-minted property when the post-mint verify fails (stage-4 BLOCKER 2)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const frame = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma.createFrame();
@@ -361,6 +388,7 @@ describe('ui.slot.addProperty', () => {
 
   it('names the leftover property in the error when the rollback deletion itself fails (stage-4 BLOCKER 2 fallback)', async () => {
     installMockFigma();
+    setMockEditorType('figma');
     const component = makeComponent('Card');
     setMockComponents([component]);
     const frame = (globalThis as unknown as { figma: { createFrame(): FakeNode } }).figma.createFrame();


### PR DESCRIPTION
## The gap

Design-only `ui.*` commands (components, variants, instances, slots) had no reverse
editor guard. In FigJam or Slides, `ui.componentSet({ base: 'X', ... })` would not
refuse — it proceeded into component logic and died with a confusing
`base must be a COMPONENT node id, got not found: X`, which reads like a bad id
rather than "wrong editor". The forward guards (`ui.figjam.*`/`ui.slides.*` calling
`requireEditor`) already refuse cleanly in the wrong editor; this closes the reverse
direction.

## Fix

One shared helper, `requireDesignFile(capability)` beside `requireEditor` in
`plugin/src/main/exec-stdlib-editor.ts`:

```ts
export function requireDesignFile(capability: string): void {
  requireEditor(capability, ['figma']);
}
```

Called as the FIRST line of each gated entrypoint — before any arg validation or
node lookup — so the refusal names the capability, the wrong editor, and the fix,
matching the forward guards' message shape.

## Classification (verified per command, not assumed)

**Gated** — each depends on a Figma design-file concept with a documented or
type-level Figma-Design-only dependency:
- `ui.componentSet` — `figma.combineAsVariants` is typed `"Note: This API is only
  available in Figma Design"`.
- `ui.slot.create` / `ui.slot.list` / `ui.slot.append` / `ui.slot.reset` /
  `ui.slot.addProperty` — a SLOT only exists on a COMPONENT/COMPONENT_SET/INSTANCE,
  none of which any FigJam board or Slides deck can ever contain.
- `ui.setProps` / `ui.swapInstance` — `componentProperties`/`swapComponent` are
  INSTANCE-only; no FigJam/Slides node type is ever `INSTANCE`.

These already had their own type checks (`node.type !== 'COMPONENT'` /
`inst.type !== 'INSTANCE'`), so they were not crash-prone — just confusing. Those
checks are unchanged and still guard the orthogonal bug they always did (a
wrong-type node passed IN Figma itself, where the new gate is a no-op).

**Deliberately left ungated** (checked against `@figma/plugin-typings`, not
assumed) — gating these would be an over-gating regression, not a fix:
- `ui.vars.*` (rename/remove/describe/addMode/renameMode/removeMode/setModeValue) —
  `figma.variables.*` carries no "Figma Design only" note anywhere in the typings.
- `ui.boundFill` — same family (`node.setBoundVariable` /
  `setBoundVariableForPaint`), same absence of a documented restriction.
- `ui.annotate.*` (get/set/categories) — `AnnotationsMixin` is implemented by base
  shape/text node types (`RECTANGLE`, `TEXT`, `VECTOR`, …) that also exist in
  FigJam and Slides, and `AnnotationsAPI` carries no editor restriction either.

This matches and extends this repo's own prior reverse-guard audits
(`knowledge/figjam.md`, `knowledge/slides.md`), which had already flagged
`vars`/`annotate` as unverified rather than confirmed-restricted — both docs are
updated in this PR to record the resolved decision.

## Test-first

New suite (`tests/exec-stdlib-design-file-guard.test.ts`) proves, per gated command:
refuses in FigJam with the editor-named message before any arg validation (fails
red pre-fix, passes post-fix); does not refuse in a Figma design file. A regression
guard proves `byPath`/`q` (generic traversal) and the left-ungated `vars.*`/
`boundFill`/`annotate.*` still execute in FigJam — over-gating those would be a
regression, not a fix.

Existing tests for the now-gated commands (`exec-stdlib-component-set.test.ts`,
`exec-stdlib-slot.test.ts`, `exec-stdlib-props.test.ts`,
`exec-stdlib-instance-swap.test.ts`) needed `setMockEditorType('figma')` added
alongside their existing `installMockFigma()` calls, since the mock defaults to no
reported editor type (matching the real "unknown host" refusal contract) and these
tests exercise the design-file happy path.

## Gates

- `npm run typecheck` — pass
- `npm run build` — pass (plugin/code.js content-hash build id updated accordingly)
- `npx vitest run --config vitest.config.ts` — 1173 passed (only unrelated failure:
  the `kernel/design-os` submodule not checked out in this worktree, a pre-existing
  environment condition, not a regression from this change)