### PR TITLE
Add comment-hygiene gate for plan/issue citations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,13 @@ GitHub issue = one Sonnet-ready task. The standard lifecycle, using installed ak
 
 - `npm run typecheck` · `npm run build` · `npm test` (includes the panel gate,
   `tests/figma-plugin-panel.test.ts`, which needs `git submodule update --init --depth 1`).
+- `npm run lint:comments` — fails on a NEW plan-id/issue-number/phase-label/finding-code
+  citation in a tracked comment or test name under `plugin/src`, `cli/src`, `shared`,
+  `tests`. Pre-existing citations are grandfathered in `scripts/comment-hygiene-baseline.json`
+  (content-keyed, not line-keyed, so unrelated edits never invalidate it); a genuinely new
+  citation anywhere — including one added right next to an existing one — still fails. Run
+  `npm run lint:comments:update-baseline` only when deliberately retiring an old citation by
+  restating its invariant directly (never to launder a new one through).
 - The panel gate runs the kernel's own linters from the pinned `kernel/design-os` submodule —
   a bridge until `ease-design/lint` is published (issue #9). Bump the pin deliberately.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,11 +24,15 @@ GitHub issue = one Sonnet-ready task. The standard lifecycle, using installed ak
 
 - `npm run typecheck` · `npm run build` · `npm test` (includes the panel gate,
   `tests/figma-plugin-panel.test.ts`, which needs `git submodule update --init --depth 1`).
-- `npm run lint:comments` — fails on a NEW plan-id/issue-number/phase-label/finding-code
-  citation in a tracked comment or test name under `plugin/src`, `cli/src`, `shared`,
-  `tests`. Pre-existing citations are grandfathered in `scripts/comment-hygiene-baseline.json`
-  (content-keyed, not line-keyed, so unrelated edits never invalidate it); a genuinely new
-  citation anywhere — including one added right next to an existing one — still fails. Run
+- `npm run lint:comments` — fails on a NEW ephemeral work-tracking ref (a GH issue/PR
+  number, a dated plan-dir slug, or a bare finding/audit label) in a tracked comment or
+  test name under `plugin/src`, `cli/src`, `shared`, `tests`. It deliberately ALLOWS this
+  repo's durable design-doc narrative — a committed `spec-NNN` citation, a roadmap
+  wave/backlog section, a review round, a phase name — since those point at documents
+  that live in the repo's own history, not an external tracker. Pre-existing ephemeral
+  refs are grandfathered in `scripts/comment-hygiene-baseline.json` (content-keyed, not
+  line-keyed, so unrelated edits never invalidate it); a genuinely new citation anywhere
+  — including one added right next to an existing one — still fails. Run
   `npm run lint:comments:update-baseline` only when deliberately retiring an old citation by
   restating its invariant directly (never to launder a new one through).
 - The panel gate runs the kernel's own linters from the pinned `kernel/design-os` submodule —

--- a/package.json
+++ b/package.json
@@ -18,7 +18,10 @@
     "build:plugin-main": "node scripts/build.mjs plugin-main",
     "build:plugin-ui": "node scripts/build.mjs plugin-ui",
     "typecheck": "tsc -p cli --noEmit && tsc -p plugin --noEmit",
-    "test": "vitest run --config vitest.config.ts"
+    "test": "vitest run --config vitest.config.ts",
+    "lint:comments": "node scripts/check-comment-hygiene.mjs",
+    "lint:comments:update-baseline": "node scripts/check-comment-hygiene.mjs --update-baseline",
+    "lint:comments:self-test": "node scripts/check-comment-hygiene.mjs --self-test"
   },
   "dependencies": {
     "ws": "^8.18.0"

--- a/scripts/check-comment-hygiene.mjs
+++ b/scripts/check-comment-hygiene.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+// Fails when a tracked source/test file states an invariant by pointing at a plan
+// artifact instead of explaining it: an issue/PR number, a spec or plan-dir slug, a
+// phase label, or a roadmap/backlog number. Those labels drift the moment the doc
+// they point at is renumbered or deleted; the line should say WHAT is true and WHY,
+// not WHERE that fact was once written down.
+//
+// Modes:
+//   node scripts/check-comment-hygiene.mjs                 gate: fail on any new citation
+//   node scripts/check-comment-hygiene.mjs --update-baseline   regenerate the baseline
+//   node scripts/check-comment-hygiene.mjs --self-test      fixture-based check of the matcher itself
+import { execFileSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const baselinePath = resolve(root, 'scripts/comment-hygiene-baseline.json');
+const SCOPE_DIRS = ['plugin/src', 'cli/src', 'shared', 'tests'];
+
+// Each pattern is scanned per-line. `normalize` turns the raw match into a stable
+// baseline key so line-number drift (an edit two lines above) never invalidates an
+// entry — only the cited label itself does.
+const PATTERNS = [
+  {
+    name: 'issue/PR number',
+    re: /\b(?:issues?|prs?|fix(?:e[sd])?|close[sd]?|resolve[sd]?|tickets?)\s*#\d+\b/gi,
+    normalize: (m) => m.toLowerCase().replace(/\s+/g, ' '),
+  },
+  {
+    name: 'spec number',
+    re: /\bspec[-\s]\d{3,6}\b/gi,
+    normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
+  },
+  {
+    name: 'plan-dir slug',
+    re: /\b\d{6}-\d{4}-/g,
+    normalize: (m) => m,
+  },
+  {
+    name: 'phase label',
+    re: /\bphase[-\s]?\d+\b/gi,
+    normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
+  },
+  {
+    // The parenthesized "(P6)" / "(P9,P14)" / "(P7/P8)" citation style — always in
+    // parens in this codebase's history, which is what keeps it from matching a
+    // priority label like "P1" used as a bare identifier elsewhere.
+    name: 'phase-P label',
+    re: /\(P\d{1,2}(?:\s?[/,]\s?P?\d{1,2})*\)/g,
+    normalize: (m) => m.toLowerCase().replace(/[()\s]/g, ''),
+  },
+  {
+    name: 'roadmap/backlog label',
+    re: /\b(?:backlog|wave)[-\s]?\d+(?:\.\d+)?\b|\bri-p\d+\b|\bcodex\s+p\d+\b/gi,
+    normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
+  },
+];
+
+/** Pure — scans one file's text; no filesystem or git access. */
+function scanContent(text) {
+  const hits = [];
+  const lines = text.split('\n');
+  for (let i = 0; i < lines.length; i += 1) {
+    const line = lines[i];
+    for (const pattern of PATTERNS) {
+      pattern.re.lastIndex = 0;
+      let match;
+      while ((match = pattern.re.exec(line)) !== null) {
+        hits.push({
+          line: i + 1,
+          lineText: line.trim(),
+          category: pattern.name,
+          token: pattern.normalize(match[0]),
+          raw: match[0],
+        });
+        if (match[0].length === 0) pattern.re.lastIndex += 1; // guard zero-width loops
+      }
+    }
+  }
+  return hits;
+}
+
+function getTrackedFiles() {
+  const out = execFileSync('git', ['ls-files', '--', ...SCOPE_DIRS], {
+    cwd: root,
+    encoding: 'utf8',
+  });
+  return out.split('\n').filter(Boolean);
+}
+
+function scanTree() {
+  /** @type {Map<string, Map<string, {count: number, hits: Array}>>} */
+  const byFile = new Map();
+  for (const relPath of getTrackedFiles()) {
+    const abs = resolve(root, relPath);
+    let text;
+    try {
+      text = readFileSync(abs, 'utf8');
+    } catch {
+      continue; // e.g. a tracked symlink to a missing target — not this check's concern
+    }
+    const hits = scanContent(text);
+    if (hits.length === 0) continue;
+    const byToken = new Map();
+    for (const hit of hits) {
+      const key = `${hit.category}::${hit.token}`;
+      if (!byToken.has(key)) byToken.set(key, { count: 0, hits: [] });
+      const entry = byToken.get(key);
+      entry.count += 1;
+      entry.hits.push(hit);
+    }
+    byFile.set(relPath, byToken);
+  }
+  return byFile;
+}
+
+function loadBaseline() {
+  if (!existsSync(baselinePath)) return {};
+  return JSON.parse(readFileSync(baselinePath, 'utf8'));
+}
+
+function baselineToPlain(byFile) {
+  const out = {};
+  for (const [file, byToken] of [...byFile.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const tokens = {};
+    for (const [key, entry] of [...byToken.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+      tokens[key] = entry.count;
+    }
+    out[file] = tokens;
+  }
+  return out;
+}
+
+function updateBaseline() {
+  const byFile = scanTree();
+  const before = loadBaseline();
+  const after = baselineToPlain(byFile);
+
+  let grew = 0;
+  let shrank = 0;
+  for (const [file, tokens] of Object.entries(after)) {
+    for (const [key, count] of Object.entries(tokens)) {
+      const prev = before[file]?.[key] ?? 0;
+      if (count > prev) grew += count - prev;
+    }
+  }
+  for (const [file, tokens] of Object.entries(before)) {
+    for (const [key, count] of Object.entries(tokens)) {
+      const now = after[file]?.[key] ?? 0;
+      if (now < count) shrank += count - now;
+    }
+  }
+
+  writeFileSync(baselinePath, `${JSON.stringify(after, null, 2)}\n`);
+  const totalTokens = Object.values(after).reduce((n, t) => n + Object.keys(t).length, 0);
+  console.log(`Baseline written: ${Object.keys(after).length} files, ${totalTokens} citation tokens.`);
+  if (grew > 0) console.log(`BASELINE GREW: +${grew} citation(s) — review this diff carefully.`);
+  if (shrank > 0) console.log(`Baseline shrank: -${shrank} citation(s) retired.`);
+}
+
+function runGate() {
+  const byFile = scanTree();
+  const baseline = loadBaseline();
+  const violations = [];
+  const staleEntries = [];
+
+  for (const [file, byToken] of byFile) {
+    const baselineTokens = baseline[file] ?? {};
+    for (const [key, entry] of byToken) {
+      const allowed = baselineTokens[key] ?? 0;
+      if (entry.count > allowed) {
+        // Report every hit beyond what's baselined (most likely what this PR just added).
+        const newHits = entry.hits.slice(allowed).map((h) => ({ ...h, file }));
+        violations.push(...newHits);
+      }
+    }
+  }
+
+  for (const [file, tokens] of Object.entries(baseline)) {
+    const byToken = byFile.get(file);
+    for (const [key, baselineCount] of Object.entries(tokens)) {
+      const actualCount = byToken?.get(key)?.count ?? 0;
+      if (actualCount < baselineCount) {
+        staleEntries.push(`${file} :: ${key} (baseline ${baselineCount}, now ${actualCount})`);
+      }
+    }
+  }
+
+  if (staleEntries.length > 0) {
+    console.log(`Note: ${staleEntries.length} baseline entr${staleEntries.length === 1 ? 'y is' : 'ies are'} stale (fewer citations than recorded). Run --update-baseline to shrink it.`);
+  }
+
+  if (violations.length > 0) {
+    console.error(`comment-hygiene: ${violations.length} citation(s) not covered by the baseline.\n`);
+    console.error('State the invariant directly instead of citing a plan id, issue number, phase label, or finding code:\n');
+    for (const v of violations) {
+      console.error(`  ${v.file}:${v.line}: [${v.category}] ${v.lineText}`);
+    }
+    process.exit(1);
+  }
+
+  console.log(`comment-hygiene: clean (${byFile.size} file(s) with baselined citations, 0 new).`);
+}
+
+function selfTest() {
+  const cases = [
+    { label: 'issue citation in a comment', text: '// leftover context (issue #42)', expectMatch: true },
+    { label: 'clean equivalent of the above', text: '// leftover: still throws under dynamic-page access', expectMatch: false },
+    { label: 'issue citation in a describe() name', text: "describe('refuses cleanly (issue #42)', () => {});", expectMatch: true },
+    { label: 'clean describe() name', text: "describe('refuses cleanly when the guard trips', () => {});", expectMatch: false },
+    { label: 'fixes # shorthand', text: '// fixes #7 by rejecting empty names', expectMatch: true },
+    { label: 'spec number citation', text: '// see spec 260801-1050 for the original ruling', expectMatch: true },
+    { label: 'plan-dir slug citation', text: '// lives at 260801-1050-taste-transfer/phase-02.md', expectMatch: true },
+    { label: 'phase label citation', text: '// deferred to phase 2 of the rollout', expectMatch: true },
+    { label: 'parenthesized P-label citation', text: '// the walker will not bind it (P9)', expectMatch: true },
+    { label: 'roadmap label citation', text: '// folded into wave 4.4 P2 of the backlog', expectMatch: true },
+    { label: 'hex color is not an issue number', text: "el.style.background = '#ff3e00';", expectMatch: false },
+    { label: 'numeric hex color stays clean without an issue word', text: "const swatch = '#123456';", expectMatch: false },
+    { label: 'the word issue near an unrelated hex code stays clean', text: "// not an issue: background is #123456 by design", expectMatch: false },
+  ];
+
+  let failures = 0;
+  for (const c of cases) {
+    const hits = scanContent(c.text);
+    const matched = hits.length > 0;
+    const ok = matched === c.expectMatch;
+    console.log(`${ok ? 'ok' : 'FAIL'} — ${c.label}`);
+    if (!ok) {
+      failures += 1;
+      console.log(`  expected match=${c.expectMatch}, got match=${matched} (hits: ${JSON.stringify(hits.map((h) => h.raw))})`);
+    }
+  }
+
+  if (failures > 0) {
+    console.error(`\nself-test: ${failures}/${cases.length} case(s) failed.`);
+    process.exit(1);
+  }
+  console.log(`\nself-test: ${cases.length}/${cases.length} cases passed.`);
+}
+
+const arg = process.argv[2];
+if (arg === '--self-test') {
+  selfTest();
+} else if (arg === '--update-baseline') {
+  updateBaseline();
+} else if (arg === '--help' || arg === '-h') {
+  console.log(`Usage:
+  node scripts/check-comment-hygiene.mjs                gate: fail on any citation not in the baseline
+  node scripts/check-comment-hygiene.mjs --update-baseline   regenerate scripts/comment-hygiene-baseline.json
+  node scripts/check-comment-hygiene.mjs --self-test     run the matcher's own fixture cases
+`);
+} else {
+  runGate();
+}

--- a/scripts/check-comment-hygiene.mjs
+++ b/scripts/check-comment-hygiene.mjs
@@ -1,9 +1,15 @@
 #!/usr/bin/env node
-// Fails when a tracked source/test file states an invariant by pointing at a plan
-// artifact instead of explaining it: an issue/PR number, a spec or plan-dir slug, a
-// phase label, or a roadmap/backlog number. Those labels drift the moment the doc
-// they point at is renumbered or deleted; the line should say WHAT is true and WHY,
-// not WHERE that fact was once written down.
+// Fails when a tracked source/test file cites an EPHEMERAL work-tracking ref instead of
+// stating the invariant directly: an issue/PR number, a dated plan-dir slug, or a bare
+// finding/audit label. Those rot the moment the tracker item is closed or renumbered.
+//
+// It deliberately ALLOWS this repo's durable design-doc narrative — references to a
+// committed spec directory (`spec 005`, `spec-005`), a roadmap wave or backlog section
+// (`wave 4.4`, `backlog 2.10`), a review round (`RI-P1`), or a phase name — because those
+// point at documents that live in the repo's own history, not at an external tracker that
+// can vanish out from under the comment. When a form is ambiguous between the two, this
+// scanner is written to ALLOW it: a missed ephemeral ref is cheaper than a false fail on
+// legitimate narrative.
 //
 // Modes:
 //   node scripts/check-comment-hygiene.mjs                 gate: fail on any new citation
@@ -28,31 +34,42 @@ const PATTERNS = [
     normalize: (m) => m.toLowerCase().replace(/\s+/g, ' '),
   },
   {
-    name: 'spec number',
-    re: /\bspec[-\s]\d{3,6}\b/gi,
-    normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
-  },
-  {
-    name: 'plan-dir slug',
+    // Dated plan-dir slugs (e.g. `260801-1050-taste-transfer`) point at a directory in an
+    // external monorepo's `plans/` — gitignored there, gone the moment the branch merges.
+    name: 'dated plan-dir slug',
     re: /\b\d{6}-\d{4}-/g,
     normalize: (m) => m,
   },
   {
-    name: 'phase label',
-    re: /\bphase[-\s]?\d+\b/gi,
+    // `spec 260801` / `spec-260801` — the DATED plan-doc form (6 digits, YYMMDD). This is
+    // distinct from this repo's own committed `spec-005` / `spec 005` (3-digit) convention,
+    // which is durable narrative and intentionally NOT matched here.
+    name: 'dated spec number',
+    re: /\bspec[-\s]\d{6}\b/gi,
     normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
   },
   {
-    // The parenthesized "(P6)" / "(P9,P14)" / "(P7/P8)" citation style — always in
-    // parens in this codebase's history, which is what keeps it from matching a
-    // priority label like "P1" used as a bare identifier elsewhere.
-    name: 'phase-P label',
+    // The parenthesized "(P6)" / "(P9,P14)" / "(P7/P8)" citation style — a bare finding
+    // label pointing at an audit round's numbering, which renumbers when a finding is
+    // added or dropped. Parens-only, so a priority label like "P1" used as a bare
+    // identifier elsewhere in code never matches.
+    name: 'parenthesized finding label',
     re: /\(P\d{1,2}(?:\s?[/,]\s?P?\d{1,2})*\)/g,
     normalize: (m) => m.toLowerCase().replace(/[()\s]/g, ''),
   },
   {
-    name: 'roadmap/backlog label',
-    re: /\b(?:backlog|wave)[-\s]?\d+(?:\.\d+)?\b|\bri-p\d+\b|\bcodex\s+p\d+\b/gi,
+    // `finding 4`, `finding-1` — a bare numbered-finding label from a review pass; the
+    // number is only meaningful relative to a findings list that can be renumbered.
+    name: 'finding number',
+    re: /\bfinding[-\s]?\d+\b/gi,
+    normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
+  },
+  {
+    // `audit 5`, `audit #5`, `audit F3` — audit used as a label prefix for a bare code.
+    // Deliberately narrow: ordinary English use ("audit log", "audit ledger", "audit
+    // signal", "audit backlog 2.10") never matches because it isn't followed by a code.
+    name: 'audit label',
+    re: /\baudit\s+(?:#\d+|\d+\b|[a-z]\d{1,2}\b)/gi,
     normalize: (m) => m.toLowerCase().replace(/\s+/g, '-'),
   },
 ];
@@ -193,7 +210,7 @@ function runGate() {
 
   if (violations.length > 0) {
     console.error(`comment-hygiene: ${violations.length} citation(s) not covered by the baseline.\n`);
-    console.error('State the invariant directly instead of citing a plan id, issue number, phase label, or finding code:\n');
+    console.error('State the invariant directly instead of citing an issue/PR number, a dated plan-dir slug, or a bare finding/audit label:\n');
     for (const v of violations) {
       console.error(`  ${v.file}:${v.line}: [${v.category}] ${v.lineText}`);
     }
@@ -205,19 +222,30 @@ function runGate() {
 
 function selfTest() {
   const cases = [
-    { label: 'issue citation in a comment', text: '// leftover context (issue #42)', expectMatch: true },
-    { label: 'clean equivalent of the above', text: '// leftover: still throws under dynamic-page access', expectMatch: false },
-    { label: 'issue citation in a describe() name', text: "describe('refuses cleanly (issue #42)', () => {});", expectMatch: true },
-    { label: 'clean describe() name', text: "describe('refuses cleanly when the guard trips', () => {});", expectMatch: false },
+    // -- ephemeral tracking refs: must FAIL --
+    { label: 'issue citation in a comment', text: '// leftover context (issue #999)', expectMatch: true },
+    { label: 'issue citation in a describe() name', text: "describe('refuses cleanly (issue #999)', () => {});", expectMatch: true },
     { label: 'fixes # shorthand', text: '// fixes #7 by rejecting empty names', expectMatch: true },
-    { label: 'spec number citation', text: '// see spec 260801-1050 for the original ruling', expectMatch: true },
-    { label: 'plan-dir slug citation', text: '// lives at 260801-1050-taste-transfer/phase-02.md', expectMatch: true },
-    { label: 'phase label citation', text: '// deferred to phase 2 of the rollout', expectMatch: true },
-    { label: 'parenthesized P-label citation', text: '// the walker will not bind it (P9)', expectMatch: true },
-    { label: 'roadmap label citation', text: '// folded into wave 4.4 P2 of the backlog', expectMatch: true },
+    { label: 'dated plan-dir slug citation', text: '// lives at 260801-9999-taste-transfer/notes.md', expectMatch: true },
+    { label: 'dated spec-number citation', text: '// see spec 260801-9999 for the original ruling', expectMatch: true },
+    { label: 'parenthesized finding-label citation', text: '// the walker will not bind it (P9)', expectMatch: true },
+    { label: 'bare finding-number citation', text: '// finding 4 — this got fixed by rejecting empty names', expectMatch: true },
+    { label: 'audit-code label citation', text: '// audit F3 flagged this getter as unsafe', expectMatch: true },
+
+    // -- durable design-doc narrative: must PASS (not flagged) --
+    { label: 'clean equivalent of an issue comment', text: '// leftover: still throws under dynamic-page access', expectMatch: false },
+    { label: 'clean describe() name', text: "describe('refuses cleanly when the guard trips', () => {});", expectMatch: false },
+    { label: 'committed 3-digit spec citation (space form)', text: '// spec 005 P3 — the mirror linter pairs SET-shaped arrays by NAME', expectMatch: false },
+    { label: 'committed 3-digit spec citation (dash form)', text: '// see spec-005 for the offline proof', expectMatch: false },
+    { label: 'roadmap wave citation', text: '// folded into wave 4.4 of the backlog', expectMatch: false },
+    { label: 'backlog section citation', text: '// Audit backlog 2.10, phase 2 rollout', expectMatch: false },
+    { label: 'review-round citation', text: '// was DEFERRED at RI-P1, fixed here', expectMatch: false },
+    { label: 'bare phase label (no tracker number)', text: '// deferred to phase 2 of the rollout', expectMatch: false },
     { label: 'hex color is not an issue number', text: "el.style.background = '#ff3e00';", expectMatch: false },
     { label: 'numeric hex color stays clean without an issue word', text: "const swatch = '#123456';", expectMatch: false },
     { label: 'the word issue near an unrelated hex code stays clean', text: "// not an issue: background is #123456 by design", expectMatch: false },
+    { label: 'ordinary "audit log" usage stays clean', text: '// appends to the audit log on every write', expectMatch: false },
+    { label: 'ordinary "audit ledger" usage stays clean', text: '// audit ledger entry per change', expectMatch: false },
   ];
 
   let failures = 0;

--- a/scripts/comment-hygiene-baseline.json
+++ b/scripts/comment-hygiene-baseline.json
@@ -1,0 +1,733 @@
+{
+  "cli/src/commands/batch.ts": {
+    "issue/PR number::issue #16": 3,
+    "issue/PR number::pr #14": 1,
+    "phase label::phase-2": 1,
+    "roadmap/backlog label::backlog-2.10": 1
+  },
+  "cli/src/commands/bind.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-5.7": 1
+  },
+  "cli/src/commands/changes.ts": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 2,
+    "roadmap/backlog label::wave-4.4": 2
+  },
+  "cli/src/commands/errors.ts": {
+    "roadmap/backlog label::backlog-4.5": 1,
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "cli/src/commands/job.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 1,
+    "roadmap/backlog label::backlog-2.6": 1
+  },
+  "cli/src/commands/mirror-verify.ts": {
+    "phase-P label::p14": 1,
+    "phase-P label::p17": 1,
+    "phase-P label::p5": 1,
+    "phase-P label::p9": 1,
+    "spec number::spec-005": 3
+  },
+  "cli/src/commands/scan-conventions.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/commands/scan-node.ts": {
+    "roadmap/backlog label::backlog-1.1": 1,
+    "spec number::spec-005": 3
+  },
+  "cli/src/commands/seat.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/commands/status.ts": {
+    "issue/PR number::issue #15": 1,
+    "issue/PR number::issue #7": 1,
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 1,
+    "roadmap/backlog label::backlog-2.10": 1
+  },
+  "cli/src/commands/sync-corrections.ts": {
+    "phase label::phase-04": 1
+  },
+  "cli/src/figma-agent.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 3,
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "cli/src/seat/routing.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/transport/broker-client.ts": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 3
+  },
+  "cli/src/transport/broker-daemon.ts": {
+    "issue/PR number::issue #15": 1,
+    "issue/PR number::issue #20": 2,
+    "issue/PR number::issue #5": 2,
+    "issue/PR number::issue #7": 3,
+    "phase label::phase-01": 8,
+    "phase label::phase-02": 5,
+    "phase label::phase-03": 2,
+    "roadmap/backlog label::backlog-1.1": 6,
+    "roadmap/backlog label::backlog-2.10": 3,
+    "roadmap/backlog label::backlog-4.6": 2,
+    "roadmap/backlog label::backlog-5.6": 1,
+    "roadmap/backlog label::backlog-5.7": 3,
+    "roadmap/backlog label::backlog-5.9": 2,
+    "roadmap/backlog label::wave-4.4": 2,
+    "spec number::spec-004": 3
+  },
+  "cli/src/transport/broker-discovery.ts": {
+    "issue/PR number::issue #24": 1
+  },
+  "cli/src/transport/broker-status.ts": {
+    "issue/PR number::issue #15": 2,
+    "issue/PR number::issue #7": 2,
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 2,
+    "roadmap/backlog label::backlog-2.10": 2,
+    "roadmap/backlog label::backlog-5.6": 1
+  },
+  "cli/src/transport/change-log.ts": {
+    "issue/PR number::fix#1": 1,
+    "issue/PR number::issue #7": 3,
+    "phase label::phase-01": 2,
+    "phase label::phase-04": 1,
+    "phase-P label::p2/p4": 1,
+    "roadmap/backlog label::backlog-5.6": 2,
+    "roadmap/backlog label::ri-p1": 1,
+    "spec number::spec-004": 1
+  },
+  "cli/src/transport/edit-feed-log.ts": {
+    "issue/PR number::issue #7": 2,
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 1,
+    "phase label::phase-04": 1,
+    "roadmap/backlog label::backlog-5.6": 2,
+    "roadmap/backlog label::backlog-5.7": 2,
+    "roadmap/backlog label::codex-p1": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "cli/src/transport/error-log.ts": {
+    "issue/PR number::issue #7": 2,
+    "roadmap/backlog label::backlog-4.4": 1,
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::backlog-5.9": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "cli/src/transport/figma-mirror-capture-run.ts": {
+    "phase label::phase-02": 5,
+    "phase label::phase-03": 2,
+    "spec number::spec-005": 1
+  },
+  "cli/src/transport/figma-sync-apply.ts": {
+    "phase label::phase-02": 1,
+    "phase label::phase-03": 1,
+    "spec number::spec-004": 1,
+    "spec number::spec-005": 2
+  },
+  "cli/src/transport/figma-sync-config.ts": {
+    "issue/PR number::issue #20": 2,
+    "spec number::spec-004": 1
+  },
+  "cli/src/transport/file-identity.ts": {
+    "phase label::phase-03": 1
+  },
+  "cli/src/transport/file-queue.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/transport/job-table.ts": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 2,
+    "roadmap/backlog label::backlog-1.1": 1,
+    "roadmap/backlog label::backlog-2.10": 1,
+    "roadmap/backlog label::backlog-2.6": 1,
+    "roadmap/backlog label::backlog-4.3": 1
+  },
+  "cli/src/transport/log-rotate.ts": {
+    "phase label::phase-04": 1
+  },
+  "cli/src/transport/plugin-registry.ts": {
+    "phase-P label::p4": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/transport/project-bind.ts": {
+    "phase label::phase-01": 2
+  },
+  "cli/src/transport/protocol-helpers.ts": {
+    "roadmap/backlog label::backlog-1.1": 2
+  },
+  "cli/src/transport/warm-retry.ts": {
+    "roadmap/backlog label::backlog-1.1": 1,
+    "roadmap/backlog label::backlog-2.6": 1
+  },
+  "cli/src/util/json-out.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "cli/src/util/mirror-normalize.ts": {
+    "phase-P label::p14": 1,
+    "spec number::spec-005": 1
+  },
+  "cli/src/util/structural-diff-bound-projection.ts": {
+    "spec number::spec-005": 1
+  },
+  "cli/src/util/structural-diff-keyed.ts": {
+    "spec number::spec-005": 1
+  },
+  "cli/src/util/structural-diff.ts": {
+    "phase-P label::p17": 1,
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/correction-edge-store.ts": {
+    "phase label::phase-04": 3
+  },
+  "plugin/src/main/edit-actor.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::codex-p1": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "plugin/src/main/edit-gapfill.ts": {
+    "phase label::phase-02": 2,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "plugin/src/main/exec-stdlib-annotate.ts": {
+    "phase label::phase-02": 1
+  },
+  "plugin/src/main/exec-stdlib-component-build.ts": {
+    "issue/PR number::issue #11": 1,
+    "issue/PR number::pr #10": 1
+  },
+  "plugin/src/main/exec-stdlib-component-set.ts": {
+    "issue/PR number::issue #11": 1,
+    "issue/PR number::issue #24": 1,
+    "issue/PR number::pr #10": 1,
+    "phase label::phase-01": 1
+  },
+  "plugin/src/main/exec-stdlib-editor.ts": {
+    "phase label::phase-02": 2,
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam-arrange.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam-content.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam-read.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam-table.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam-types.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-figjam.ts": {
+    "phase label::phase-03": 1
+  },
+  "plugin/src/main/exec-stdlib-instance.ts": {
+    "phase label::phase-03": 1,
+    "roadmap/backlog label::backlog-3.1": 1
+  },
+  "plugin/src/main/exec-stdlib-slides-content.ts": {
+    "phase label::phase-04": 2
+  },
+  "plugin/src/main/exec-stdlib-slides-crud.ts": {
+    "phase label::phase-04": 2
+  },
+  "plugin/src/main/exec-stdlib-slides-resolve.ts": {
+    "phase label::phase-04": 1
+  },
+  "plugin/src/main/exec-stdlib-slides-types.ts": {
+    "phase label::phase-04": 1
+  },
+  "plugin/src/main/exec-stdlib-slides-view.ts": {
+    "phase label::phase-04": 1
+  },
+  "plugin/src/main/exec-stdlib-slides.ts": {
+    "phase label::phase-04": 1
+  },
+  "plugin/src/main/exec-stdlib-slot-content.ts": {
+    "phase label::phase-02": 2
+  },
+  "plugin/src/main/exec-stdlib-slot-property.ts": {
+    "phase label::phase-02": 1
+  },
+  "plugin/src/main/exec-stdlib-slot-types.ts": {
+    "phase label::phase-02": 1
+  },
+  "plugin/src/main/exec-stdlib-slot.ts": {
+    "phase label::phase-02": 2
+  },
+  "plugin/src/main/exec-stdlib-variables.ts": {
+    "issue/PR number::pr #10": 2,
+    "phase label::phase-01": 1
+  },
+  "plugin/src/main/exec-stdlib.ts": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 1,
+    "phase label::phase-03": 1,
+    "phase label::phase-04": 1,
+    "roadmap/backlog label::backlog-3.1": 1
+  },
+  "plugin/src/main/executor-frame.ts": {
+    "spec number::spec-005": 4
+  },
+  "plugin/src/main/executor-instance-inner-overrides.ts": {
+    "phase-P label::p10": 1,
+    "phase-P label::p13": 1,
+    "phase-P label::p15": 1,
+    "phase-P label::p9": 1,
+    "spec number::spec-005": 3
+  },
+  "plugin/src/main/executor-instance-inner-slot.ts": {
+    "spec number::spec-005": 3
+  },
+  "plugin/src/main/executor-instance-inner-visual.ts": {
+    "phase-P label::p14": 1,
+    "phase-P label::p9": 1,
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/executor-instance.ts": {
+    "spec number::spec-005": 4
+  },
+  "plugin/src/main/executor-keyed-vars.ts": {
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/executor-ops.ts": {
+    "phase label::phase-02": 1,
+    "phase label::phase-03": 2,
+    "phase label::phase-04": 1,
+    "phase label::phase-1": 1
+  },
+  "plugin/src/main/executor-shapes.ts": {
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/executor-text.ts": {
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/executor-token-var-resolve.ts": {
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/executor-variables.ts": {
+    "issue/PR number::pr #10": 1,
+    "phase label::phase-01": 1,
+    "phase label::phase-1": 1,
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/instance-inner-fill-sizing.ts": {
+    "phase-P label::p9": 1,
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/instance-inner-override-keys.ts": {
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/instance-inner-visual.ts": {
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/main.ts": {
+    "phase label::phase-01": 4,
+    "phase label::phase-02": 3,
+    "phase label::phase-03": 3,
+    "phase label::phase-04": 1,
+    "roadmap/backlog label::codex-p1": 2,
+    "roadmap/backlog label::wave-4.4": 7,
+    "spec number::spec-004": 3,
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/resolve-main-component.ts": {
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/scan-keyed-vars.ts": {
+    "phase-P label::p15": 1,
+    "spec number::spec-005": 3
+  },
+  "plugin/src/main/scan-node-inner-overrides.ts": {
+    "phase-P label::p14": 1,
+    "phase-P label::p15": 1,
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/scan-node-instance.ts": {
+    "phase-P label::p11": 1,
+    "phase-P label::p14": 1,
+    "spec number::spec-005": 2
+  },
+  "plugin/src/main/scan-node-types.ts": {
+    "spec number::spec-005": 3
+  },
+  "plugin/src/main/scan-node-utils.ts": {
+    "spec number::spec-005": 1
+  },
+  "plugin/src/main/scan-node.ts": {
+    "spec number::spec-005": 4
+  },
+  "plugin/src/main/scan-token-refs.ts": {
+    "phase-P label::p8": 1,
+    "spec number::spec-005": 3
+  },
+  "plugin/src/ui/activity-feed.ts": {
+    "roadmap/backlog label::backlog-4.7": 1
+  },
+  "plugin/src/ui/panel-model.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 1,
+    "roadmap/backlog label::backlog-4.4": 1,
+    "spec number::spec-004": 1,
+    "spec number::spec-005": 1
+  },
+  "plugin/src/ui/panel-ui.ts": {
+    "roadmap/backlog label::backlog-4.7": 2,
+    "spec number::spec-004": 2
+  },
+  "plugin/src/ui/panel.html": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 3,
+    "phase label::phase-03": 5,
+    "roadmap/backlog label::backlog-4.7": 1,
+    "spec number::spec-004": 2
+  },
+  "plugin/src/ui/ui-relay.ts": {
+    "phase-P label::p2": 1,
+    "roadmap/backlog label::backlog-4.6": 2,
+    "roadmap/backlog label::wave-4.4": 1,
+    "spec number::spec-004": 3
+  },
+  "shared/edit-feed.ts": {
+    "phase label::phase-01": 1,
+    "phase label::phase-02": 2,
+    "phase label::phase-03": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "shared/edit-vocabulary.ts": {
+    "phase label::phase-02": 1,
+    "phase label::phase-03": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "shared/editor-surface.ts": {
+    "phase label::phase-02": 1
+  },
+  "shared/figma-changes.ts": {
+    "phase label::phase-03": 1,
+    "phase-P label::p2/p4": 2,
+    "spec number::spec-004": 1
+  },
+  "shared/figma-payload-types.ts": {
+    "phase-P label::p3": 1,
+    "spec number::spec-005": 9
+  },
+  "shared/figma-sync-summary.ts": {
+    "spec number::spec-004": 1,
+    "spec number::spec-005": 1
+  },
+  "shared/figma-unbindable-fields.ts": {
+    "spec number::spec-005": 1
+  },
+  "shared/mutating-commands.ts": {
+    "roadmap/backlog label::backlog-2.4": 1
+  },
+  "shared/protocol.ts": {
+    "issue/PR number::issue #7": 1,
+    "phase label::phase-01": 3,
+    "phase label::phase-02": 1,
+    "phase label::phase-1": 1,
+    "phase-P label::p2": 1,
+    "phase-P label::p4": 1,
+    "roadmap/backlog label::backlog-1.1": 5,
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::wave-4.4": 1,
+    "spec number::spec-004": 3
+  },
+  "shared/safe-cleanup.ts": {
+    "issue/PR number::issue #24": 1,
+    "issue/PR number::pr #12": 1,
+    "issue/PR number::pr #13": 1,
+    "issue/PR number::pr #23": 2
+  },
+  "shared/supervised-memory.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/activity-feed.test.ts": {
+    "roadmap/backlog label::backlog-4.7": 1
+  },
+  "tests/batch-op-ceiling.test.ts": {
+    "issue/PR number::issue #16": 1,
+    "issue/PR number::pr #14": 3
+  },
+  "tests/batch-timeout-scaling.test.ts": {
+    "phase label::phase-2": 1,
+    "roadmap/backlog label::backlog-2.10": 1
+  },
+  "tests/broker-advertisement-atomic.test.ts": {
+    "issue/PR number::issue #5": 1
+  },
+  "tests/broker-daemon-harness.test.ts": {
+    "issue/PR number::issue #15": 1,
+    "issue/PR number::issue #20": 1,
+    "issue/PR number::issue #32": 2,
+    "issue/PR number::issue #5": 2,
+    "issue/PR number::issue #7": 5,
+    "issue/PR number::pr #14": 1,
+    "roadmap/backlog label::backlog-2.10": 2,
+    "roadmap/backlog label::backlog-5.6": 3,
+    "roadmap/backlog label::backlog-5.7": 1,
+    "roadmap/backlog label::backlog-5.9": 1
+  },
+  "tests/broker-discovery-probe.test.ts": {
+    "issue/PR number::issue #5": 2
+  },
+  "tests/broker-loopback-host.test.ts": {
+    "issue/PR number::issue #5": 1
+  },
+  "tests/broker-status.test.ts": {
+    "issue/PR number::issue #15": 1,
+    "issue/PR number::issue #7": 1,
+    "issue/PR number::pr #14": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/change-log.test.ts": {
+    "issue/PR number::issue #7": 2,
+    "phase label::phase-03": 2,
+    "phase-P label::p2/p4": 1,
+    "roadmap/backlog label::backlog-5.6": 2,
+    "spec number::spec-004": 1
+  },
+  "tests/changes-command.test.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "tests/chunk-buffer-sweep.test.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/correction-edge-store.test.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/edit-actor.test.ts": {
+    "roadmap/backlog label::codex-p1": 2
+  },
+  "tests/edit-feed-log.test.ts": {
+    "issue/PR number::issue #7": 1,
+    "roadmap/backlog label::backlog-5.6": 1,
+    "roadmap/backlog label::backlog-5.7": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "tests/edit-feed.test.ts": {
+    "phase label::phase-02": 2,
+    "roadmap/backlog label::codex-p1": 2
+  },
+  "tests/edit-gapfill.test.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "tests/editor-surface.test.ts": {
+    "phase label::phase-02": 1
+  },
+  "tests/error-log.test.ts": {
+    "issue/PR number::issue #7": 3,
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::backlog-5.9": 2
+  },
+  "tests/errors-command.test.ts": {
+    "roadmap/backlog label::backlog-4.6": 1,
+    "roadmap/backlog label::wave-4.4": 1
+  },
+  "tests/exec-js-normalize.test.ts": {
+    "phase label::phase-02": 1
+  },
+  "tests/exec-stdlib-annotate.test.ts": {
+    "phase label::phase-02": 1
+  },
+  "tests/exec-stdlib-component-set.test.ts": {
+    "issue/PR number::issue #11": 2,
+    "issue/PR number::pr #10": 1,
+    "phase label::phase-01": 1
+  },
+  "tests/exec-stdlib-editor.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-figjam-arrange.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-figjam-content.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-figjam-read.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-figjam-table.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-instance-swap.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/exec-stdlib-props.test.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-3.1": 1
+  },
+  "tests/exec-stdlib-slides.test.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/exec-stdlib-slot.test.ts": {
+    "phase label::phase-02": 1
+  },
+  "tests/exec-stdlib-variables.test.ts": {
+    "issue/PR number::pr #10": 2,
+    "phase label::phase-01": 1
+  },
+  "tests/exec-undo-group.test.ts": {
+    "phase label::phase-02": 1
+  },
+  "tests/executor-ops-status.test.ts": {
+    "issue/PR number::issue #15": 1,
+    "issue/PR number::issue #3": 1,
+    "phase label::phase-02": 1,
+    "phase label::phase-03": 2
+  },
+  "tests/executor-variables.test.ts": {
+    "phase label::phase-01": 1
+  },
+  "tests/figma-changes-coalesce.test.ts": {
+    "spec number::spec-004": 1
+  },
+  "tests/figma-mirror-capture-run.test.ts": {
+    "phase label::phase-02": 3,
+    "spec number::spec-005": 1
+  },
+  "tests/figma-plugin-panel.test.ts": {
+    "phase label::phase-02": 2,
+    "phase label::phase-03": 3,
+    "roadmap/backlog label::backlog-4.7": 1
+  },
+  "tests/figma-sync-config.test.ts": {
+    "spec number::spec-004": 1
+  },
+  "tests/figma-sync-summary.test.ts": {
+    "spec number::spec-004": 1,
+    "spec number::spec-005": 1
+  },
+  "tests/file-guard-plumbing.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/file-queue.test.ts": {
+    "phase label::phase-01": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/helpers/mock-figma.ts": {
+    "issue/PR number::pr #10": 4,
+    "phase label::phase-01": 3,
+    "phase label::phase-02": 6,
+    "phase label::phase-03": 7,
+    "phase label::phase-04": 8,
+    "phase-P label::p5": 1,
+    "spec number::spec-005": 15
+  },
+  "tests/instance-inherited-fill-binding.test.ts": {
+    "spec number::spec-005": 2
+  },
+  "tests/instance-inner-component-properties.test.ts": {
+    "spec number::spec-005": 4
+  },
+  "tests/instance-inner-fill-sizing.test.ts": {
+    "phase-P label::p16": 1,
+    "spec number::spec-005": 3
+  },
+  "tests/instance-inner-overrides.test.ts": {
+    "spec number::spec-005": 4
+  },
+  "tests/instance-inner-visual-overrides.test.ts": {
+    "spec number::spec-005": 3
+  },
+  "tests/job-command.test.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/job-table-sender-verification.test.ts": {
+    "roadmap/backlog label::backlog-2.10": 1
+  },
+  "tests/job-table.test.ts": {
+    "phase label::phase-01": 2,
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/json-out.test.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/keyed-var-binding.test.ts": {
+    "spec number::spec-005": 1
+  },
+  "tests/log-rotate.test.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/mirror-verify.test.ts": {
+    "spec number::spec-005": 1
+  },
+  "tests/mutating-commands.test.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/panel-model.test.ts": {
+    "roadmap/backlog label::backlog-4.4": 1,
+    "spec number::spec-004": 1
+  },
+  "tests/plugin-registry.test.ts": {
+    "phase label::phase-01": 2
+  },
+  "tests/project-bind.test.ts": {
+    "phase label::phase-01": 1
+  },
+  "tests/route-filter.test.ts": {
+    "phase label::phase-03": 1
+  },
+  "tests/safe-cleanup.test.ts": {
+    "issue/PR number::pr #23": 1
+  },
+  "tests/scale-baseline.test.ts": {
+    "phase label::phase-04": 1,
+    "plan-dir slug::260730-0847-": 2,
+    "plan-dir slug::260730-1204-": 1
+  },
+  "tests/scan-node-fixed-point.test.ts": {
+    "spec number::spec-005": 10
+  },
+  "tests/scan-node-walker-bundle.test.ts": {
+    "spec number::spec-005": 2
+  },
+  "tests/seat-routing.test.ts": {
+    "phase label::phase-01": 2,
+    "roadmap/backlog label::backlog-1.1": 2
+  },
+  "tests/structural-diff-bound-projection.test.ts": {
+    "spec number::spec-005": 4
+  },
+  "tests/structural-diff-keyed.test.ts": {
+    "spec number::spec-005": 3
+  },
+  "tests/structural-diff.test.ts": {
+    "spec number::spec-005": 1
+  },
+  "tests/supervised-memory.test.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/sync-corrections.test.ts": {
+    "phase label::phase-04": 1
+  },
+  "tests/text-binding-fidelity.test.ts": {
+    "spec number::spec-005": 1
+  },
+  "tests/timeout-job-hint.test.ts": {
+    "phase label::phase-02": 1,
+    "roadmap/backlog label::backlog-1.1": 1
+  },
+  "tests/token-var-reattach.test.ts": {
+    "spec number::spec-005": 1
+  },
+  "tests/warm-retry.test.ts": {
+    "roadmap/backlog label::backlog-1.1": 1
+  }
+}

--- a/scripts/comment-hygiene-baseline.json
+++ b/scripts/comment-hygiene-baseline.json
@@ -1,205 +1,74 @@
 {
   "cli/src/commands/batch.ts": {
     "issue/PR number::issue #16": 3,
-    "issue/PR number::pr #14": 1,
-    "phase label::phase-2": 1,
-    "roadmap/backlog label::backlog-2.10": 1
+    "issue/PR number::pr #14": 1
   },
   "cli/src/commands/bind.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-5.7": 1
-  },
-  "cli/src/commands/changes.ts": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 2,
-    "roadmap/backlog label::wave-4.4": 2
-  },
-  "cli/src/commands/errors.ts": {
-    "roadmap/backlog label::backlog-4.5": 1,
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "cli/src/commands/job.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 1,
-    "roadmap/backlog label::backlog-2.6": 1
+    "finding number::finding-4": 1
   },
   "cli/src/commands/mirror-verify.ts": {
-    "phase-P label::p14": 1,
-    "phase-P label::p17": 1,
-    "phase-P label::p5": 1,
-    "phase-P label::p9": 1,
-    "spec number::spec-005": 3
-  },
-  "cli/src/commands/scan-conventions.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "cli/src/commands/scan-node.ts": {
-    "roadmap/backlog label::backlog-1.1": 1,
-    "spec number::spec-005": 3
-  },
-  "cli/src/commands/seat.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 1
+    "parenthesized finding label::p14": 1,
+    "parenthesized finding label::p17": 1,
+    "parenthesized finding label::p5": 1,
+    "parenthesized finding label::p9": 1
   },
   "cli/src/commands/status.ts": {
     "issue/PR number::issue #15": 1,
-    "issue/PR number::issue #7": 1,
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 1,
-    "roadmap/backlog label::backlog-2.10": 1
-  },
-  "cli/src/commands/sync-corrections.ts": {
-    "phase label::phase-04": 1
-  },
-  "cli/src/figma-agent.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 3,
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "cli/src/seat/routing.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "cli/src/transport/broker-client.ts": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 3
+    "issue/PR number::issue #7": 1
   },
   "cli/src/transport/broker-daemon.ts": {
+    "finding number::finding-1": 3,
+    "finding number::finding-2": 1,
+    "finding number::finding-3": 1,
+    "finding number::finding-4": 2,
     "issue/PR number::issue #15": 1,
     "issue/PR number::issue #20": 2,
     "issue/PR number::issue #5": 2,
-    "issue/PR number::issue #7": 3,
-    "phase label::phase-01": 8,
-    "phase label::phase-02": 5,
-    "phase label::phase-03": 2,
-    "roadmap/backlog label::backlog-1.1": 6,
-    "roadmap/backlog label::backlog-2.10": 3,
-    "roadmap/backlog label::backlog-4.6": 2,
-    "roadmap/backlog label::backlog-5.6": 1,
-    "roadmap/backlog label::backlog-5.7": 3,
-    "roadmap/backlog label::backlog-5.9": 2,
-    "roadmap/backlog label::wave-4.4": 2,
-    "spec number::spec-004": 3
+    "issue/PR number::issue #7": 3
   },
   "cli/src/transport/broker-discovery.ts": {
     "issue/PR number::issue #24": 1
   },
   "cli/src/transport/broker-status.ts": {
+    "finding number::finding-1": 1,
     "issue/PR number::issue #15": 2,
-    "issue/PR number::issue #7": 2,
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 2,
-    "roadmap/backlog label::backlog-2.10": 2,
-    "roadmap/backlog label::backlog-5.6": 1
+    "issue/PR number::issue #7": 2
   },
   "cli/src/transport/change-log.ts": {
+    "finding number::finding-1": 1,
     "issue/PR number::fix#1": 1,
     "issue/PR number::issue #7": 3,
-    "phase label::phase-01": 2,
-    "phase label::phase-04": 1,
-    "phase-P label::p2/p4": 1,
-    "roadmap/backlog label::backlog-5.6": 2,
-    "roadmap/backlog label::ri-p1": 1,
-    "spec number::spec-004": 1
+    "parenthesized finding label::p2/p4": 1
   },
   "cli/src/transport/edit-feed-log.ts": {
-    "issue/PR number::issue #7": 2,
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 1,
-    "phase label::phase-04": 1,
-    "roadmap/backlog label::backlog-5.6": 2,
-    "roadmap/backlog label::backlog-5.7": 2,
-    "roadmap/backlog label::codex-p1": 1,
-    "roadmap/backlog label::wave-4.4": 1
+    "finding number::finding-1": 2,
+    "issue/PR number::issue #7": 2
   },
   "cli/src/transport/error-log.ts": {
-    "issue/PR number::issue #7": 2,
-    "roadmap/backlog label::backlog-4.4": 1,
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::backlog-5.9": 1,
-    "roadmap/backlog label::wave-4.4": 1
+    "issue/PR number::issue #7": 2
   },
   "cli/src/transport/figma-mirror-capture-run.ts": {
-    "phase label::phase-02": 5,
-    "phase label::phase-03": 2,
-    "spec number::spec-005": 1
-  },
-  "cli/src/transport/figma-sync-apply.ts": {
-    "phase label::phase-02": 1,
-    "phase label::phase-03": 1,
-    "spec number::spec-004": 1,
-    "spec number::spec-005": 2
+    "finding number::finding-1": 1
   },
   "cli/src/transport/figma-sync-config.ts": {
-    "issue/PR number::issue #20": 2,
-    "spec number::spec-004": 1
+    "issue/PR number::issue #20": 2
   },
   "cli/src/transport/file-identity.ts": {
-    "phase label::phase-03": 1
-  },
-  "cli/src/transport/file-queue.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "cli/src/transport/job-table.ts": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 2,
-    "roadmap/backlog label::backlog-1.1": 1,
-    "roadmap/backlog label::backlog-2.10": 1,
-    "roadmap/backlog label::backlog-2.6": 1,
-    "roadmap/backlog label::backlog-4.3": 1
-  },
-  "cli/src/transport/log-rotate.ts": {
-    "phase label::phase-04": 1
+    "finding number::finding-1": 1
   },
   "cli/src/transport/plugin-registry.ts": {
-    "phase-P label::p4": 1,
-    "roadmap/backlog label::backlog-1.1": 1
+    "parenthesized finding label::p4": 1
   },
   "cli/src/transport/project-bind.ts": {
-    "phase label::phase-01": 2
-  },
-  "cli/src/transport/protocol-helpers.ts": {
-    "roadmap/backlog label::backlog-1.1": 2
-  },
-  "cli/src/transport/warm-retry.ts": {
-    "roadmap/backlog label::backlog-1.1": 1,
-    "roadmap/backlog label::backlog-2.6": 1
-  },
-  "cli/src/util/json-out.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
+    "finding number::finding-1": 1,
+    "finding number::finding-4": 2,
+    "finding number::finding-5": 1
   },
   "cli/src/util/mirror-normalize.ts": {
-    "phase-P label::p14": 1,
-    "spec number::spec-005": 1
-  },
-  "cli/src/util/structural-diff-bound-projection.ts": {
-    "spec number::spec-005": 1
-  },
-  "cli/src/util/structural-diff-keyed.ts": {
-    "spec number::spec-005": 1
+    "parenthesized finding label::p14": 1
   },
   "cli/src/util/structural-diff.ts": {
-    "phase-P label::p17": 1,
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/correction-edge-store.ts": {
-    "phase label::phase-04": 3
-  },
-  "plugin/src/main/edit-actor.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::codex-p1": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "plugin/src/main/edit-gapfill.ts": {
-    "phase label::phase-02": 2,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "plugin/src/main/exec-stdlib-annotate.ts": {
-    "phase label::phase-02": 1
+    "parenthesized finding label::p17": 1
   },
   "plugin/src/main/exec-stdlib-component-build.ts": {
     "issue/PR number::issue #11": 1,
@@ -208,242 +77,64 @@
   "plugin/src/main/exec-stdlib-component-set.ts": {
     "issue/PR number::issue #11": 1,
     "issue/PR number::issue #24": 1,
-    "issue/PR number::pr #10": 1,
-    "phase label::phase-01": 1
-  },
-  "plugin/src/main/exec-stdlib-editor.ts": {
-    "phase label::phase-02": 2,
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam-arrange.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam-content.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam-read.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam-table.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam-types.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-figjam.ts": {
-    "phase label::phase-03": 1
-  },
-  "plugin/src/main/exec-stdlib-instance.ts": {
-    "phase label::phase-03": 1,
-    "roadmap/backlog label::backlog-3.1": 1
-  },
-  "plugin/src/main/exec-stdlib-slides-content.ts": {
-    "phase label::phase-04": 2
-  },
-  "plugin/src/main/exec-stdlib-slides-crud.ts": {
-    "phase label::phase-04": 2
-  },
-  "plugin/src/main/exec-stdlib-slides-resolve.ts": {
-    "phase label::phase-04": 1
-  },
-  "plugin/src/main/exec-stdlib-slides-types.ts": {
-    "phase label::phase-04": 1
-  },
-  "plugin/src/main/exec-stdlib-slides-view.ts": {
-    "phase label::phase-04": 1
-  },
-  "plugin/src/main/exec-stdlib-slides.ts": {
-    "phase label::phase-04": 1
-  },
-  "plugin/src/main/exec-stdlib-slot-content.ts": {
-    "phase label::phase-02": 2
-  },
-  "plugin/src/main/exec-stdlib-slot-property.ts": {
-    "phase label::phase-02": 1
-  },
-  "plugin/src/main/exec-stdlib-slot-types.ts": {
-    "phase label::phase-02": 1
-  },
-  "plugin/src/main/exec-stdlib-slot.ts": {
-    "phase label::phase-02": 2
+    "issue/PR number::pr #10": 1
   },
   "plugin/src/main/exec-stdlib-variables.ts": {
-    "issue/PR number::pr #10": 2,
-    "phase label::phase-01": 1
-  },
-  "plugin/src/main/exec-stdlib.ts": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 1,
-    "phase label::phase-03": 1,
-    "phase label::phase-04": 1,
-    "roadmap/backlog label::backlog-3.1": 1
-  },
-  "plugin/src/main/executor-frame.ts": {
-    "spec number::spec-005": 4
+    "issue/PR number::pr #10": 2
   },
   "plugin/src/main/executor-instance-inner-overrides.ts": {
-    "phase-P label::p10": 1,
-    "phase-P label::p13": 1,
-    "phase-P label::p15": 1,
-    "phase-P label::p9": 1,
-    "spec number::spec-005": 3
-  },
-  "plugin/src/main/executor-instance-inner-slot.ts": {
-    "spec number::spec-005": 3
+    "parenthesized finding label::p10": 1,
+    "parenthesized finding label::p13": 1,
+    "parenthesized finding label::p15": 1,
+    "parenthesized finding label::p9": 1
   },
   "plugin/src/main/executor-instance-inner-visual.ts": {
-    "phase-P label::p14": 1,
-    "phase-P label::p9": 1,
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/executor-instance.ts": {
-    "spec number::spec-005": 4
-  },
-  "plugin/src/main/executor-keyed-vars.ts": {
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/executor-ops.ts": {
-    "phase label::phase-02": 1,
-    "phase label::phase-03": 2,
-    "phase label::phase-04": 1,
-    "phase label::phase-1": 1
-  },
-  "plugin/src/main/executor-shapes.ts": {
-    "spec number::spec-005": 1
-  },
-  "plugin/src/main/executor-text.ts": {
-    "spec number::spec-005": 1
-  },
-  "plugin/src/main/executor-token-var-resolve.ts": {
-    "spec number::spec-005": 2
+    "parenthesized finding label::p14": 1,
+    "parenthesized finding label::p9": 1
   },
   "plugin/src/main/executor-variables.ts": {
-    "issue/PR number::pr #10": 1,
-    "phase label::phase-01": 1,
-    "phase label::phase-1": 1,
-    "spec number::spec-005": 1
+    "issue/PR number::pr #10": 1
   },
   "plugin/src/main/instance-inner-fill-sizing.ts": {
-    "phase-P label::p9": 1,
-    "spec number::spec-005": 1
-  },
-  "plugin/src/main/instance-inner-override-keys.ts": {
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/instance-inner-visual.ts": {
-    "spec number::spec-005": 1
+    "parenthesized finding label::p9": 1
   },
   "plugin/src/main/main.ts": {
-    "phase label::phase-01": 4,
-    "phase label::phase-02": 3,
-    "phase label::phase-03": 3,
-    "phase label::phase-04": 1,
-    "roadmap/backlog label::codex-p1": 2,
-    "roadmap/backlog label::wave-4.4": 7,
-    "spec number::spec-004": 3,
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/resolve-main-component.ts": {
-    "spec number::spec-005": 1
+    "finding number::finding-2": 1
   },
   "plugin/src/main/scan-keyed-vars.ts": {
-    "phase-P label::p15": 1,
-    "spec number::spec-005": 3
+    "parenthesized finding label::p15": 1
   },
   "plugin/src/main/scan-node-inner-overrides.ts": {
-    "phase-P label::p14": 1,
-    "phase-P label::p15": 1,
-    "spec number::spec-005": 2
+    "parenthesized finding label::p14": 1,
+    "parenthesized finding label::p15": 1
   },
   "plugin/src/main/scan-node-instance.ts": {
-    "phase-P label::p11": 1,
-    "phase-P label::p14": 1,
-    "spec number::spec-005": 2
-  },
-  "plugin/src/main/scan-node-types.ts": {
-    "spec number::spec-005": 3
-  },
-  "plugin/src/main/scan-node-utils.ts": {
-    "spec number::spec-005": 1
-  },
-  "plugin/src/main/scan-node.ts": {
-    "spec number::spec-005": 4
+    "parenthesized finding label::p11": 1,
+    "parenthesized finding label::p14": 1
   },
   "plugin/src/main/scan-token-refs.ts": {
-    "phase-P label::p8": 1,
-    "spec number::spec-005": 3
-  },
-  "plugin/src/ui/activity-feed.ts": {
-    "roadmap/backlog label::backlog-4.7": 1
+    "parenthesized finding label::p8": 1
   },
   "plugin/src/ui/panel-model.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 1,
-    "roadmap/backlog label::backlog-4.4": 1,
-    "spec number::spec-004": 1,
-    "spec number::spec-005": 1
+    "finding number::finding-2": 1
   },
   "plugin/src/ui/panel-ui.ts": {
-    "roadmap/backlog label::backlog-4.7": 2,
-    "spec number::spec-004": 2
-  },
-  "plugin/src/ui/panel.html": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 3,
-    "phase label::phase-03": 5,
-    "roadmap/backlog label::backlog-4.7": 1,
-    "spec number::spec-004": 2
+    "finding number::finding-2": 2
   },
   "plugin/src/ui/ui-relay.ts": {
-    "phase-P label::p2": 1,
-    "roadmap/backlog label::backlog-4.6": 2,
-    "roadmap/backlog label::wave-4.4": 1,
-    "spec number::spec-004": 3
-  },
-  "shared/edit-feed.ts": {
-    "phase label::phase-01": 1,
-    "phase label::phase-02": 2,
-    "phase label::phase-03": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "shared/edit-vocabulary.ts": {
-    "phase label::phase-02": 1,
-    "phase label::phase-03": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "shared/editor-surface.ts": {
-    "phase label::phase-02": 1
+    "parenthesized finding label::p2": 1
   },
   "shared/figma-changes.ts": {
-    "phase label::phase-03": 1,
-    "phase-P label::p2/p4": 2,
-    "spec number::spec-004": 1
+    "parenthesized finding label::p2/p4": 2
   },
   "shared/figma-payload-types.ts": {
-    "phase-P label::p3": 1,
-    "spec number::spec-005": 9
-  },
-  "shared/figma-sync-summary.ts": {
-    "spec number::spec-004": 1,
-    "spec number::spec-005": 1
-  },
-  "shared/figma-unbindable-fields.ts": {
-    "spec number::spec-005": 1
-  },
-  "shared/mutating-commands.ts": {
-    "roadmap/backlog label::backlog-2.4": 1
+    "parenthesized finding label::p3": 1
   },
   "shared/protocol.ts": {
+    "finding number::finding-2": 1,
     "issue/PR number::issue #7": 1,
-    "phase label::phase-01": 3,
-    "phase label::phase-02": 1,
-    "phase label::phase-1": 1,
-    "phase-P label::p2": 1,
-    "phase-P label::p4": 1,
-    "roadmap/backlog label::backlog-1.1": 5,
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::wave-4.4": 1,
-    "spec number::spec-004": 3
+    "parenthesized finding label::p2": 1,
+    "parenthesized finding label::p4": 1
   },
   "shared/safe-cleanup.ts": {
     "issue/PR number::issue #24": 1,
@@ -451,34 +142,21 @@
     "issue/PR number::pr #13": 1,
     "issue/PR number::pr #23": 2
   },
-  "shared/supervised-memory.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/activity-feed.test.ts": {
-    "roadmap/backlog label::backlog-4.7": 1
-  },
   "tests/batch-op-ceiling.test.ts": {
     "issue/PR number::issue #16": 1,
     "issue/PR number::pr #14": 3
-  },
-  "tests/batch-timeout-scaling.test.ts": {
-    "phase label::phase-2": 1,
-    "roadmap/backlog label::backlog-2.10": 1
   },
   "tests/broker-advertisement-atomic.test.ts": {
     "issue/PR number::issue #5": 1
   },
   "tests/broker-daemon-harness.test.ts": {
+    "finding number::finding-1": 1,
     "issue/PR number::issue #15": 1,
     "issue/PR number::issue #20": 1,
     "issue/PR number::issue #32": 2,
     "issue/PR number::issue #5": 2,
     "issue/PR number::issue #7": 5,
-    "issue/PR number::pr #14": 1,
-    "roadmap/backlog label::backlog-2.10": 2,
-    "roadmap/backlog label::backlog-5.6": 3,
-    "roadmap/backlog label::backlog-5.7": 1,
-    "roadmap/backlog label::backlog-5.9": 1
+    "issue/PR number::pr #14": 1
   },
   "tests/broker-discovery-probe.test.ts": {
     "issue/PR number::issue #5": 2
@@ -487,247 +165,57 @@
     "issue/PR number::issue #5": 1
   },
   "tests/broker-status.test.ts": {
+    "finding number::finding-1": 1,
     "issue/PR number::issue #15": 1,
     "issue/PR number::issue #7": 1,
-    "issue/PR number::pr #14": 1,
-    "roadmap/backlog label::backlog-1.1": 1
+    "issue/PR number::pr #14": 1
   },
   "tests/change-log.test.ts": {
+    "finding number::finding-1": 1,
     "issue/PR number::issue #7": 2,
-    "phase label::phase-03": 2,
-    "phase-P label::p2/p4": 1,
-    "roadmap/backlog label::backlog-5.6": 2,
-    "spec number::spec-004": 1
-  },
-  "tests/changes-command.test.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "tests/chunk-buffer-sweep.test.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "tests/correction-edge-store.test.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/edit-actor.test.ts": {
-    "roadmap/backlog label::codex-p1": 2
+    "parenthesized finding label::p2/p4": 1
   },
   "tests/edit-feed-log.test.ts": {
-    "issue/PR number::issue #7": 1,
-    "roadmap/backlog label::backlog-5.6": 1,
-    "roadmap/backlog label::backlog-5.7": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "tests/edit-feed.test.ts": {
-    "phase label::phase-02": 2,
-    "roadmap/backlog label::codex-p1": 2
-  },
-  "tests/edit-gapfill.test.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "tests/editor-surface.test.ts": {
-    "phase label::phase-02": 1
+    "finding number::finding-1": 2,
+    "issue/PR number::issue #7": 1
   },
   "tests/error-log.test.ts": {
-    "issue/PR number::issue #7": 3,
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::backlog-5.9": 2
-  },
-  "tests/errors-command.test.ts": {
-    "roadmap/backlog label::backlog-4.6": 1,
-    "roadmap/backlog label::wave-4.4": 1
-  },
-  "tests/exec-js-normalize.test.ts": {
-    "phase label::phase-02": 1
-  },
-  "tests/exec-stdlib-annotate.test.ts": {
-    "phase label::phase-02": 1
+    "issue/PR number::issue #7": 3
   },
   "tests/exec-stdlib-component-set.test.ts": {
     "issue/PR number::issue #11": 2,
-    "issue/PR number::pr #10": 1,
-    "phase label::phase-01": 1
-  },
-  "tests/exec-stdlib-editor.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-figjam-arrange.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-figjam-content.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-figjam-read.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-figjam-table.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-instance-swap.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/exec-stdlib-props.test.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-3.1": 1
-  },
-  "tests/exec-stdlib-slides.test.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/exec-stdlib-slot.test.ts": {
-    "phase label::phase-02": 1
+    "issue/PR number::pr #10": 1
   },
   "tests/exec-stdlib-variables.test.ts": {
-    "issue/PR number::pr #10": 2,
-    "phase label::phase-01": 1
-  },
-  "tests/exec-undo-group.test.ts": {
-    "phase label::phase-02": 1
+    "issue/PR number::pr #10": 2
   },
   "tests/executor-ops-status.test.ts": {
     "issue/PR number::issue #15": 1,
-    "issue/PR number::issue #3": 1,
-    "phase label::phase-02": 1,
-    "phase label::phase-03": 2
-  },
-  "tests/executor-variables.test.ts": {
-    "phase label::phase-01": 1
-  },
-  "tests/figma-changes-coalesce.test.ts": {
-    "spec number::spec-004": 1
+    "issue/PR number::issue #3": 1
   },
   "tests/figma-mirror-capture-run.test.ts": {
-    "phase label::phase-02": 3,
-    "spec number::spec-005": 1
-  },
-  "tests/figma-plugin-panel.test.ts": {
-    "phase label::phase-02": 2,
-    "phase label::phase-03": 3,
-    "roadmap/backlog label::backlog-4.7": 1
-  },
-  "tests/figma-sync-config.test.ts": {
-    "spec number::spec-004": 1
-  },
-  "tests/figma-sync-summary.test.ts": {
-    "spec number::spec-004": 1,
-    "spec number::spec-005": 1
-  },
-  "tests/file-guard-plumbing.test.ts": {
-    "phase label::phase-03": 1
-  },
-  "tests/file-queue.test.ts": {
-    "phase label::phase-01": 1,
-    "roadmap/backlog label::backlog-1.1": 1
+    "finding number::finding-1": 2
   },
   "tests/helpers/mock-figma.ts": {
     "issue/PR number::pr #10": 4,
-    "phase label::phase-01": 3,
-    "phase label::phase-02": 6,
-    "phase label::phase-03": 7,
-    "phase label::phase-04": 8,
-    "phase-P label::p5": 1,
-    "spec number::spec-005": 15
-  },
-  "tests/instance-inherited-fill-binding.test.ts": {
-    "spec number::spec-005": 2
-  },
-  "tests/instance-inner-component-properties.test.ts": {
-    "spec number::spec-005": 4
+    "parenthesized finding label::p5": 1
   },
   "tests/instance-inner-fill-sizing.test.ts": {
-    "phase-P label::p16": 1,
-    "spec number::spec-005": 3
-  },
-  "tests/instance-inner-overrides.test.ts": {
-    "spec number::spec-005": 4
-  },
-  "tests/instance-inner-visual-overrides.test.ts": {
-    "spec number::spec-005": 3
-  },
-  "tests/job-command.test.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "tests/job-table-sender-verification.test.ts": {
-    "roadmap/backlog label::backlog-2.10": 1
-  },
-  "tests/job-table.test.ts": {
-    "phase label::phase-01": 2,
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "tests/json-out.test.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "tests/keyed-var-binding.test.ts": {
-    "spec number::spec-005": 1
-  },
-  "tests/log-rotate.test.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/mirror-verify.test.ts": {
-    "spec number::spec-005": 1
-  },
-  "tests/mutating-commands.test.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
+    "parenthesized finding label::p16": 1
   },
   "tests/panel-model.test.ts": {
-    "roadmap/backlog label::backlog-4.4": 1,
-    "spec number::spec-004": 1
-  },
-  "tests/plugin-registry.test.ts": {
-    "phase label::phase-01": 2
+    "finding number::finding-2": 1
   },
   "tests/project-bind.test.ts": {
-    "phase label::phase-01": 1
-  },
-  "tests/route-filter.test.ts": {
-    "phase label::phase-03": 1
+    "finding number::finding-1": 1,
+    "finding number::finding-4": 2,
+    "finding number::finding-5": 1
   },
   "tests/safe-cleanup.test.ts": {
     "issue/PR number::pr #23": 1
   },
   "tests/scale-baseline.test.ts": {
-    "phase label::phase-04": 1,
-    "plan-dir slug::260730-0847-": 2,
-    "plan-dir slug::260730-1204-": 1
-  },
-  "tests/scan-node-fixed-point.test.ts": {
-    "spec number::spec-005": 10
-  },
-  "tests/scan-node-walker-bundle.test.ts": {
-    "spec number::spec-005": 2
-  },
-  "tests/seat-routing.test.ts": {
-    "phase label::phase-01": 2,
-    "roadmap/backlog label::backlog-1.1": 2
-  },
-  "tests/structural-diff-bound-projection.test.ts": {
-    "spec number::spec-005": 4
-  },
-  "tests/structural-diff-keyed.test.ts": {
-    "spec number::spec-005": 3
-  },
-  "tests/structural-diff.test.ts": {
-    "spec number::spec-005": 1
-  },
-  "tests/supervised-memory.test.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/sync-corrections.test.ts": {
-    "phase label::phase-04": 1
-  },
-  "tests/text-binding-fidelity.test.ts": {
-    "spec number::spec-005": 1
-  },
-  "tests/timeout-job-hint.test.ts": {
-    "phase label::phase-02": 1,
-    "roadmap/backlog label::backlog-1.1": 1
-  },
-  "tests/token-var-reattach.test.ts": {
-    "spec number::spec-005": 1
-  },
-  "tests/warm-retry.test.ts": {
-    "roadmap/backlog label::backlog-1.1": 1
+    "dated plan-dir slug::260730-0847-": 2,
+    "dated plan-dir slug::260730-1204-": 1
   }
 }


