### PR TITLE
Durable per-file contention counter for queued mutation time

### DIFF
--- a/cli/src/commands/contention.ts
+++ b/cli/src/commands/contention.ts
@@ -1,0 +1,88 @@
+// `figma-agent contention` — the agent's read path over the durable per-file contention
+// counter (`design/figma-contention.json`, contention-log.ts). This is the evidence the
+// locked decision to revisit finer-than-per-file locking depends on ("only when queuedMs
+// measures > 5 min/day for real" — job-table.ts's own decision-6 note): the job table
+// alone cannot answer that question, because its finished records are capped and TTL'd
+// (job-table.ts) long before a day's total could accumulate. This command's output IS
+// the measurement that trigger needs.
+//
+//   figma-agent contention [--file <name>] [--since <days>]
+//
+// Pure fs read, no broker round-trip — works even with the plugin closed, same contract
+// as `changes`/`errors`. Unlike `changes` (one feed file per project file), the store is
+// one shared JSON object keyed by every file's own slug, so `--file` FILTERS entries
+// (case-insensitive substring against the raw fileSlug key) rather than picking a file on
+// disk — the same shape as `errors`' own `--file`.
+import type { CommandArgs } from '../figma-agent.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+import { contentionLogPath, readContentionStore, type ContentionStore } from '../transport/contention-log.ts';
+
+export interface ContentionRow {
+  fileSlug: string;
+  day: string;
+  totalQueuedMs: number;
+  jobCount: number;
+}
+
+export interface ContentionFilter {
+  file?: string;
+  /** Only days within the last N UTC calendar days, inclusive of today. */
+  sinceDays?: number;
+}
+
+/** `--since <days>` must be a non-negative finite number — `args.num` already rejects a
+ *  non-numeric string, but (same gap `changes.ts`'s `validateLimit` closed for `--limit`)
+ *  lets `Infinity`/negative values through as clean numbers that would otherwise silently
+ *  mean "everything" or "nothing" for a value that never legitimately meant that. */
+export function validateSinceDays(n: number | undefined): number | undefined {
+  if (n === undefined) return undefined;
+  if (!Number.isFinite(n) || n < 0) {
+    throw new CliError('E_INVALID_ARGS', `--since must be a non-negative number of days, got "${n}"`);
+  }
+  return n;
+}
+
+function sinceCutoffKey(sinceDays: number, now: number): string {
+  const cutoff = new Date(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - sinceDays);
+  return cutoff.toISOString().slice(0, 10);
+}
+
+/** Flattens the keyed store into rows (one per file/day), optionally filtered by
+ *  `--file` / `--since <days>`, newest day first within each file. */
+export function flattenContention(store: ContentionStore, filter: ContentionFilter, now: number): ContentionRow[] {
+  const needle = filter.file?.trim().toLowerCase();
+  const cutoffKey = filter.sinceDays !== undefined ? sinceCutoffKey(filter.sinceDays, now) : undefined;
+  const rows: ContentionRow[] = [];
+  for (const [fileSlug, days] of Object.entries(store)) {
+    if (needle !== undefined && !fileSlug.toLowerCase().includes(needle)) continue;
+    for (const [day, totals] of Object.entries(days)) {
+      if (cutoffKey !== undefined && day < cutoffKey) continue;
+      rows.push({ fileSlug, day, totalQueuedMs: totals.totalQueuedMs, jobCount: totals.jobCount });
+    }
+  }
+  rows.sort((a, b) => (a.fileSlug === b.fileSlug ? b.day.localeCompare(a.day) : a.fileSlug.localeCompare(b.fileSlug)));
+  return rows;
+}
+
+export async function run(args: CommandArgs): Promise<unknown> {
+  const file = args.str('file');
+  const sinceDays = validateSinceDays(args.num('since'));
+
+  const path = contentionLogPath();
+  const store = readContentionStore(path);
+  const rows = flattenContention(store, { file, sinceDays }, Date.now());
+  const totalQueuedMs = rows.reduce((sum, r) => sum + r.totalQueuedMs, 0);
+  const totalJobCount = rows.reduce((sum, r) => sum + r.jobCount, 0);
+
+  return {
+    // Resolved path printed for the same reason `changes`'/`errors`' own path is — a
+    // cwd/broker spawn-cwd mismatch is visible, never silent.
+    logPath: path,
+    since: sinceDays ?? null,
+    count: rows.length,
+    totalQueuedMs,
+    totalJobCount,
+    rows,
+  };
+}

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -9,6 +9,7 @@ import { getLastFileContext, setExpectedFile, setExpectedInstance, setProjectDir
 import { printErrorJson, printJson, withFileContext } from './util/json-out.ts';
 import * as batch from './commands/batch.ts';
 import * as changes from './commands/changes.ts';
+import * as contention from './commands/contention.ts';
 import * as errors from './commands/errors.ts';
 import * as bind from './commands/bind.ts';
 import * as bindVariable from './commands/bind-variable.ts';
@@ -68,6 +69,7 @@ const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown>
   batch,
   changes,
   errors,
+  contention,
 };
 
 const HELP = `figma-agent — CLI bridge to the Figma plugin (via a local WS broker)
@@ -119,6 +121,10 @@ Commands:
   errors               [--since ts|iso --file name --limit 50]  read the broker's error log
                        (backlog 4.6) — full untruncated message + cmd/activity/code/fileName,
                        for an agent to read-and-fix; --file filters by the entry's own fileName
+  contention           [--file name --since days]  read the durable per-file/per-day
+                       queued-time counter — total ms a mutation waited in the FIFO before
+                       dispatch, plus jobCount, per UTC day; --file filters by fileSlug,
+                       --since limits to the last N days; pure fs, works with the plugin closed
 
 Global: --file "<exact file name>"   route to that file's plugin AND refuse to run anywhere else
                                      (exact, case-insensitive; beats FIGMA_AGENT_FILE; payloads

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -34,6 +34,7 @@ import {
   appendEditFrames, editFeedPathForIdentity, migrateLegacyUnboundEdits, safeSlug, unboundEditStagingPath,
 } from './edit-feed-log.ts';
 import { appendErrorFrame, buildErrorLogFrame, errorLogPathFor, unboundErrorStagingPath } from './error-log.ts';
+import { addQueued as addQueuedContention, contentionLogPath, contentionLogPathFor } from './contention-log.ts';
 import { readIdleMs, readIdleMsFor } from './figma-sync-config.ts';
 import { spawnReconcileApply } from './figma-sync-apply.ts';
 import {
@@ -308,6 +309,30 @@ function appendErrorLog(errorsPath: string, reply: ReplyErr, fallbackFileName: s
   } catch (err) {
     errorLogAppendFailures += 1;
     log(`ERROR_LOG append failed (${errorLogAppendFailures} total): ${(err as Error).message}`);
+  }
+}
+
+/** Count of `appendContentionLog` failures since the broker started — same shape as
+ *  `errorLogAppendFailures`, logged alongside every failure so a repeatedly-failing write
+ *  is visible as a trend, not a single easy-to-miss line. */
+let contentionLogAppendFailures = 0;
+
+/**
+ * Write-through one finished job's `queuedMs` into its file's durable contention counter
+ * (contention-log.ts) — best-effort, same contract as appendErrorLog/appendEditFeed: a
+ * log failure must never disrupt the relay. `job-table.ts` only stamps `queuedMs` in
+ * `markRunning` (a mutating job that actually got dispatched) and `cancelQueued` (one
+ * cancelled while still queued); a job that fails straight out of the queue without
+ * either (its pinned plugin vanished before it ever ran) carries no `queuedMs` at all —
+ * `undefined` here means exactly that, nothing to add, never a bug to paper over.
+ */
+function appendContentionLog(path: string, fileSlug: string, queuedMs: number | undefined, now: number): void {
+  if (queuedMs === undefined) return;
+  try {
+    addQueuedContention(path, fileSlug, queuedMs, now);
+  } catch (err) {
+    contentionLogAppendFailures += 1;
+    log(`CONTENTION_LOG append failed (${contentionLogAppendFailures} total): ${(err as Error).message}`);
   }
 }
 
@@ -667,6 +692,22 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const errReplyFrame = (id: string, code: ErrorCode, message: string): string =>
     JSON.stringify({ id, ok: false, error: { code, message } } satisfies ReplyErr);
 
+  /**
+   * Write-through a finished job's `queuedMs` into its durable contention counter — the
+   * ONE seam every `st.jobs.finish`/`cancelQueued` call site below routes through, right
+   * after the job table itself has finalized the record, so the durable counter and the
+   * in-memory job table can never disagree. Path resolution mirrors the SAME
+   * fileIdentity→resolveProjectDir shape DOC_CHANGE/EDIT_FEED/the error log already use:
+   * a bound file's counter lives in its own project, an unbound one falls back to the
+   * broker's own cwd default (there is nowhere else to durably route it before a bind
+   * exists — same accepted limitation `PLUGIN_HELLO`'s own idle-window fallback states).
+   */
+  const recordContention = (rec: Pick<JobRecord, 'fileSlug' | 'queuedMs'>): void => {
+    const bound = resolveProjectDir(rec.fileSlug, st.bindIndex);
+    const path = bound ? contentionLogPathFor(bound) : contentionLogPath();
+    appendContentionLog(path, rec.fileSlug, rec.queuedMs, Date.now());
+  };
+
   /** Send every held frame, in order, to the resolved target — one call for a normal
    *  request, N in sequence for a chunked one (the frames are already the full, ordered
    *  wire payload; the broker never reassembles or re-derives them). */
@@ -680,6 +721,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     } catch (err) {
       const msg = `relay to plugin failed: ${(err as Error).message}`;
       st.jobs.finish(job.jobId, false, [errReplyFrame(job.requestId, 'E_PLUGIN_ERROR', msg)]);
+      recordContention(job);
       if (job.from && job.from.readyState === WebSocket.OPEN) sendReplyErr(job.from, job.requestId, 'E_PLUGIN_ERROR', msg);
       st.pending.delete(job.requestId);
       st.dispatchedTo.delete(job.requestId);
@@ -719,6 +761,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       const msg = 'Figma plugin disconnected while this job was queued';
       const frame = errReplyFrame(nextJob.requestId, 'E_NO_PLUGIN', msg);
       st.jobs.finish(nextJob.jobId, false, [frame]);
+      recordContention(nextJob);
       if (nextJob.from && nextJob.from.readyState === WebSocket.OPEN) {
         try { nextJob.from.send(frame); } catch { /* requester vanished */ }
       }
@@ -976,6 +1019,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         // (`handleClose`'s CLI branch used to drop `pending` before the reply could land).
         const ok = replyOk(job.replyFrames);
         st.jobs.finish(job.jobId, ok, job.replyFrames);
+        recordContention(job);
         advanceQueue(job);
       }
     }
@@ -1028,6 +1072,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         if (rec !== 'unknown' && rec !== 'expired') {
           const q = st.queues.get(rec.fileSlug);
           if (q) st.queues.set(rec.fileSlug, removeFromQueue(q, jobId));
+          recordContention(rec); // cancelQueued stamps queuedMs itself — this IS its finalization
         }
       }
       sendReplyOk(ws, msg.id, result);
@@ -1067,6 +1112,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (rec.state === 'running') {
         st.jobs.finish(jobId, false, [errReplyFrame(rec.requestId, 'E_TIMEOUT',
           'force-released — the script may still be running; its result (if any) is discarded and unverified')]);
+        recordContention(rec);
       }
       // Stage-4 fix round (M4, ruling Q1) — "discarded means discarded": if the wedged
       // script DOES eventually reply, `routeFromPlugin` must not forward it to a CLI that
@@ -1152,6 +1198,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       const job = st.jobs.byRequestId(id);
       if (job) {
         st.jobs.finish(job.jobId, false, [errReplyFrame(id, 'E_NO_PLUGIN', msg)]);
+        recordContention(job);
         const q = st.queues.get(job.fileSlug);
         if (q && q.running === job.jobId) {
           advanceQueue(job);
@@ -1469,6 +1516,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       const msg = `no reply within ${WATCHDOG_TIMEOUT_MS}ms — the script may still be running; ` +
         `this file's mutation slot stays blocked until 'figma-agent job ${job.jobId} --force-release'`;
       st.jobs.finish(job.jobId, false, [errReplyFrame(job.requestId, 'E_TIMEOUT', msg)]);
