### PR TITLE
fix: make the broker daemon's log path injectable

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -52,6 +52,13 @@ import type { ComponentChange } from '../../../shared/figma-changes.ts';
 import type { EditInput, EditSource } from '../../../shared/edit-feed.ts';
 
 const LOG_FILE = '/tmp/figma-agent-broker.log';
+// Resolved once at `runBrokerDaemon` startup (default: the constant above, unchanged
+// production behavior) — the log path is injectable so a test broker never appends to
+// the shared /tmp log a live dev session reads. `log()` reads this mutable binding
+// rather than the constant directly; safe as module state because each daemon run
+// resolves it exactly once, before any request handling (and therefore any `log()`
+// call) can occur.
+let activeLogFile: string = LOG_FILE;
 
 // envMs (protocol-helpers.ts) lets manual acceptance shrink the idle-shutdown /
 // heartbeat / plugin-wait knobs to seconds — shared with broker-discovery.ts so
@@ -162,7 +169,7 @@ interface BrokerState {
 
 function log(line: string): void {
   try {
-    appendFileSync(LOG_FILE, `${new Date().toISOString()} [${process.pid}] ${line}\n`);
+    appendFileSync(activeLogFile, `${new Date().toISOString()} [${process.pid}] ${line}\n`);
   } catch { /* logging is best-effort */ }
 }
 
@@ -338,17 +345,20 @@ function appendContentionLog(path: string, fileSlug: string, queuedMs: number | 
 
 /**
  * Closing round (daemon harness ruling) — every field defaults to today's real behaviour
- * (the shared /tmp advertisement file, the real 9410-9419 port range, `process.exit`).
- * The ONLY caller that ever overrides these is the in-process daemon harness
- * (tests/broker-daemon-harness.test.ts): a tmpdir advertisement path, `ports: [0]` (an
- * OS-assigned ephemeral bind, so a test broker never fights over — or clobbers — a real
- * one), and an `exit` stub that throws a sentinel instead of killing the test runner.
- * Production callers (figma-agent.ts's `__broker` entry) pass no options at all.
+ * (the shared /tmp advertisement file, the real 9410-9419 port range, `process.exit`, the
+ * shared /tmp log file). The ONLY caller that ever overrides these is the in-process
+ * daemon harness (tests/broker-daemon-harness.test.ts): a tmpdir advertisement path,
+ * `ports: [0]` (an OS-assigned ephemeral bind, so a test broker never fights over — or
+ * clobbers — a real one), an `exit` stub that throws a sentinel instead of killing the
+ * test runner, and a scratch `logFile` so a test broker never appends to the real
+ * /tmp/figma-agent-broker.log a live dev session shares. Production callers
+ * (figma-agent.ts's `__broker` entry) pass no options at all.
  */
 export interface BrokerDaemonOptions {
   advertisePath?: string;
   ports?: readonly number[];
   exit?: (code: number) => never;
+  logFile?: string;
 }
 
 function defaultPortRange(): number[] {
@@ -361,6 +371,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const advertisePath = options?.advertisePath ?? BROKER_FILE;
   const ports = options?.ports ?? defaultPortRange();
   const exit: (code: number) => never = options?.exit ?? ((code: number): never => process.exit(code));
+  // Resolved BEFORE any `log()` call below — a harness-spawned broker must never
+  // append to the real /tmp log a live dev session shares.
+  activeLogFile = options?.logFile ?? LOG_FILE;
 
   // Refuse to double-start when a live same-or-newer broker already advertises.
   const existing = readAdvertisement(advertisePath);

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -7,12 +7,13 @@
 //
 // Isolation (team-lead ruling, option B — dependency injection, NOT core extraction):
 // `runBrokerDaemon`'s optional `options` param — an OS-assigned ephemeral port
-// (`ports: [0]`), a tmpdir advertisement path, and an `exit` stub that THROWS instead of
-// killing the vitest worker — so this file NEVER touches this machine's real
-// /tmp/figma-agent-broker.json, the real 9410-9419 port range, or a real live broker. Also
-// redirects the change-log dir (`FIGMA_AGENT_CHANGES_DIR`, existing test convention — see
-// change-log.ts's own header) and the bind-cache file (`FIGMA_AGENT_BINDS_FILE`, existing
-// override — see project-bind.ts) to the same scratch tmpdir.
+// (`ports: [0]`), a tmpdir advertisement path, a scratch `logFile`, and an `exit` stub
+// that THROWS instead of killing the vitest worker — so this file NEVER touches this
+// machine's real /tmp/figma-agent-broker.json, the real 9410-9419 port range, the real
+// /tmp/figma-agent-broker.log, or a real live broker. Also redirects the change-log dir
+// (`FIGMA_AGENT_CHANGES_DIR`, existing test convention — see change-log.ts's own header)
+// and the bind-cache file (`FIGMA_AGENT_BINDS_FILE`, existing override — see
+// project-bind.ts) to the same scratch tmpdir.
 //
 // `WATCHDOG_TIMEOUT_MS`/`HEARTBEAT_MS`/etc. are `envMs(...)`-derived MODULE-LOAD-TIME
 // constants in broker-daemon.ts (not read per-call) — a `beforeEach` env assignment is too
@@ -31,12 +32,14 @@ import type { ContentionStore } from '../cli/src/transport/contention-log.ts';
 type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts');
 
 const WATCHDOG_MS_KEY = 'FIGMA_AGENT_WATCHDOG_MS';
+const PLUGIN_WAIT_MS_KEY = 'FIGMA_AGENT_PLUGIN_WAIT_MS';
 const CHANGES_DIR_KEY = 'FIGMA_AGENT_CHANGES_DIR';
 const BINDS_FILE_KEY = 'FIGMA_AGENT_BINDS_FILE';
 const UNBOUND_DIR_KEY = 'FIGMA_AGENT_UNBOUND_DIR';
 
 let scratchDir: string;
 let advertisePath: string;
+let scratchLogFile: string;
 let sockets: WebSocket[];
 
 /** Load `broker-daemon.ts` fresh, AFTER the given env vars are set — required for the
@@ -65,7 +68,9 @@ function testExit(): (code: number) => never {
 
 async function startTestBroker(env: Record<string, string> = {}): Promise<number> {
   const mod = await loadBrokerDaemon(env);
-  await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+  // `logFile` keeps this in-process broker's own log traffic in the scratch dir —
+  // the default `/tmp/figma-agent-broker.log` is shared with a live dev session.
+  await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit(), logFile: scratchLogFile });
   const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number };
   return ad.port;
 }
@@ -215,6 +220,7 @@ async function bindProject(
 beforeEach(() => {
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-broker-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
+  scratchLogFile = join(scratchDir, 'broker.log');
   sockets = [];
 });
 
@@ -777,14 +783,16 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
   });
 });
 
-// `--instance <id>` admission. NOT run by the executor: this harness
-// spawns a real in-process broker via `runBrokerDaemon`, and per the assigned constraint on
-// this machine a live plugin session is connected and this harness pollutes its broker
-// discovery (issue #32) — written here (the one file that exercises the real `admitRequest`
-// closure) and left for the orchestrator to run post-smoke.
+// `--instance <id>` admission — exercises the real `admitRequest` closure via a real
+// in-process broker started with its own scratch advertisement path, ephemeral port,
+// and log file, so it never touches a live plugin session's broker discovery.
 describe('daemon harness — admitRequest with an `--instance` (expectedInstance) filter', () => {
   it('an instanceId matching NO connected plugin → E_NO_PLUGIN names the instanceId, never "open the file panel"', async () => {
-    const port = await startTestBroker();
+    // A non-matching --instance parks (same as any unmatched filter) until the plugin-wait
+    // window elapses, then answers E_NO_PLUGIN — shrink the window so this test observes
+    // that real deadline instead of the 12s production default (same envMs override
+    // pattern the watchdog tests already use).
+    const port = await startTestBroker({ [PLUGIN_WAIT_MS_KEY]: '200' });
     const plugin = await connectSocket(port);
     await helloPlugin(plugin, 'inst-live', 'FileLive');
 
@@ -822,12 +830,9 @@ describe('daemon harness — admitRequest with an `--instance` (expectedInstance
 });
 
 // `job --force-release` guard (a HEALTHY still-running job is refused unless `--force`
-// overrides it; a watchdog-wedged job keeps unwedging with a bare `--force-release`). NOT
-// run by the executor: this harness spawns a real in-process broker via `runBrokerDaemon`,
-// and per the assigned constraint on this machine a live plugin session is connected and
-// this harness pollutes its broker discovery (issue #32) — written here (the one file that
-// exercises the real `handleJobCommand`/`advanceQueue` closures) and left for the
-// orchestrator to run post-smoke.
+// overrides it; a watchdog-wedged job keeps unwedging with a bare `--force-release`) —
+// exercises the real `handleJobCommand`/`advanceQueue` closures via a real in-process
+// broker, isolated from a live plugin session's broker discovery the same way as above.
 describe('daemon harness — force-release refuses a HEALTHY running job, allows `--force`, never regresses the wedged-unwedge path', () => {
   it('a bare `--force-release` on a job still `running` inside the watchdog window is REFUSED — the slot stays held, nothing advances', async () => {
     const port = await startTestBroker();
@@ -955,6 +960,11 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
 
     const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-bound-contention-'));
     try {
+      // `resolveProjectDir`'s own `isUsable()` treats a project without a `design/` dir
+      // as "stopped looking like a project" (never a fallback guess) — pre-create it the
+      // way a genuine bind target always already has one (same idiom as the other bound
+      // fixtures in this file).
+      mkdirSync(join(boundProjectDir, 'design'), { recursive: true });
       const cliBind = await connectSocket(port);
       await bindProject(cliBind, 'Bound Contention File', boundProjectDir, 'req-cont-bind');
 

--- a/tests/broker-daemon-log-file-default.test.ts
+++ b/tests/broker-daemon-log-file-default.test.ts
@@ -1,0 +1,82 @@
+// The log path is injectable so a test broker never appends to the shared /tmp log a
+// live dev session reads — this is the one remaining shared real resource
+// `BrokerDaemonOptions` did not already inject (advertisePath/ports/exit were).
+//
+// `node:fs`'s ESM namespace exports are not configurable (vi.spyOn can't touch them
+// directly), so the wrap is wired through vi.mock + vi.hoisted, same convention as
+// broker-advertisement-atomic.test.ts. Unlike that file, this wrapper does NOT call
+// through to the real `appendFileSync` when the target path is the real shared
+// default (`/tmp/figma-agent-broker.log`) — this file must never actually write to
+// that path, on THIS machine, even to prove a regression. Every other path (this
+// test's own scratch log) calls through to the real filesystem normally.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const DEFAULT_LOG_FILE = '/tmp/figma-agent-broker.log';
+
+const fsSpies = vi.hoisted(() => ({
+  appendFileSync: vi.fn(),
+}));
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>();
+  return {
+    ...actual,
+    appendFileSync: (...args: Parameters<typeof actual.appendFileSync>) => {
+      fsSpies.appendFileSync(...args);
+      const [path] = args;
+      if (path === DEFAULT_LOG_FILE) return; // never actually write the shared default
+      return actual.appendFileSync(...args);
+    },
+  };
+});
+
+function testExit(): (code: number) => never {
+  return (code: number): never => {
+    throw new Error(`__TEST_BROKER_EXIT__ code=${code}`);
+  };
+}
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-broker-log-default-'));
+  fsSpies.appendFileSync.mockClear();
+});
+
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('runBrokerDaemon — log file default resolution', () => {
+  it('omitting `logFile` still resolves to the real shared default path', async () => {
+    vi.resetModules();
+    const { runBrokerDaemon } = await import('../cli/src/transport/broker-daemon.ts');
+    await runBrokerDaemon({
+      advertisePath: join(scratchDir, 'broker.json'),
+      ports: [0],
+      exit: testExit(),
+      // logFile intentionally omitted — production behavior must be byte-unchanged.
+    });
+    const paths = fsSpies.appendFileSync.mock.calls.map((call) => call[0]);
+    expect(paths).toContain(DEFAULT_LOG_FILE);
+  });
+
+  it('an injected `logFile` receives every write; the default path is never appended to', async () => {
+    vi.resetModules();
+    const { runBrokerDaemon } = await import('../cli/src/transport/broker-daemon.ts');
+    const scratchLogFile = join(scratchDir, 'broker.log');
+    await runBrokerDaemon({
+      advertisePath: join(scratchDir, 'broker.json'),
+      ports: [0],
+      exit: testExit(),
+      logFile: scratchLogFile,
+    });
+    const paths = fsSpies.appendFileSync.mock.calls.map((call) => call[0]);
+    expect(paths.length).toBeGreaterThan(0);
+    expect(paths.every((p) => p === scratchLogFile)).toBe(true);
+    expect(paths).not.toContain(DEFAULT_LOG_FILE);
+  });
+});


### PR DESCRIPTION
## Summary

`BrokerDaemonOptions` already injects `advertisePath`, `ports` (harness uses `[0]`, OS-ephemeral), and `exit`, so the in-process daemon harness (`tests/broker-daemon-harness.test.ts`) never touches the real `/tmp/figma-agent-broker.json` advertisement or the real 9410-9419 port range. One shared resource was still hardcoded: `LOG_FILE = '/tmp/figma-agent-broker.log'` (`broker-daemon.ts`), written by `log()` via `appendFileSync`. A harness-spawned broker therefore appended to the real log a live dev session shares.

- Added `logFile?: string` to `BrokerDaemonOptions`; `runBrokerDaemon` resolves `activeLogFile = options?.logFile ?? LOG_FILE` once at startup, before any `log()` call. Production behavior (no options passed) is unchanged.
- The harness now passes a scratch `logFile` (same tmpdir as its other overrides) in its one `runBrokerDaemon` call site.
- Added `tests/broker-daemon-log-file-default.test.ts`: mocks `node:fs`'s `appendFileSync` (wrap, not replace — same convention as `broker-advertisement-atomic.test.ts`) to prove (a) omitting `logFile` still resolves to the real default path, and (b) an injected `logFile` receives every write while the default path is never appended to. The mock never lets a write actually reach the real default path, so this test cannot interfere with a live session even in a failure case.

With the harness now fully isolated, its previously-deferred `--instance` / force-release / contention tests run for the first time. That surfaced two pre-existing bugs in those already-written fixtures (unrelated to the log-path fix):
- A bound-project fixture never created the target's `design/` dir, which `resolveProjectDir`'s `isUsable()` requires — it silently fell back to the broker's cwd default instead of the bound project.
- A `--instance` targeting a non-connected instance correctly parks (same as any unmatched filter) for the plugin-wait window, which defaults to 12s — longer than vitest's 5s test timeout. Shrunk via the already-existing `FIGMA_AGENT_PLUGIN_WAIT_MS` override, the same pattern the watchdog tests already use.

## Test plan
- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npx vitest run --config vitest.config.ts tests/broker-daemon-harness.test.ts` — **22/22 pass** (previously 0 of these deferred cases had ever run)
- [x] `npx vitest run --config vitest.config.ts tests/broker-daemon-log-file-default.test.ts` — 2/2 pass
- [x] `npm test` (full suite, submodule initialized) — **104 files / 1319 tests pass**
- [x] Verified only these two test files call `runBrokerDaemon`; neither binds the real 9410-9419 range nor writes the real `/tmp/figma-agent-broker.log`