### PR TITLE
perf: dedupe node fetches and bound the walk in ui.figjam.connections

### DIFF
--- a/plugin/code.js
+++ b/plugin/code.js
@@ -3368,6 +3368,7 @@
   var MAX_CODE_BLOCK_CHARS = 5e4;
   var MAX_ARRANGE_NODES = 500;
   var MAX_BOARD_READ_NODES = 1e3;
+  var MAX_CONNECTORS_READ = 1e3;
   var STICKY_COLORS = {
     YELLOW: { r: 1, g: 0.85, b: 0.4 },
     BLUE: { r: 0.53, g: 0.78, b: 1 },
@@ -3682,25 +3683,30 @@
     const nodes = matching.slice(0, maxNodes).map(extractBoardNode);
     return { nodes, totalFound: matching.length, truncated, page: figma.currentPage.name, scope: "page-top-level" };
   }
+  function toEndpointResult(ep) {
+    return { nodeId: ep.nodeId, unresolved: ep.unresolved, position: ep.position };
+  }
   async function resolveEndpoint(ep) {
     if (!("endpointNodeId" in ep)) {
-      return { nodeId: null, unresolved: false, position: "position" in ep ? ep.position : null };
+      return { nodeId: null, unresolved: false, position: "position" in ep ? ep.position : null, node: null };
     }
     const node = await figma.getNodeByIdAsync(ep.endpointNodeId);
-    return { nodeId: ep.endpointNodeId, unresolved: !node, position: null };
+    return { nodeId: ep.endpointNodeId, unresolved: !node, position: null, node };
   }
   async function connections() {
     requireEditor("ui.figjam.connections", ["figjam"]);
-    const connectors = figma.currentPage.findAll((n) => n.type === "CONNECTOR");
+    const allConnectors = figma.currentPage.findAll((n) => n.type === "CONNECTOR");
+    const truncated = allConnectors.length > MAX_CONNECTORS_READ;
+    const connectors = allConnectors.slice(0, MAX_CONNECTORS_READ);
     const connectedNodes = {};
     const edges = [];
     for (const conn of connectors) {
       const start = await resolveEndpoint(conn.connectorStart);
       const end = await resolveEndpoint(conn.connectorEnd);
-      edges.push({ id: conn.id, label: conn.text.characters || null, start, end });
+      edges.push({ id: conn.id, label: conn.text.characters || null, start: toEndpointResult(start), end: toEndpointResult(end) });
       for (const ep of [start, end]) {
         if (!ep.nodeId || ep.unresolved || connectedNodes[ep.nodeId]) continue;
-        const node = await figma.getNodeByIdAsync(ep.nodeId);
+        const node = ep.node;
         if (!node) continue;
         const asText = "characters" in node ? node.characters : void 0;
         connectedNodes[ep.nodeId] = {
@@ -3711,7 +3717,13 @@
         };
       }
     }
-    return { edges, connectedNodes, totalConnectors: connectors.length, totalConnectedNodes: Object.keys(connectedNodes).length };
+    return {
+      edges,
+      connectedNodes,
+      totalConnectors: allConnectors.length,
+      totalConnectedNodes: Object.keys(connectedNodes).length,
+      truncated
+    };
   }
 
   // plugin/src/main/exec-stdlib-figjam.ts

--- a/plugin/src/main/exec-stdlib-figjam-read.ts
+++ b/plugin/src/main/exec-stdlib-figjam-read.ts
@@ -3,7 +3,7 @@
 // THIRD-PARTY.md), code.js:6361-6501.
 import { requireEditor } from './exec-stdlib-editor';
 import { figmaColorToHex } from './executor-styles';
-import { MAX_BOARD_READ_NODES, type BoardOpts } from './exec-stdlib-figjam-types';
+import { MAX_BOARD_READ_NODES, MAX_CONNECTORS_READ, type BoardOpts } from './exec-stdlib-figjam-types';
 
 const TABLE_READ_ROW_CAP = 10;
 