+      recordContention(job);
       log(`watchdog: job ${job.jobId} (${job.cmd}) timed out — slot for "${job.fileSlug}" stays blocked`);
       // Deliberately NO advanceQueue(job) here — see the comment above.
     }

--- a/cli/src/transport/contention-log.ts
+++ b/cli/src/transport/contention-log.ts
@@ -1,0 +1,150 @@
+// Durable per-file, per-UTC-day contention counter — fs layer for the broker.
+//
+// `job-table.ts` stamps `queuedMs` (time a mutation waited in a file's FIFO before
+// dispatch) on a job record in `markRunning`/`cancelQueued`, but that record only lives
+// as long as the job table keeps it: FINISHED records are capped at `JOB_FINISHED_CAP`
+// and evicted after `JOB_TTL_MS` (job-table.ts). A per-file daily total built only from
+// that table can therefore never accumulate long enough to answer the locked decision
+// to revisit finer-than-per-file locking ("only when queuedMs measures > 5 min/day for
+// real" — job-table.ts's own decision-6 note). This store is that daily total's durable
+// home: it is never evicted on the job table's TTL/cap schedule, only pruned by its own
+// retention window below.
+//
+// A deliberate near-copy of error-log.ts's path handling (broker-cwd-independent base +
+// explicit-project routing), but a different SHAPE: a single JSON object (a running
+// total per file/day), not an append-only JSONL event log — an event log of every job
+// that ever finished would grow forever for no benefit this counter needs. Keyed by the
+// SAME file-slug identity every other durable feed uses (file-identity.ts), via the
+// `fileSlug` job records already carry.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+import { changeLogDir } from './change-log.ts';
+
+export const CONTENTION_LOG_FILENAME = 'figma-contention.json';
+
+/** Days of history kept per file, pruned on every write to that file's bucket —
+ *  deterministic by UTC calendar date, never a silent drop: a day this far in the past
+ *  no longer bears on "does queuedMs exceed 5 min/day", so it is dropped on the next
+ *  write to that file, not archived or counted (Law 1 is satisfied by this comment
+ *  stating the rule, the same way the other durable feeds' rotation policy is a stated
+ *  size, not a counted event). */
+export const CONTENTION_RETENTION_DAYS = 30;
+
+/** `<changeLogDir()>/figma-contention.json` — shares changeLogDir()'s
+ *  `FIGMA_AGENT_CHANGES_DIR` override, same base as the change/edit/error logs. This is
+ *  the broker-cwd default, used when no project binding resolves for a job's fileSlug
+ *  (mirrors error-log.ts's `errorLogPath`). */
+export function contentionLogPath(): string {
+  return join(changeLogDir(), CONTENTION_LOG_FILENAME);
+}
+
+/** The SAME filename, rooted at an explicit project dir instead of the broker's cwd
+ *  (mirrors error-log.ts's `errorLogPathFor` / edit-feed-log.ts's
+ *  `editFeedPathForIdentity`). */
+export function contentionLogPathFor(projectDir: string): string {
+  return join(projectDir, 'design', CONTENTION_LOG_FILENAME);
+}
+
+/** One UTC calendar day's tally for one file. */
+export interface ContentionDayTotals {
+  totalQueuedMs: number;
+  jobCount: number;
+}
+
+/** `{ [fileSlug]: { [YYYY-MM-DD]: ContentionDayTotals } }` — the whole store, small by
+ *  construction (one entry per file per day, bounded by `CONTENTION_RETENTION_DAYS`). */
+export type ContentionStore = Record<string, Record<string, ContentionDayTotals>>;
+
+/** UTC calendar-day key, `YYYY-MM-DD`. `now` is always passed in by the caller (the
+ *  daemon has it) — this module never calls `Date.now()` itself, so every accumulation
+ *  and retention decision below is exercised deterministically by tests. */
+export function utcDayKey(now: number): string {
+  return new Date(now).toISOString().slice(0, 10);
+}
+
+function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return v !== null && typeof v === 'object' && !Array.isArray(v);
+}
+
+function isValidDayTotals(v: unknown): v is ContentionDayTotals {
+  if (!isPlainObject(v)) return false;
+  return typeof v.totalQueuedMs === 'number' && Number.isFinite(v.totalQueuedMs) &&
+    typeof v.jobCount === 'number' && Number.isFinite(v.jobCount);
+}
+
+/**
+ * Shape-guards a raw parsed JSON blob into a valid `ContentionStore`, dropping anything
+ * that does not match rather than throwing — same reasoning as error-log.ts's
+ * `isValidErrorLogFrame` gate: a corrupt or partially-written file must never crash the
+ * broker's write path or the reader command, it just degrades to "nothing recorded yet"
+ * for the malformed slice.
+ */
+function sanitizeStore(raw: unknown): ContentionStore {
+  const store: ContentionStore = {};
+  if (!isPlainObject(raw)) return store;
+  for (const [fileSlug, days] of Object.entries(raw)) {
+    if (!isPlainObject(days)) continue;
+    const cleanDays: Record<string, ContentionDayTotals> = {};
+    for (const [day, totals] of Object.entries(days)) {
+      if (isValidDayTotals(totals)) cleanDays[day] = totals;
+    }
+    if (Object.keys(cleanDays).length > 0) store[fileSlug] = cleanDays;
+  }
+  return store;
+}
+
+/** Reads the store at `path`. A missing file reads as empty — no job has ever finished
+ *  yet, not an error (same contract as error-log.ts/errors.ts's `readErrorLog`). A
+ *  corrupt file also reads as empty rather than throwing (see `sanitizeStore`); the next
+ *  write starts a fresh store instead of ever blocking the relay on a bad read. */
+export function readContentionStore(path: string): ContentionStore {
+  if (!existsSync(path)) return {};
+  try {
+    return sanitizeStore(JSON.parse(readFileSync(path, 'utf8')));
+  } catch {
+    return {};
+  }
+}
+
+/** Drops any day older than `CONTENTION_RETENTION_DAYS` before `today` (a `YYYY-MM-DD`
+ *  key), for one file's own day-bucket. */
+function pruneFileDays(days: Record<string, ContentionDayTotals>, today: string): Record<string, ContentionDayTotals> {
+  const cutoff = new Date(today);
+  cutoff.setUTCDate(cutoff.getUTCDate() - CONTENTION_RETENTION_DAYS);
+  const cutoffKey = cutoff.toISOString().slice(0, 10);
+  const pruned: Record<string, ContentionDayTotals> = {};
+  for (const [day, totals] of Object.entries(days)) {
+    if (day >= cutoffKey) pruned[day] = totals;
+  }
+  return pruned;
+}
+
+/** Parent dir of a file path (mirrors change-log.ts's / error-log.ts's private helper —
+ *  kept separate per the "near-copy, deliberately separate" contract those already
+ *  state, rather than sharing a util that would couple the log layers). */
+function resolveDir(filePath: string): string {
+  const idx = filePath.lastIndexOf('/');
+  return idx <= 0 ? filePath : filePath.slice(0, idx);
+}
+
+/**
+ * Write-through: add one finished job's `queuedMs` to its file's today bucket (UTC),
+ * creating the `design/` dir and the store file as needed, then prune that file's own
+ * day-bucket down to the retention window. Read-modify-write of the whole (small,
+ * pruned) JSON file — this is a low-frequency accumulator (one call per finished job,
+ * never a hot path), so a full rewrite per call is the KISS choice over a partial-update
+ * scheme. Safe against interleaving with itself: every call site in the daemon is
+ * synchronous end-to-end (no `await` between the read and the write), and Node's single
+ * threaded event loop cannot interleave two synchronous call stacks.
+ */
+export function addQueued(path: string, fileSlug: string, queuedMs: number, now: number): void {
+  const store = readContentionStore(path);
+  const today = utcDayKey(now);
+  const fileDays = store[fileSlug] ?? {};
+  const existing = fileDays[today] ?? { totalQueuedMs: 0, jobCount: 0 };
+  fileDays[today] = { totalQueuedMs: existing.totalQueuedMs + queuedMs, jobCount: existing.jobCount + 1 };
+  store[fileSlug] = pruneFileDays(fileDays, today);
+  mkdirSync(resolveDir(path), { recursive: true });
+  writeFileSync(path, JSON.stringify(store), 'utf8');
+}

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -26,6 +26,7 @@ import { join } from 'node:path';
 import WebSocket from 'ws';
 import { makeRequestFrame } from '../shared/protocol.ts';
 import type { EventMsg, JobInfo, ReplyErr, ReplyOk, WireMsg } from '../shared/protocol.ts';