### PR DESCRIPTION
## Recurring class

Hand-fixed in review three times now (#36, #40, #43): a code comment or test name cites a plan id, issue number, phase label, or finding code instead of stating the invariant directly. A prose rule drifts; this adds the check that fails without it.

## Policy (narrowed after owner review — see history)

**Flags (fails the gate) — ephemeral work-tracking refs that rot the moment the tracker item is closed/renumbered:**
- `issue #N` / `PR #N` / `fixes #N` / `closes #N` / `resolves #N` / `ticket #N`
- dated plan-dir slugs `NNNNNN-NNNN-` (e.g. `260801-1050-taste-transfer`)
- `spec NNNNNN` / `spec-NNNNNN` — the **dated** plan-doc form (6-digit YYMMDD)
- `(P6)` / `(P9,P14)` / `(P7/P8)` — bare parenthesized finding-round labels
- `finding N` — bare numbered-finding labels
- `audit N` / `audit #N` / `audit F3` — audit used as a label prefix for a bare code

**Allows (does not flag) — durable design-doc narrative this repo intentionally uses:**
- `spec 005` / `spec-005` — the **committed** 3-digit spec-dir form
- `wave 4.4`, `backlog 2.10` — roadmap/backlog sections
- `RI-P1`, `Codex P1` — review-round labels
- bare `phase N` (no tracker number attached)

Hex colors, semver, and plain identifiers are excluded by construction (word-boundary + adjacency requirements), not an allowlist. Ambiguous forms default to ALLOW per the owner's call: a missed ephemeral ref is cheaper than a false fail on legitimate narrative.

`npm run lint:comments:self-test` runs 21 fixture cases: 8 must-flag (covering every ephemeral pattern above, including the issue's exact planted-comment / planted-`describe()` acceptance cases), 13 must-not-flag (every durable form above, plus the hex-color/ordinary-English false-positive traps: `audit log`, `audit ledger`, a hex color 20 chars from the word "issue").

## Scope finding + resolution

A full scan initially found 381 pre-existing citation tokens across 175/268 tracked files under the original (broader) pattern set — this repo's dominant historical comment style, not the two hand-fixed leaks the issue assumed. After the owner's policy call above, re-scanning with the narrowed patterns shrinks the baseline to **109 tokens across 55 files** — real GH issue/PR-number citations and bare finding/`(P#)` labels, which genuinely are ephemeral, not the durable spec/wave/backlog/phase narrative that made up most of the original count.

The check ships with a **content-keyed baseline** (`scripts/comment-hygiene-baseline.json`): every pre-existing ephemeral ref is grandfathered by its exact normalized text (e.g. `issue #16`, `finding-4`), not by line number, so an unrelated edit two lines above never invalidates an entry. Any citation beyond what's baselined — a brand-new one, or one more of an existing token in the same file — still fails (verified: planting `issue #12345` in `shared/protocol.ts` fails correctly; planting durable-narrative text — `spec-777`, `wave 9.9`, `backlog 3.3` — in `shared/edit-feed.ts` produces zero violations, confirming the allow-list actually holds).

**0 refs stripped in this PR.** `npm run lint:comments:update-baseline` exists for deliberately retiring a citation later by restating its invariant directly.

## Wired into the gate

No `.github/workflows/` exists in this repo yet — the gate is the documented `CLAUDE.md` list. Added `npm run lint:comments` there alongside `typecheck`/`build`/`test`, plus `lint:comments:update-baseline` and `lint:comments:self-test`.

## Gate tails

```
$ npm run typecheck
tsc -p cli --noEmit && tsc -p plugin --noEmit
(clean, no output)

$ npm run build
cli/dist/figma-agent.js  243.6kb
plugin/code.js  190.8kb

$ npm run lint:comments:self-test
ok — issue citation in a comment
ok — issue citation in a describe() name
ok — fixes # shorthand
ok — dated plan-dir slug citation
ok — dated spec-number citation
ok — parenthesized finding-label citation
ok — bare finding-number citation
ok — audit-code label citation
ok — clean equivalent of an issue comment
ok — clean describe() name
ok — committed 3-digit spec citation (space form)
ok — committed 3-digit spec citation (dash form)
ok — roadmap wave citation
ok — backlog section citation
ok — review-round citation
ok — bare phase label (no tracker number)
ok — hex color is not an issue number
ok — numeric hex color stays clean without an issue word
ok — the word issue near an unrelated hex code stays clean
ok — ordinary "audit log" usage stays clean
ok — ordinary "audit ledger" usage stays clean
self-test: 21/21 cases passed.

$ npm run lint:comments
comment-hygiene: clean (55 file(s) with baselined citations, 0 new).
```

`npm test` / the broker-daemon-harness suite intentionally not run per task constraint (live plugin session safety, #32) — not touched here. Files owned by the parallel contention-log task (`cli/src/transport/contention-log.ts`, `job-table.ts`, `error-log.ts`, `cli/src/commands/contention.ts`) were not edited; the hygiene scan found no ephemeral leaks in them.