@@ -92,34 +92,54 @@ export async function board(opts: BoardOpts = {}): Promise<{
 
 interface EndpointResult { nodeId: string | null; unresolved: boolean; position: { x: number; y: number } | null }
 
-async function resolveEndpoint(ep: ConnectorEndpoint): Promise<EndpointResult> {
+/** `resolveEndpoint`'s internal result — carries the already-fetched node alongside
+ * the serializable `EndpointResult` so the caller below can reuse it instead of
+ * calling `getNodeByIdAsync` a second time for the same id. Never returned as-is
+ * from `connections()` (see `toEndpointResult`) — a live Figma node isn't
+ * serializable across the plugin/UI boundary anyway. */
+interface ResolvedEndpoint extends EndpointResult { node: BaseNode | null }
+
+function toEndpointResult(ep: ResolvedEndpoint): EndpointResult {
+  return { nodeId: ep.nodeId, unresolved: ep.unresolved, position: ep.position };
+}
+
+async function resolveEndpoint(ep: ConnectorEndpoint): Promise<ResolvedEndpoint> {
   if (!('endpointNodeId' in ep)) {
-    return { nodeId: null, unresolved: false, position: 'position' in ep ? ep.position : null };
+    return { nodeId: null, unresolved: false, position: 'position' in ep ? ep.position : null, node: null };
   }
   const node = await figma.getNodeByIdAsync(ep.endpointNodeId);
   // Absorbed fact 11: an endpoint whose node cannot be resolved appears as
   // `unresolved: true`, never dropped — a dropped edge silently changes the graph.
-  return { nodeId: ep.endpointNodeId, unresolved: !node, position: null };
+  return { nodeId: ep.endpointNodeId, unresolved: !node, position: null, node };
 }
 
 export async function connections(): Promise<{
   edges: { id: string; label: string | null; start: EndpointResult; end: EndpointResult }[];
   connectedNodes: Record<string, { id: string; type: string; name: string; text: string | null }>;
-  totalConnectors: number; totalConnectedNodes: number;
+  totalConnectors: number; totalConnectedNodes: number; truncated: boolean;
 }> {
   requireEditor('ui.figjam.connections', ['figjam']);
-  // Absorbed fact 11: findAll(type === 'CONNECTOR').
-  const connectors = figma.currentPage.findAll((n) => n.type === 'CONNECTOR') as ConnectorNode[];
+  // Absorbed fact 11: findAll(type === 'CONNECTOR') — connectors can nest, unlike
+  // board()'s top-level-only read, so the deep walk stays. Only the RESULT is
+  // capped (same truncated-flag pattern as board()'s MAX_BOARD_READ_NODES) so a
+  // page with an unbounded number of connectors can't force an unbounded async
+  // fetch loop below; nothing past the cap is silently merged into what IS read.
+  const allConnectors = figma.currentPage.findAll((n) => n.type === 'CONNECTOR') as ConnectorNode[];
+  const truncated = allConnectors.length > MAX_CONNECTORS_READ;
+  const connectors = allConnectors.slice(0, MAX_CONNECTORS_READ);
   const connectedNodes: Record<string, { id: string; type: string; name: string; text: string | null }> = {};
   const edges: { id: string; label: string | null; start: EndpointResult; end: EndpointResult }[] = [];
 
   for (const conn of connectors) {
     const start = await resolveEndpoint(conn.connectorStart);
     const end = await resolveEndpoint(conn.connectorEnd);
-    edges.push({ id: conn.id, label: conn.text.characters || null, start, end });
+    edges.push({ id: conn.id, label: conn.text.characters || null, start: toEndpointResult(start), end: toEndpointResult(end) });
+    // Reuse the node `resolveEndpoint` already fetched above — the loop used to
+    // call `getNodeByIdAsync` a second time for the same id here (4 fetches per
+    // connector where 2 suffice).
     for (const ep of [start, end]) {
       if (!ep.nodeId || ep.unresolved || connectedNodes[ep.nodeId]) continue;
-      const node = await figma.getNodeByIdAsync(ep.nodeId);
+      const node = ep.node;
       if (!node) continue;
       const asText = 'characters' in node ? (node as { characters?: unknown }).characters : undefined;
       connectedNodes[ep.nodeId] = {
@@ -128,5 +148,8 @@ export async function connections(): Promise<{
       };
     }
   }
-  return { edges, connectedNodes, totalConnectors: connectors.length, totalConnectedNodes: Object.keys(connectedNodes).length };
+  return {
+    edges, connectedNodes, totalConnectors: allConnectors.length,
+    totalConnectedNodes: Object.keys(connectedNodes).length, truncated,
+  };
 }

--- a/plugin/src/main/exec-stdlib-figjam-types.ts
+++ b/plugin/src/main/exec-stdlib-figjam-types.ts
@@ -12,6 +12,7 @@ export const MAX_TEXT_CHARS = 5_000;
 export const MAX_CODE_BLOCK_CHARS = 50_000;
 export const MAX_ARRANGE_NODES = 500;
 export const MAX_BOARD_READ_NODES = 1_000;
+export const MAX_CONNECTORS_READ = 1_000;
 
 /** Absorbed fact 2 — sticky colour is a FILL, not an enum property. The fork's own
  * `__stickyColors` map (code.js:78-88), labelled a WORKAROUND, not the API: `[re-verify]`

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1412,7 +1412,7 @@ code {
       syncPrompt.hidden = true;
     }, 4e3);
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "d2cc78a" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "cc4b840" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/tests/exec-stdlib-figjam-read.test.ts
+++ b/tests/exec-stdlib-figjam-read.test.ts
@@ -1,9 +1,10 @@
 // `ui.figjam.board` / `ui.figjam.connections` (absorption phase-03). Covers: the
 // corrected `truncated` computation (exhausted-source, not results.length>=maxNodes)
 // and the unresolved-edge labelling.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { installMockFigma, setMockEditorType, type FakeNode } from './helpers/mock-figma.ts';
 import { board, connections } from '../plugin/src/main/exec-stdlib-figjam-read.ts';
+import { MAX_CONNECTORS_READ } from '../plugin/src/main/exec-stdlib-figjam-types.ts';
 
 function asFigma(): {
   createSticky(): FakeNode; createFrame(): FakeNode; createConnector(): FakeNode;
@@ -105,5 +106,52 @@ describe('ui.figjam.connections', () => {
     expect(result.edges).toHaveLength(1); // the edge itself is never dropped
     expect(result.edges[0]!.end).toMatchObject({ nodeId: 'nonexistent-node', unresolved: true });
     expect(result.totalConnectedNodes).toBe(1); // only the resolvable end counted
+  });
+
+  it('resolves each endpoint node exactly once — the loop reuses resolveEndpoint\'s fetch instead of re-fetching by id', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const figma = asFigma();
+    const a = figma.createFrame();
+    const b = figma.createFrame();
+    const conn = figma.createConnector();
+    conn.connectorStart = { endpointNodeId: a.id, magnet: 'AUTO' };
+    conn.connectorEnd = { endpointNodeId: b.id, magnet: 'AUTO' };
+    conn.text.characters = 'flows to';
+    const mockFigma = (globalThis as unknown as { figma: { getNodeByIdAsync(id: string): Promise<unknown> } }).figma;
+    const spy = vi.spyOn(mockFigma, 'getNodeByIdAsync');
+    const result = await connections();
+    // Output shape is unchanged from the pre-dedupe behavior.
+    expect(result.edges[0]).toMatchObject({ label: 'flows to' });
+    expect(result.totalConnectedNodes).toBe(2);
+    // The perf assertion: one fetch per endpoint (2 total for this connector), not
+    // the pre-fix 4 (resolveEndpoint's own fetch, then a second re-fetch per endpoint
+    // in the loop below it).
+    expect(spy).toHaveBeenCalledTimes(2);
+    spy.mockRestore();
+  });
+
+  it('caps the number of connectors processed and reports truncated: true when the page exceeds the cap', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const figma = asFigma();
+    for (let i = 0; i < MAX_CONNECTORS_READ + 1; i++) figma.createConnector();
+    const result = await connections();
+    expect(result.totalConnectors).toBe(MAX_CONNECTORS_READ + 1);
+    expect(result.edges).toHaveLength(MAX_CONNECTORS_READ);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('truncated is falsy when the page is at or under the cap — no edge is silently dropped', async () => {
+    installMockFigma();
+    setMockEditorType('figjam');
+    const figma = asFigma();
+    figma.createConnector();
+    figma.createConnector();
+    figma.createConnector();
+    const result = await connections();
+    expect(result.totalConnectors).toBe(3);
+    expect(result.edges).toHaveLength(3);
+    expect(result.truncated).toBeFalsy();
   });
 });


### PR DESCRIPTION
## What

`ui.figjam.connections` was fetching each endpoint's node twice per
connector: `resolveEndpoint` calls `getNodeByIdAsync(ep.endpointNodeId)`
to build the serializable `EndpointResult`, then the loop right below it
calls `getNodeByIdAsync(ep.nodeId)` again for the same id to build the
`connectedNodes` entry — 4 async fetches per connector where 2 suffice.

`resolveEndpoint` now returns the already-fetched node alongside its
result (an internal-only `ResolvedEndpoint`, stripped back down to the
public `EndpointResult` shape before it goes into `edges`), and the loop
reuses that reference instead of re-fetching.

`figma.currentPage.findAll(n => n.type === 'CONNECTOR')` still walks the
whole page — connectors can nest, unlike `board()`'s top-level-only
read, so `findAll` stays. What's now bounded is the *result*: capped at
`MAX_CONNECTORS_READ`, mirroring `board()`'s existing
`MAX_BOARD_READ_NODES` / `truncated` pattern. `totalConnectors` still
reports the true page count; `truncated` is set when the cap bites, so
a caller can tell some connectors weren't processed rather than the
walk silently stopping. The existing `unresolved: true` handling for an
endpoint whose node can't be resolved is unchanged — an edge is never
dropped either way.

## Test-first

Added to `tests/exec-stdlib-figjam-read.test.ts`:
- a `getNodeByIdAsync` call-count assertion (spy on the mock) for a
  single connector between two nodes — this failed against the
  pre-change code (`4 times`, not `2`) and passes after the dedupe.
- a bounded-walk test: more connectors than `MAX_CONNECTORS_READ` →
  exactly the cap in `edges`, `truncated: true`, no throw.
- an at/under-cap test: `truncated` falsy, everything present.
- the existing `unresolved: true` edge-never-dropped test still passes
  unchanged.

## Gate (worktree)

- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run` on the figjam test family (`exec-stdlib-figjam-read`,
  `-content`, `-table`, `-arrange`) — 44/44 pass

Full `npm test` / broker-daemon-harness intentionally not run here
(live-plugin-session territory, tracked separately) — this change is
plugin-unit level with a mocked `figma`, which is the right gate for it.