+import type { ContentionStore } from '../cli/src/transport/contention-log.ts';
 
 type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts');
 
@@ -918,5 +919,95 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr3-b'));
     const polledB = await pollJob(cliB, jobB, 'req-fr3-poll-b');
     expect(polledB.job.state).toBe('running');
+  });
+});
+
+describe('daemon harness — a finished job\'s queuedMs write-throughs into the durable contention counter', () => {
+  it('an UNBOUND file\'s queued time lands at the broker cwd default, keyed by its own fileSlug', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-cont-1', 'Contention File');
+    const pluginFrames = collectFrames(plugin);
+
+    const cli = await connectSocket(port);
+    const jobId = await sendMutatingJob(cli, 'req-cont-1');
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-cont-1'));
+    plugin.send(JSON.stringify({ id: 'req-cont-1', ok: true, result: {} } satisfies ReplyOk));
+    await pollJob(cli, jobId, 'req-cont-1-poll'); // the job is terminal by the time this resolves
+
+    // No PROJECT_BIND ever happened for this identity — the broker's own cwd default
+    // (FIGMA_AGENT_CHANGES_DIR, same base changeLogDir()/errorLogPath() use).
+    const path = join(scratchDir, 'figma-contention.json');
+    await waitFor(() => existsSync(path));
+    const store = JSON.parse(readFileSync(path, 'utf8')) as ContentionStore;
+    const slug = 'contention-file'; // safeSlug('Contention File') — no fileKey, so fileIdentity falls back to the name slug
+    const days = store[slug];
+    expect(days).toBeDefined();
+    const totals = Object.values(days!)[0]!;
+    expect(totals.jobCount).toBe(1);
+    expect(totals.totalQueuedMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('a BOUND file\'s queued time lands in its OWN project, never the broker cwd default', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-cont-2', 'Bound Contention File');
+
+    const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-bound-contention-'));
+    try {
+      const cliBind = await connectSocket(port);
+      await bindProject(cliBind, 'Bound Contention File', boundProjectDir, 'req-cont-bind');
+
+      const cli = await connectSocket(port);
+      const pluginFrames = collectFrames(plugin);
+      const jobId = await sendMutatingJob(cli, 'req-cont-2');
+      await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-cont-2'));
+      plugin.send(JSON.stringify({ id: 'req-cont-2', ok: true, result: {} } satisfies ReplyOk));
+      await pollJob(cli, jobId, 'req-cont-2-poll');
+
+      const boundPath = join(boundProjectDir, 'design', 'figma-contention.json');
+      const cwdDefaultPath = join(scratchDir, 'figma-contention.json');
+      await waitFor(() => existsSync(boundPath));
+      const store = JSON.parse(readFileSync(boundPath, 'utf8')) as ContentionStore;
+      const slug = 'bound-contention-file';
+      expect(store[slug]).toBeDefined();
+      expect(Object.values(store[slug]!)[0]!.jobCount).toBe(1);
+      // Never ALSO written to the broker's own cwd default for this identity.
+      if (existsSync(cwdDefaultPath)) {
+        const cwdStore = JSON.parse(readFileSync(cwdDefaultPath, 'utf8')) as ContentionStore;
+        expect(cwdStore[slug]).toBeUndefined();
+      }
+    } finally {
+      rmSync(boundProjectDir, { recursive: true, force: true });
+    }
+  });
+
+  it('a job cancelled while still QUEUED also write-throughs its own queuedMs (cancelQueued stamps it, not markRunning)', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-cont-3', 'Cancel Contention File');
+    const pluginFrames = collectFrames(plugin);
+
+    const cliA = await connectSocket(port);
+    await sendMutatingJob(cliA, 'req-cont-3a'); // dispatched immediately — occupies the file's slot
+    await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-cont-3a'));
+
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-cont-3b'); // QUEUED behind job A
+
+    cliB.send(JSON.stringify(makeRequestFrame('req-cont-3-cancel', 'JOB', { mode: 'cancel', jobId: jobB })));
+    const cancelReply = await nextFrame<ReplyOk>(cliB, (m) => (m as ReplyOk).id === 'req-cont-3-cancel');
+    expect((cancelReply.result as { ok: boolean }).ok).toBe(true);
+
+    const path = join(scratchDir, 'figma-contention.json');
+    const slug = 'cancel-contention-file';
+    await waitFor(() => {
+      if (!existsSync(path)) return false;
+      const store = JSON.parse(readFileSync(path, 'utf8')) as ContentionStore;
+      return store[slug] !== undefined;
+    });
+    const store = JSON.parse(readFileSync(path, 'utf8')) as ContentionStore;
+    // Job A is still running (unfinished) — only job B's cancelled queuedMs is recorded so far.
+    expect(Object.values(store[slug]!)[0]!.jobCount).toBe(1);
   });
 });

--- a/tests/contention-command.test.ts
+++ b/tests/contention-command.test.ts
@@ -1,0 +1,130 @@
+// `figma-agent contention` — pure filtering/flattening + one full `run()` pass over a
+// real fixture store (tmpdir, FIGMA_AGENT_CHANGES_DIR override — same convention as
+// errors-command.test.ts).
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from '../cli/src/arg-parse.ts';
+import { flattenContention, run, validateSinceDays, type ContentionRow } from '../cli/src/commands/contention.ts';
+import { CONTENTION_LOG_FILENAME, type ContentionStore } from '../cli/src/transport/contention-log.ts';
+import { CliError } from '../cli/src/transport/protocol-helpers.ts';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+const FIXTURE: ContentionStore = {
+  'vsf-pcp': {
+    '2026-01-15': { totalQueuedMs: 1000, jobCount: 4 },
+    '2026-01-10': { totalQueuedMs: 300, jobCount: 1 },
+  },
+  'platform-design-system': {
+    '2026-01-14': { totalQueuedMs: 50, jobCount: 1 },
+  },
+};
+
+describe('flattenContention', () => {
+  it('flattens every file/day into rows, newest day first within each file', () => {
+    const rows = flattenContention(FIXTURE, {}, NOW);
+    expect(rows).toEqual<ContentionRow[]>([
+      { fileSlug: 'platform-design-system', day: '2026-01-14', totalQueuedMs: 50, jobCount: 1 },
+      { fileSlug: 'vsf-pcp', day: '2026-01-15', totalQueuedMs: 1000, jobCount: 4 },
+      { fileSlug: 'vsf-pcp', day: '2026-01-10', totalQueuedMs: 300, jobCount: 1 },
+    ]);
+  });
+
+  it('--file filters by a case-insensitive substring against the raw fileSlug', () => {
+    const rows = flattenContention(FIXTURE, { file: 'VSF' }, NOW);
+    expect(rows.map((r) => r.fileSlug)).toEqual(['vsf-pcp', 'vsf-pcp']);
+  });
+
+  it('--since <days> keeps only days within the last N UTC calendar days, inclusive of today', () => {
+    const rows = flattenContention(FIXTURE, { sinceDays: 1 }, NOW); // today + yesterday only
+    expect(rows.map((r) => r.day)).toEqual(['2026-01-14', '2026-01-15']);
+  });
+
+  it('--file and --since compose', () => {
+    const rows = flattenContention(FIXTURE, { file: 'vsf', sinceDays: 1 }, NOW);
+    expect(rows).toEqual<ContentionRow[]>([
+      { fileSlug: 'vsf-pcp', day: '2026-01-15', totalQueuedMs: 1000, jobCount: 4 },
+    ]);
+  });
+
+  it('an unmatched --file yields an empty result, never throws', () => {
+    expect(flattenContention(FIXTURE, { file: 'nope' }, NOW)).toEqual([]);
+  });
+});
+
+describe('validateSinceDays', () => {
+  it('undefined passes through', () => {
+    expect(validateSinceDays(undefined)).toBeUndefined();
+  });
+
+  it('rejects a negative value', () => {
+    expect(() => validateSinceDays(-1)).toThrow(CliError);
+  });
+
+  it('rejects a non-finite value (Infinity)', () => {
+    expect(() => validateSinceDays(Number.POSITIVE_INFINITY)).toThrow(CliError);
+  });
+
+  it('accepts zero and positive finite values', () => {
+    expect(validateSinceDays(0)).toBe(0);
+    expect(validateSinceDays(7)).toBe(7);
+  });
+});
+
+describe('run — full envelope over a real fixture store', () => {
+  let dir: string;
+  const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'fa-contention-run-'));
+    process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+    writeFileSync(join(dir, CONTENTION_LOG_FILENAME), JSON.stringify(FIXTURE), 'utf8');
+  });
+  afterEach(() => {
+    if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
+    else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('reads the store, reports totals + every row', async () => {
+    const out = await run(parseArgs([])) as {
+      logPath: string; since: number | null; count: number; totalQueuedMs: number; totalJobCount: number; rows: ContentionRow[];
+    };
+    expect(out.logPath).toContain(CONTENTION_LOG_FILENAME);
+    expect(out.since).toBeNull();
+    expect(out.count).toBe(3);
+    expect(out.totalQueuedMs).toBe(1000 + 300 + 50);
+    expect(out.totalJobCount).toBe(4 + 1 + 1);
+    expect(out.rows).toHaveLength(3);
+  });
+
+  it('--file filters by fileSlug', async () => {
+    const out = await run(parseArgs(['--file', 'platform'])) as { rows: ContentionRow[]; count: number };
+    expect(out.count).toBe(1);
+    expect(out.rows[0]!.fileSlug).toBe('platform-design-system');
+  });
+
+  it('--since <days> limits to the last N days (relative to real Date.now — a wide window keeps a 2026 fixture)', async () => {
+    const out = await run(parseArgs(['--since', '36500'])) as { rows: ContentionRow[]; count: number };
+    expect(out.count).toBe(3);
+  });
+
+  it('--since 0 excludes every day before real today', async () => {
+    const out = await run(parseArgs(['--since', '0'])) as { rows: ContentionRow[]; count: number };
+    expect(out.count).toBe(0); // the fixture's fixed 2026-01 dates are all before the real "today"
+  });
+
+  it('rejects a negative --since', async () => {
+    await expect(run(parseArgs(['--since', '-1']))).rejects.toThrow(CliError);
+  });
+
+  it('a missing store file reads as empty, never throws', async () => {
+    rmSync(join(dir, CONTENTION_LOG_FILENAME));
+    const out = await run(parseArgs([])) as { count: number; rows: ContentionRow[] };
+    expect(out.count).toBe(0);
+    expect(out.rows).toEqual([]);
+  });
+});

--- a/tests/contention-log.test.ts
+++ b/tests/contention-log.test.ts
@@ -1,0 +1,139 @@
+// Durable per-file/per-day contention counter — fs layer for the broker. Mirrors
+// error-log.test.ts's shape (tmpdir + FIGMA_AGENT_CHANGES_DIR override), but this store
+// is a single keyed JSON object (a running total), not an append-only JSONL log — so
+// these tests exercise accumulation + retention pruning instead of append-only growth.
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  CONTENTION_LOG_FILENAME, CONTENTION_RETENTION_DAYS,
+  addQueued, contentionLogPath, contentionLogPathFor, readContentionStore, utcDayKey,
+} from '../cli/src/transport/contention-log.ts';
+
+let dir: string;
+const prevEnv = process.env['FIGMA_AGENT_CHANGES_DIR'];
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-contention-log-'));
+  process.env['FIGMA_AGENT_CHANGES_DIR'] = dir;
+});
+afterEach(() => {
+  if (prevEnv === undefined) delete process.env['FIGMA_AGENT_CHANGES_DIR'];
+  else process.env['FIGMA_AGENT_CHANGES_DIR'] = prevEnv;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// A fixed, deterministic UTC instant — noon, so a ±1 day nudge never crosses a
+// calendar-day boundary by accident.
+const T0 = Date.UTC(2026, 0, 15, 12, 0, 0);
+
+describe('contentionLogPath / contentionLogPathFor', () => {
+  it('the default lives at <changeLogDir()>/figma-contention.json', () => {
+    expect(contentionLogPath()).toBe(join(dir, CONTENTION_LOG_FILENAME));
+  });
+
+  it('the explicit-project variant is rooted at <projectDir>/design, not the broker cwd', () => {
+    expect(contentionLogPathFor('/tmp/some-project')).toBe(join('/tmp/some-project', 'design', CONTENTION_LOG_FILENAME));
+  });
+});
+
+describe('readContentionStore', () => {
+  it('a missing file reads as empty, not an error', () => {
+    expect(readContentionStore(join(dir, 'nope.json'))).toEqual({});
+  });
+
+  it('a corrupt (non-JSON) file reads as empty rather than throwing', () => {
+    const path = join(dir, 'bad.json');
+    writeFileSync(path, 'NOT JSON', 'utf8');
+    expect(readContentionStore(path)).toEqual({});
+  });
+
+  it('a shape-invalid entry is dropped, a valid sibling entry survives', () => {
+    const path = join(dir, 'mixed.json');
+    writeFileSync(path, JSON.stringify({
+      'good-file': { '2026-01-01': { totalQueuedMs: 500, jobCount: 2 } },
+      'bad-file': { '2026-01-01': { totalQueuedMs: 'not a number', jobCount: 1 } },
+    }), 'utf8');
+    expect(readContentionStore(path)).toEqual({
+      'good-file': { '2026-01-01': { totalQueuedMs: 500, jobCount: 2 } },
+    });
+  });
+});
+
+describe('addQueued — accumulation', () => {
+  it('two calls for the SAME file/day sum totalQueuedMs and increment jobCount', () => {
+    const path = contentionLogPath();
+    addQueued(path, 'vsf-pcp', 100, T0);
+    addQueued(path, 'vsf-pcp', 250, T0 + 1000); // same UTC day, a second later
+    const store = readContentionStore(path);
+    expect(store['vsf-pcp']?.[utcDayKey(T0)]).toEqual({ totalQueuedMs: 350, jobCount: 2 });
+  });
+
+  it('a DIFFERENT UTC day is a separate bucket for the same file', () => {
+    const path = contentionLogPath();
+    addQueued(path, 'vsf-pcp', 100, T0);
+    addQueued(path, 'vsf-pcp', 200, T0 + DAY_MS);
+    const store = readContentionStore(path);
+    const days = store['vsf-pcp']!;
+    expect(Object.keys(days).sort()).toEqual([utcDayKey(T0), utcDayKey(T0 + DAY_MS)]);
+    expect(days[utcDayKey(T0)]).toEqual({ totalQueuedMs: 100, jobCount: 1 });
+    expect(days[utcDayKey(T0 + DAY_MS)]).toEqual({ totalQueuedMs: 200, jobCount: 1 });
+  });
+
+  it('a DIFFERENT file gets its OWN bucket, never merged with another file\'s', () => {
+    const path = contentionLogPath();
+    addQueued(path, 'file-a', 100, T0);
+    addQueued(path, 'file-b', 900, T0);
+    const store = readContentionStore(path);
+    expect(store['file-a']?.[utcDayKey(T0)]?.totalQueuedMs).toBe(100);
+    expect(store['file-b']?.[utcDayKey(T0)]?.totalQueuedMs).toBe(900);
+  });
+
+  it('creates the file (and its parent dir) on the very first call', () => {
+    const path = join(dir, 'nested', 'figma-contention.json');
+    addQueued(path, 'vsf-pcp', 42, T0);
+    expect(JSON.parse(readFileSync(path, 'utf8'))).toEqual({
+      'vsf-pcp': { [utcDayKey(T0)]: { totalQueuedMs: 42, jobCount: 1 } },
+    });
+  });
+});
+
+describe('addQueued — retention pruning', () => {
+  it('a day older than the retention window is dropped the next time that file is written', () => {
+    const path = contentionLogPath();
+    const oldDay = T0;
+    const newDay = T0 + (CONTENTION_RETENTION_DAYS + 1) * DAY_MS; // just past the window
+    addQueued(path, 'vsf-pcp', 100, oldDay);
+    expect(readContentionStore(path)['vsf-pcp']?.[utcDayKey(oldDay)]).toBeDefined();
+
+    addQueued(path, 'vsf-pcp', 50, newDay); // triggers pruning for THIS file's bucket
+    const days = readContentionStore(path)['vsf-pcp']!;
+    expect(days[utcDayKey(oldDay)]).toBeUndefined();
+    expect(days[utcDayKey(newDay)]).toEqual({ totalQueuedMs: 50, jobCount: 1 });
+  });
+
+  it('a day exactly at the retention boundary is kept, one day past it is dropped', () => {
+    const path = contentionLogPath();
+    const boundaryDay = T0; // exactly CONTENTION_RETENTION_DAYS before `today` below
+    const today = T0 + CONTENTION_RETENTION_DAYS * DAY_MS;
+    addQueued(path, 'vsf-pcp', 10, boundaryDay);
+    addQueued(path, 'vsf-pcp', 20, today);
+    const days = readContentionStore(path)['vsf-pcp']!;
+    expect(days[utcDayKey(boundaryDay)]).toEqual({ totalQueuedMs: 10, jobCount: 1 });
+    expect(days[utcDayKey(today)]).toEqual({ totalQueuedMs: 20, jobCount: 1 });
+  });
+
+  it('pruning one file\'s bucket never touches another file\'s untouched bucket', () => {
+    const path = contentionLogPath();
+    const oldDay = T0;
+    const newDay = T0 + (CONTENTION_RETENTION_DAYS + 1) * DAY_MS;
+    addQueued(path, 'file-a', 100, oldDay);
+    addQueued(path, 'file-b', 100, oldDay);
+    addQueued(path, 'file-a', 50, newDay); // only file-a is written again
+    const store = readContentionStore(path);
+    expect(store['file-a']?.[utcDayKey(oldDay)]).toBeUndefined(); // pruned
+    expect(store['file-b']?.[utcDayKey(oldDay)]).toEqual({ totalQueuedMs: 100, jobCount: 1 }); // untouched, still there
+  });
+});


### PR DESCRIPTION
## Why

`queuedMs` (per-file time a mutation waited in the FIFO before dispatch, `job-table.ts`'s `markRunning`/`cancelQueued`) only lives on FINISHED job records, which are capped at `JOB_FINISHED_CAP = 200` and evicted after `JOB_TTL_MS = 10 min`. The locked decision to consider finer-than-per-file locking is gated behind "revisit only when `queuedMs` measures > 5 min/day for real" — but a per-file daily total built only from the job table can never accumulate that long. The trigger was permanently un-fireable. This is instrumentation only: no locking or queue behavior changes.

## Durable store design

- `cli/src/transport/contention-log.ts` — a small JSON store keyed `{ [fileSlug]: { [YYYY-MM-DD]: { totalQueuedMs, jobCount } } }`, a deliberate near-copy of `error-log.ts`'s path handling (broker-cwd-independent default + explicit-project routing, same `file-identity.ts` slug every other durable feed uses) but a different shape: a running total, not an append-only event log. `addQueued(path, fileSlug, queuedMs, now)` write-throughs with UTC-day bucketing; retention prunes any day older than 30 days on the next write to that file's own bucket (deterministic by date, stated in a comment — never a silent drop).

## Daemon-owns-IO seam

`job-table.ts` stays socket/IO-free per its own top-of-file invariant. `broker-daemon.ts` adds one `recordContention(rec)` closure, called right after every one of the 7 places a job's terminal state is set (`st.jobs.finish(...)` × 6 call sites, `st.jobs.cancelQueued(...)` × 1) — it resolves the same bound-vs-broker-cwd path DOC_CHANGE/EDIT_FEED/the error log already use, then write-throughs `rec.queuedMs` if defined. A job that fails straight out of the queue without ever running (`markRunning` never called) carries no `queuedMs`, and the write-through is a documented no-op for that case — an existing gap in what `job-table.ts` measures, not something this change alters.

## Reader

`figma-agent contention [--file <name>] [--since <days>]` (`cli/src/commands/contention.ts`, registered in `figma-agent.ts`) — pure fs read, works with the plugin closed, mirrors `errors`' shape. Its output is the actual measurement the locked decision needs.

## Test-first

New `contention-log.test.ts` (accumulation, per-day/per-file buckets, retention pruning) and `contention-command.test.ts` (filter/flatten, `run()` over a fixture) — all new code, so these necessarily failed before this change existed. Also appended 3 scenarios to `tests/broker-daemon-harness.test.ts` proving the daemon wiring seam end to end (unbound default path, bound project path, the cancel-while-queued path) — **not run as part of this PR's own gate**, per the live-plugin-session harness constraint; left for the orchestrator to run.

## Gate

- `npm run typecheck` — pass
- `npm run build` — pass
- New unit tests (`contention-log.test.ts` + `contention-command.test.ts`, 27 tests) — pass
- `npm test` / the broker-daemon-harness suite — **not run**, per the live-plugin-session constraint

## Test plan
- [ ] Orchestrator runs the full suite (harness tests included) in an environment without a live plugin session attached