### PR TITLE
Pin daemon routing to a plugin via the panel (#35 P2)

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -25,7 +25,7 @@ import {
 } from './protocol-helpers.ts';
 import { PluginRegistry, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
-import { resolveRouteFilter, type RouteFilter } from './route-filter.ts';
+import { pinDisconnected, resolveRouteFilter, type RouteFilter } from './route-filter.ts';
 import {
   appendChangeFrames, changeLogPathFor, migrateLegacyUnboundChanges, migrateStagedChanges,
   unboundStagingPath, unboundStagingRoot,
@@ -483,6 +483,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const idleMs = readIdleMs();
   let syncInFlight = false;
 
+  // Target pin (#35 P2): the panel's "Target this plugin" button routes here — a
+  // deliberate human act, ranked above the env pin and recency but below a per-request
+  // `--instance`/`--file` (see route-filter.ts). RUNTIME-ONLY (never persisted, never
+  // survives a broker restart, like every other piece of `st`) and cleared the moment its
+  // instance disconnects (`handleClose`) — a pin must never keep pointing at a dead plugin.
+  let targetInstancePin: string | null = null;
+
   /** Send one unsolicited EventMsg to a single socket (best-effort). */
   const sendEvent = (ws: WebSocket, type: EventMsg['type'], data: Record<string, unknown>): void => {
     try { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type, data } satisfies EventMsg)); }
@@ -496,15 +503,22 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // busy command stream does not spam the socket.
   let lastPeersSig = '';
   const broadcastPeers = (): void => {
-    const target = st.registry.selectTarget(currentFilter());
+    // #35 P2: a LIVE pin outranks recency for `isActiveTarget` too — the panel's whole
+    // point is telling the owner "commands go here because you pinned it", not the
+    // ordinary recency story. A pin whose instance already vanished (about to be cleared
+    // by `handleClose`, or a stale read racing that clear) is never treated as live here.
+    const pinnedEntry = targetInstancePin !== null ? st.registry.getByInstanceId(targetInstancePin) : null;
+    const pinnedLive = pinnedEntry && pinnedEntry.ws.readyState === WebSocket.OPEN ? pinnedEntry : null;
+    const target = pinnedLive ?? st.registry.selectTarget(currentFilter());
     const entries = st.registry.liveEntries();
-    const sig = `${entries.length}|${target?.instanceId ?? ''}`;
+    const sig = `${entries.length}|${target?.instanceId ?? ''}|${pinnedLive?.instanceId ?? ''}`;
     if (sig === lastPeersSig) return; // nothing a panel would render differently
     lastPeersSig = sig;
     for (const entry of entries) {
       sendEvent(entry.ws, 'PEERS', {
         count: entries.length,
         isActiveTarget: target?.instanceId === entry.instanceId,
+        pinned: pinnedLive?.instanceId === entry.instanceId,
       });
     }
   };
@@ -800,7 +814,20 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     from: WebSocket, id: string, rawText: string, cmd?: string, expectedFile?: string,
     expectedInstance?: string, readOnly = false, projectDir?: string, activity?: string,
   ): void => {
-    const filter = resolveRouteFilter(expectedFile, currentFilter(), expectedInstance);
+    // #35 P2: the standing runtime pin is consulted BEFORE `resolveRouteFilter` — a
+    // per-request `--instance`/`--file` still bypasses it entirely (route-filter.ts's own
+    // precedence), but a no-flag command with a pin set must never silently fall through
+    // to the env pin or recency once its instance is gone (Law 1). Liveness is this
+    // daemon's own registry check — `pinDisconnected` (pure) only composes that fact with
+    // the override rule.
+    const pin = targetInstancePin;
+    const pinLive = pin !== null && st.registry.getByInstanceId(pin)?.ws.readyState === WebSocket.OPEN;
+    if (pin !== null && pinDisconnected(expectedFile, expectedInstance, pin, pinLive)) {
+      sendReplyErr(from, id, 'E_TARGET_DISCONNECTED',
+        `the pinned plugin (instance ${pin}) is no longer connected — re-target it with the panel's "Target this plugin" button, or clear the pin and retry`);
+      return;
+    }
+    const filter = resolveRouteFilter(expectedFile, currentFilter(), expectedInstance, pinLive ? pin : null);
     let targetWs = st.dispatchedTo.get(id);
     if (targetWs && targetWs.readyState !== WebSocket.OPEN) targetWs = undefined;
     if (!targetWs) {
@@ -1226,6 +1253,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (removedId !== null) {
       const remaining = st.registry.size();
       log(`plugin [${removedId}] disconnected (${remaining} still connected)`);
+      // #35 P2: a pin must never keep pointing at a plugin that just left — Law 1 applies
+      // symmetrically here (an admission refuses a dead pin outright; a disconnect clears
+      // it outright), so the NEXT no-flag command falls through to the env pin/recency
+      // instead of hitting E_TARGET_DISCONNECTED forever.
+      if (removedId === targetInstancePin) {
+        targetInstancePin = null;
+        log(`target pin cleared — pinned instance [${removedId}] disconnected`);
+      }
       // Only announce PLUGIN_GONE when the LAST plugin leaves — a CLI waiting on a
       // still-connected file must not be told the bridge is gone.
       if (remaining === 0) broadcastToClients(JSON.stringify({ type: 'PLUGIN_GONE', data: {} } satisfies EventMsg));
@@ -1414,6 +1449,33 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         // Live-sync commit (spec 004 P4): the panel's "Sync now" click → run the
         // deterministic kernel apply and report the result back to this plugin.
         if (isPlugin) handleSyncRequest(ws);
+      } else if (msg.type === 'SET_TARGET') {
+        // #35 P2: the panel's "Target this plugin" button. `data.instanceId` is validated
+        // against THIS socket's own registered entry, never looked up independently — a
+        // panel can only ever pin ITSELF this way, so a sender that is a registered live
+        // plugin is by construction a live instance, with no separate liveness re-check
+        // needed. A mismatched/stale payload (a race, or a forged frame) is refused, never
+        // silently applied to the wrong instance.
+        if (isPlugin) {
+          const data = msg.data as { instanceId?: unknown };
+          const claimed = typeof data?.instanceId === 'string' ? data.instanceId : null;
+          const own = st.registry.getByWs(ws)?.instanceId ?? null;
+          if (claimed !== null && claimed === own) {
+            targetInstancePin = own;
+            log(`target pin set → [${own}]`);
+            broadcastPeers();
+          } else {
+            log(`SET_TARGET refused — claimed instance [${claimed ?? '?'}] does not match this socket's own [${own ?? '?'}]`);
+          }
+        }
+      } else if (msg.type === 'CLEAR_TARGET') {
+        // Explicit human un-pin — a no-op (no log, no broadcast) if nothing was pinned, so
+        // clicking "Targeted ✓" twice in a row from two different panels never spams the log.
+        if (isPlugin && targetInstancePin !== null) {
+          log(`target pin cleared (was [${targetInstancePin}])`);
+          targetInstancePin = null;
+          broadcastPeers();
+        }
       } else if (isPlugin) {
         broadcastToClients(text); // other plugin events fan out to CLI clients
       }

--- a/cli/src/transport/route-filter.ts
+++ b/cli/src/transport/route-filter.ts
@@ -1,7 +1,14 @@
 // Which file (or instance) a request routes to, and how strictly. PURE — the daemon reads env +
 // envelope and asks here, so precedence is a unit test rather than a code path only reachable
 // with two Figma files open.
-export type FilterSource = 'flag' | 'env' | 'none';
+//
+// 'pin' (#35 P2): the panel's "Target this plugin" button sets a daemon RUNTIME pin
+// (`targetInstancePin`) — a human's standing routing choice, ranked below a per-request
+// flag (which always wins for that one command) but above the env pin and recency (a
+// more recent, more deliberate act than either). The daemon resolves liveness BEFORE
+// calling here (see `pinDisconnected`) — this module stays pure and never touches the
+// registry.
+export type FilterSource = 'flag' | 'env' | 'pin' | 'none';
 
 // `value` is a file NAME under kind:'name', or an opaque instanceId under kind:'instance' — the
 // registry needs this to know which comparison to run (name matching vs. instance lookup). The
@@ -17,7 +24,8 @@ export interface RouteFilter {
 
 /**
  * Precedence: explicit `--instance` (per request, exact, unique) > explicit `--file` (per
- * request, exact) > FIGMA_AGENT_FILE (per daemon) > active plugin.
+ * request, exact) > the daemon's `targetInstancePin` (runtime, set by the panel's "Target
+ * this plugin" button) > FIGMA_AGENT_FILE (per daemon) > active plugin.
  *
  * `--instance` targets a specific plugin instance by its minted, opaque instanceId — it always
  * matches 0 or 1 entries, so it is exact by construction (no substring mode makes sense for a
@@ -25,19 +33,46 @@ export interface RouteFilter {
  * of a guard the plugin re-checks against `figma.root.name`. A substring filter could route
  * "Design" to "Design System" and then have the plugin refuse it with E_WRONG_FILE — routing and
  * guard must agree, so they use the same comparison.
+ *
+ * `pin` is the pinned instanceId, or `null`/omitted when no pin is set OR the caller has
+ * already found it disconnected (see `pinDisconnected`) — this function never re-derives
+ * liveness itself, matching `envPin`'s own trust-the-caller shape. Exact + kind:'instance',
+ * same as `--instance`, since a pin is also a unique key.
  */
 export function resolveRouteFilter(
   expectedFile?: string | null,
   envPin?: string | null,
   instanceFlag?: string | null,
+  pin?: string | null,
 ): RouteFilter {
   const instance = instanceFlag?.trim();
   if (instance) return { value: instance, exact: true, source: 'flag', kind: 'instance' };
   const flag = expectedFile?.trim();
   if (flag) return { value: flag, exact: true, source: 'flag', kind: 'name' };
+  const pinned = pin?.trim();
+  if (pinned) return { value: pinned, exact: true, source: 'pin', kind: 'instance' };
   const env = envPin?.trim();
   if (env) return { value: env, exact: false, source: 'env', kind: 'name' };
   return { value: null, exact: false, source: 'none', kind: 'name' };
+}
+
+/**
+ * True when a standing `targetInstancePin` applies to this request (no per-request
+ * `--instance`/`--file` overrides it) AND its instance is no longer live. The caller must
+ * refuse the command outright (`E_TARGET_DISCONNECTED`) rather than pass a `null` pin
+ * through to `resolveRouteFilter` and let it fall through to the env pin or recency — Law
+ * 1: a standing pin never silently re-points at another plugin. `pinLive` is the daemon's
+ * OWN liveness check (`registry.getByInstanceId(pin)?.ws` OPEN) — this function only
+ * composes that fact with the per-request-flag override rule, staying pure.
+ */
+export function pinDisconnected(
+  expectedFile?: string | null,
+  instanceFlag?: string | null,
+  pin?: string | null,
+  pinLive?: boolean,
+): boolean {
+  if (expectedFile?.trim() || instanceFlag?.trim()) return false; // a per-request flag always overrides the pin
+  return Boolean(pin?.trim()) && pinLive !== true;
 }
 
 export { fileMatches } from '../../../shared/file-match.ts';

--- a/plugin/src/ui/panel-model.ts
+++ b/plugin/src/ui/panel-model.ts
@@ -74,16 +74,29 @@ export const PANEL_HEIGHT = 420;
 // The panel's honest answer to "which file will my command hit?" — must never say
 // "command target" when the broker's routing target is elsewhere. Driven by the new
 // PEERS event (broker → every connected plugin, count + isActiveTarget).
-export function fileNote(count: number, isActiveTarget: boolean): string {
-  if (count <= 1) return isActiveTarget ? 'command target' : ''; // count<=1 && !isActiveTarget cannot happen today
+//
+// `pinned` (#35 P2, additive — defaults `false` so every pre-existing call site/test is
+// untouched): PEERS' own `pinned` flag, true when THIS plugin is the target because the
+// owner explicitly pinned it via "Target this plugin", not merely because it is the
+// most-recently-active file. Distinct wording, never a separate boolean note, so the one
+// line stays the single source of "why does my command land here".
+export function fileNote(count: number, isActiveTarget: boolean, pinned = false): string {
+  if (count <= 1) return isActiveTarget ? (pinned ? 'pinned target' : 'command target') : ''; // count<=1 && !isActiveTarget cannot happen today
   const others = count - 1;
   const files = others === 1 ? 'file' : 'files';
   // Wording pass (owner directive 2026-07-30): "connected" is redundant here — the whole
   // Context block only ever shows OTHER connected files — and "commands go to another
   // file" trims to "elsewhere" without losing the honest claim.
-  return isActiveTarget
-    ? `command target · ${others} other ${files}`
-    : `${others} other ${files} — commands go elsewhere`;
+  if (!isActiveTarget) return `${others} other ${files} — commands go elsewhere`;
+  return pinned ? `pinned target · ${others} other ${files}` : `command target · ${others} other ${files}`;
+}
+
+// ─── Target pin (#35 P2) — the "Target this plugin" button's own label ──────
+// A toggle: pinned → "Targeted ✓" (click clears it); unpinned → "Target this plugin"
+// (click sets it). Kept as a pure mapping so the DOM glue (panel-ui.ts) never composes
+// this string itself.
+export function targetButtonLabel(pinned: boolean): string {
+  return pinned ? 'Targeted ✓' : 'Target this plugin';
 }
 
 // ─── Idle-commit sync prompt (spec 004 P4) ────────────────────────────────────

--- a/plugin/src/ui/panel-ui.ts
+++ b/plugin/src/ui/panel-ui.ts
@@ -14,6 +14,7 @@ import {
   statusSentence, showOnboarding, fileNote, PANEL_HEIGHT,
   syncPromptLabel, syncResultLabel, syncNowLabel, shouldClearPendingCount,
   syncStartSentence, syncResultSentence, syncStuckSentence, syncSupersededSentence, SYNC_STUCK_TIMEOUT_MS,
+  targetButtonLabel,
 } from './panel-model';
 import {
   toActivityRecord, toActivityResult, pushActivity, resolveActivity, diffRowKeys,
@@ -36,6 +37,7 @@ const ctxFile = el('fga-ctx-file');
 const ctxFileNote = el('fga-ctx-file-note');
 const ctxPage = el('fga-ctx-page');
 const ctxSelection = el('fga-ctx-selection');
+const targetBtn = el('fga-target-btn') as HTMLButtonElement;
 const activityList = el('fga-activity');
 const versionEl = el('fga-version');
 const syncPrompt = el('fga-sync');
@@ -52,6 +54,7 @@ let selectionName: string | null = null;
 let selectionCount = 0;
 let peersCount = 1;
 let peersIsActiveTarget = true; // sole plugin ⇒ trivially the target until PEERS says otherwise
+let peersPinned = false; // #35 P2: THIS plugin is the target because the owner pinned it, not merely recency
 
 // ─── Icons (Phosphor inline SVG — no text glyphs anywhere, §1) ───────────────
 // Official @phosphor-icons/core v2 path data, "regular" weight, 256x256 viewBox, MIT —
@@ -91,10 +94,11 @@ function makeIcon(name: IconName): SVGSVGElement {
 function renderContext(): void {
   ctxFile.textContent = sceneFile || '—';
   ctxFile.title = sceneFile || ''; // the row ellipsises — hover still tells the truth
-  ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget);
+  ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
   ctxPage.textContent = scenePage || '—';
   ctxPage.title = scenePage || '';
   ctxSelection.textContent = selectionText();
+  targetBtn.textContent = targetButtonLabel(peersPinned);
 }
 
 /** "None" / "Hero card" / "Hero card +2 more". Never fabricates a name. The <dt>
@@ -241,10 +245,14 @@ window.addEventListener('figma-agent:activity', (ev) => {
 });
 
 // Peers (panel IA v2): the broker's honest answer to "which file will my command hit?".
+// `pinned` (#35 P2, additive): true only when THIS plugin is the standing target pin, not
+// merely the most-recently-active file — an older broker never sends it, so it stays
+// false (the pre-#35 behavior) rather than crash on the missing field.
 window.addEventListener('figma-agent:peers', (ev) => {
-  const d = (ev as CustomEvent).detail as { count?: unknown; isActiveTarget?: unknown } | undefined;
+  const d = (ev as CustomEvent).detail as { count?: unknown; isActiveTarget?: unknown; pinned?: unknown } | undefined;
   if (typeof d?.count === 'number' && Number.isFinite(d.count)) peersCount = d.count;
   if (typeof d?.isActiveTarget === 'boolean') peersIsActiveTarget = d.isActiveTarget;
+  peersPinned = typeof d?.pinned === 'boolean' && d.pinned;
   renderContext();
 });
 
@@ -363,6 +371,16 @@ window.addEventListener('figma-agent:sync-result', (ev) => {
   parent.postMessage({ pluginMessage: { type: 'SYNC_DONE', commit } }, '*');
   syncPrompt.hidden = false;
   if (commit) setTimeout(() => { syncPrompt.hidden = true; }, 4000);
+});
+
+// #35 P2 — "Target this plugin": a toggle. Pinned → clicking sends CLEAR_TARGET;
+// unpinned → SET_TARGET. `peersPinned` (from the last PEERS event) is the state read at
+// click time — no local optimistic flip: the button's own label/state is driven entirely
+// by the broker's next PEERS broadcast, the same "the wire is the source of truth" shape
+// every other panel affordance here already follows (sync prompt, activity feed).
+targetBtn.addEventListener('click', () => {
+  const event = peersPinned ? 'figma-agent:clear-target' : 'figma-agent:set-target';
+  try { window.dispatchEvent(new CustomEvent(event)); } catch { /* no DOM events */ }
 });
 
 versionEl.textContent = `v0.1.0 · ${typeof __BUILD_ID__ === 'string' ? __BUILD_ID__ : 'dev'}`;

--- a/plugin/src/ui/panel.html
+++ b/plugin/src/ui/panel.html
@@ -664,6 +664,9 @@ code {
   overflow-wrap: anywhere;
 }
 .detail-note:empty { display: none; }
+/* #35 P2 — "Target this plugin": reuses .sync-btn's own look (outlined, not filled),
+   spaced off the grid above it the same way .sync-actions separates from .sync-msg. */
+#fga-target-btn { margin-top: var(--space-1); }
 
 /* Block 3 — ACTIVITY: mono-free, sentence-case prose rows — [icon][sentence]
    + a caption line with relative time. The sentence says what the agent DID. */
@@ -914,6 +917,11 @@ code {
       <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
       <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
     </dl>
+    <!-- #35 P2: pins the daemon's routing target to THIS plugin instance (a runtime-only,
+         human-set pin — see broker-daemon.ts's `targetInstancePin`). Toggles between
+         "Target this plugin" and "Targeted ✓" — panel-ui.ts wires the click, panel-model.ts
+         owns the label text. -->
+    <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
   </section>
 
   <section class="activity fga-block" id="fga-activity-block" aria-label="Activity log">

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -457,4 +457,15 @@ window.addEventListener('figma-agent:sync-request', () => {
   wsSend({ type: 'SYNC_REQUEST', data: {} });
 });
 
+// #35 P2: the panel's "Target this plugin" button dispatches these DOM events; forward
+// to the broker as SET_TARGET/CLEAR_TARGET carrying THIS iframe's own INSTANCE_ID — the
+// broker only ever pins the socket that sent the message (see broker-daemon.ts's
+// SET_TARGET handler), so there is no other identity to carry here.
+window.addEventListener('figma-agent:set-target', () => {
+  wsSend({ type: 'SET_TARGET', data: { instanceId: INSTANCE_ID } });
+});
+window.addEventListener('figma-agent:clear-target', () => {
+  wsSend({ type: 'CLEAR_TARGET', data: { instanceId: INSTANCE_ID } });
+});
+
 void connectLoop();

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -664,6 +664,9 @@ code {
   overflow-wrap: anywhere;
 }
 .detail-note:empty { display: none; }
+/* #35 P2 — "Target this plugin": reuses .sync-btn's own look (outlined, not filled),
+   spaced off the grid above it the same way .sync-actions separates from .sync-msg. */
+#fga-target-btn { margin-top: var(--space-1); }
 
 /* Block 3 — ACTIVITY: mono-free, sentence-case prose rows — [icon][sentence]
    + a caption line with relative time. The sentence says what the agent DID. */
@@ -914,6 +917,11 @@ code {
       <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
       <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
     </dl>
+    <!-- #35 P2: pins the daemon's routing target to THIS plugin instance (a runtime-only,
+         human-set pin — see broker-daemon.ts's `targetInstancePin`). Toggles between
+         "Target this plugin" and "Targeted ✓" — panel-ui.ts wires the click, panel-model.ts
+         owns the label text. -->
+    <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
   </section>
 
   <section class="activity fga-block" id="fga-activity-block" aria-label="Activity log">
@@ -1003,11 +1011,15 @@ code {
   function showOnboarding(state, hadConnection2) {
     return !hadConnection2 && (state === "disconnected" || state === "probing");
   }
-  function fileNote(count, isActiveTarget) {
-    if (count <= 1) return isActiveTarget ? "command target" : "";
+  function fileNote(count, isActiveTarget, pinned = false) {
+    if (count <= 1) return isActiveTarget ? pinned ? "pinned target" : "command target" : "";
     const others = count - 1;
     const files = others === 1 ? "file" : "files";
-    return isActiveTarget ? `command target \xB7 ${others} other ${files}` : `${others} other ${files} \u2014 commands go elsewhere`;
+    if (!isActiveTarget) return `${others} other ${files} \u2014 commands go elsewhere`;
+    return pinned ? `pinned target \xB7 ${others} other ${files}` : `command target \xB7 ${others} other ${files}`;
+  }
+  function targetButtonLabel(pinned) {
+    return pinned ? "Targeted \u2713" : "Target this plugin";
   }
   function syncPromptLabel(count) {
     const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
@@ -1162,6 +1174,7 @@ code {
   var ctxFileNote = el("fga-ctx-file-note");
   var ctxPage = el("fga-ctx-page");
   var ctxSelection = el("fga-ctx-selection");
+  var targetBtn = el("fga-target-btn");
   var activityList = el("fga-activity");
   var versionEl = el("fga-version");
   var syncPrompt = el("fga-sync");
@@ -1177,6 +1190,7 @@ code {
   var selectionCount = 0;
   var peersCount = 1;
   var peersIsActiveTarget = true;
+  var peersPinned = false;
   var SVG_NS = "http://www.w3.org/2000/svg";
   var ICONS = {
     // check-circle, regular — the wrapper's aria-label carries the state; colour (via
@@ -1201,10 +1215,11 @@ code {
   function renderContext() {
     ctxFile.textContent = sceneFile || "\u2014";
     ctxFile.title = sceneFile || "";
-    ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget);
+    ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
     ctxPage.textContent = scenePage || "\u2014";
     ctxPage.title = scenePage || "";
     ctxSelection.textContent = selectionText();
+    targetBtn.textContent = targetButtonLabel(peersPinned);
   }
   function selectionText() {
     if (selectionCount <= 0) return "None";
@@ -1313,6 +1328,7 @@ code {
     const d = ev.detail;
     if (typeof d?.count === "number" && Number.isFinite(d.count)) peersCount = d.count;
     if (typeof d?.isActiveTarget === "boolean") peersIsActiveTarget = d.isActiveTarget;
+    peersPinned = typeof d?.pinned === "boolean" && d.pinned;
     renderContext();
   });
   window.addEventListener("message", (ev) => {
@@ -1411,6 +1427,13 @@ code {
     if (commit) setTimeout(() => {
       syncPrompt.hidden = true;
     }, 4e3);
+  });
+  targetBtn.addEventListener("click", () => {
+    const event = peersPinned ? "figma-agent:clear-target" : "figma-agent:set-target";
+    try {
+      window.dispatchEvent(new CustomEvent(event));
+    } catch {
+    }
   });
   versionEl.textContent = `v0.1.0 \xB7 ${true ? "cc4b840" : "dev"}`;
   setInterval(render, 1e3);
@@ -3210,6 +3233,12 @@ code {
   }
   window.addEventListener("figma-agent:sync-request", () => {
     wsSend({ type: "SYNC_REQUEST", data: {} });
+  });
+  window.addEventListener("figma-agent:set-target", () => {
+    wsSend({ type: "SET_TARGET", data: { instanceId: INSTANCE_ID } });
+  });
+  window.addEventListener("figma-agent:clear-target", () => {
+    wsSend({ type: "CLEAR_TARGET", data: { instanceId: INSTANCE_ID } });
   });
   void connectLoop();
 })();

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -203,8 +203,17 @@ export interface EventMsg {
   // thread and its iframe — they never cross this wire, so they are not listed here.)
   //
   // PEERS (panel IA v2): broker → every connected plugin, whenever the live registry
-  // changes (register/disconnect/scene update) or a reply lands. { count, isActiveTarget }
-  // — additive and ignorable by an older plugin bundle.
+  // changes (register/disconnect/scene update) or a reply lands. { count, isActiveTarget,
+  // pinned } — additive and ignorable by an older plugin bundle. `pinned` (#35 P2): true
+  // for the ONE entry, if any, matching the daemon's `targetInstancePin`; `isActiveTarget`
+  // reflects that same pin when one is set, falling back to recency otherwise — so a panel
+  // can tell "I'm the target because I'm pinned" from "…because I'm most-recent".
+  //
+  // SET_TARGET / CLEAR_TARGET (#35 P2): panel → broker, carrying the panel's own
+  // `instanceId` — sets/clears `targetInstancePin` (a daemon RUNTIME pin, never
+  // persisted). The broker validates the sender's own registered instance before
+  // pinning; an unrecognised/disconnected instanceId is ignored. Disconnecting the
+  // pinned instance clears the pin too (see broker-daemon.ts's `handleClose`).
   //
   // EDIT_FEED (wave 4.4 P1): the plugin's widened, actor-labelled documentchange batch —
   // plugin → broker; the broker appends it to its own per-file feed
@@ -222,7 +231,7 @@ export interface EventMsg {
   type:
     | 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG'
     | 'DOC_CHANGE' | 'SYNC_CONFIG' | 'SYNC_REQUEST' | 'SYNC_RESULT' | 'PEERS' | 'EDIT_FEED'
-    | 'JOB_STATE';
+    | 'JOB_STATE' | 'SET_TARGET' | 'CLEAR_TARGET';
   data: Record<string, unknown>;
 }
 
@@ -305,7 +314,12 @@ export type ErrorCode =
   // layer (see `RequestMsg.readOnly`'s own comment): the plugin is the one place that
   // can actually observe whether the script wrote anything, so this is where the
   // mis-declaration turns from a silent breach into a refusal.
-  | 'E_READONLY_VIOLATION';
+  | 'E_READONLY_VIOLATION'
+  // #35 P2 — a no-flag command with a standing `targetInstancePin` set, whose pinned
+  // instance has disconnected. Never falls through to the env pin or recency (Law 1: a
+  // standing pin never silently re-points at another plugin) — the caller re-targets via
+  // the panel's "Target this plugin" button, or clears the pin and retries unpinned.
+  | 'E_TARGET_DISCONNECTED';
 
 // ── Timeouts (ms) ───────────────────────────────────────────────────
 export const DEFAULT_TIMEOUT_MS = 15_000;

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -1021,3 +1021,189 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
     expect(Object.values(store[slug]!)[0]!.jobCount).toBe(1);
   });
 });
+
+// #35 P2 — the panel's "Target this plugin" button (SET_TARGET/CLEAR_TARGET) and the
+// daemon's `targetInstancePin` it sets. Exercises the REAL `admitRequest`/`handleClose`/
+// `broadcastPeers` closures end to end, same isolation as every other describe block here.
+function setTarget(ws: WebSocket, instanceId: string): void {
+  ws.send(JSON.stringify({ type: 'SET_TARGET', data: { instanceId } } satisfies EventMsg));
+}
+function clearTarget(ws: WebSocket, instanceId: string): void {
+  ws.send(JSON.stringify({ type: 'CLEAR_TARGET', data: { instanceId } } satisfies EventMsg));
+}
+/** A read-only request (GET_SELECTION, IMPLICIT_READ_ONLY) — dispatches immediately, no
+ *  per-file queue to reason about, so a test only has to observe WHICH plugin received it. */
+function sendReadOnlyRequest(ws: WebSocket, reqId: string, expectedInstance?: string): void {
+  ws.send(JSON.stringify(makeRequestFrame(reqId, 'GET_SELECTION', {}, undefined, undefined, undefined, undefined, expectedInstance)));
+}
+/**
+ * JOB_STATE is sent to the CLI the moment a request is ADMITTED (dispatched to a plugin
+ * or queued) — BEFORE any plugin reply, which these tests' bare `WebSocket` "plugins"
+ * never send. Waiting for a real reply here would hang forever (that bug produced this
+ * helper); JOB_STATE alone is the correct, always-present admission signal these
+ * precedence/routing tests need.
+ */
+function waitForJobState(ws: WebSocket): Promise<void> {
+  return nextFrame(ws, (m) => (m as EventMsg).type === 'JOB_STATE').then(() => undefined);
+}
+/**
+ * Distinguishes "admitted, dispatched somewhere" (a JOB_STATE arrives) from "refused
+ * outright" (an immediate ReplyErr carrying `reqId` arrives, with NO JOB_STATE ever sent
+ * — `admitRequest`'s `E_TARGET_DISCONNECTED` refusal returns before job creation). Used
+ * only where a test must tell the two apart; every other pin test only needs
+ * `waitForJobState` (dispatch always succeeds there).
+ */
+function admissionOutcome(ws: WebSocket, reqId: string): Promise<'dispatched' | 'refused'> {
+  return Promise.race([
+    nextFrame(ws, (m) => (m as EventMsg).type === 'JOB_STATE').then(() => 'dispatched' as const),
+    nextFrame(ws, (m) => (m as ReplyErr).id === reqId && (m as ReplyErr).ok === false).then(() => 'refused' as const),
+  ]);
+}
+
+describe('daemon harness — target pin (#35 P2): SET_TARGET/CLEAR_TARGET, precedence, disconnect-clears, PEERS', () => {
+  it('SET_TARGET pins routing to that instance even though a DIFFERENT plugin is more recently active', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a', 'PinFileA');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b', 'PinFileB'); // B HELLOs after A — B is recency-favored by default
+    // Drain the HELLO-triggered PEERS broadcast(s) before attaching the listeners below —
+    // otherwise a straggler from registration (not from SET_TARGET) can land on a
+    // freshly-attached listener and be misread as this test's own signal.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+
+    setTarget(pluginA, 'inst-pin-a');
+    await waitFor(() => framesA.frames.some((f) => (f as { type?: string }).type === 'PEERS'));
+
+    const cli = await connectSocket(port);
+    sendReadOnlyRequest(cli, 'req-pin-1');
+    await waitForJobState(cli);
+    await waitFor(() => framesA.frames.some((f) => (f as { id?: string }).id === 'req-pin-1'));
+
+    expect(framesA.frames.some((f) => (f as { id?: string }).id === 'req-pin-1')).toBe(true);
+    expect(framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-1')).toBe(false);
+  });
+
+  it('a per-request --instance still overrides the pin (per-request flags always win)', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a2', 'PinFileA2');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b2', 'PinFileB2');
+    await new Promise((resolve) => setTimeout(resolve, 50)); // drain the HELLO-triggered PEERS broadcast(s)
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+
+    setTarget(pluginA, 'inst-pin-a2');
+    await waitFor(() => framesA.frames.some((f) => (f as { type?: string }).type === 'PEERS'));
+
+    const cli = await connectSocket(port);
+    sendReadOnlyRequest(cli, 'req-pin-2', 'inst-pin-b2'); // explicit --instance targets B despite A's pin
+    await waitForJobState(cli);
+    await waitFor(() => framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-2'));
+
+    expect(framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-2')).toBe(true);
+    expect(framesA.frames.some((f) => (f as { id?: string }).id === 'req-pin-2')).toBe(false);
+  });
+
+  it('CLEAR_TARGET clears the pin — a later no-flag command falls back to recency', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a3', 'PinFileA3');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b3', 'PinFileB3'); // recency-favored once unpinned
+    await new Promise((resolve) => setTimeout(resolve, 50)); // drain the HELLO-triggered PEERS broadcast(s)
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+
+    setTarget(pluginA, 'inst-pin-a3');
+    await waitFor(() => framesA.frames.some((f) => (f as { type?: string }).type === 'PEERS'));
+    clearTarget(pluginA, 'inst-pin-a3');
+    await waitFor(() => framesA.frames.filter((f) => (f as { type?: string }).type === 'PEERS').length >= 2);
+
+    const cli = await connectSocket(port);
+    sendReadOnlyRequest(cli, 'req-pin-3');
+    await waitForJobState(cli);
+    await waitFor(() => framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-3'));
+
+    expect(framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-3')).toBe(true);
+    expect(framesA.frames.some((f) => (f as { id?: string }).id === 'req-pin-3')).toBe(false);
+  });
+
+  it('the pinned instance disconnecting clears the pin — a later no-flag command falls through to recency, never stuck refusing', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a4', 'PinFileA4');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b4', 'PinFileB4');
+    await new Promise((resolve) => setTimeout(resolve, 50)); // drain the HELLO-triggered PEERS broadcast(s)
+    const framesA = collectFrames(pluginA);
+
+    setTarget(pluginA, 'inst-pin-a4');
+    await waitFor(() => framesA.frames.some((f) => (f as { type?: string }).type === 'PEERS'));
+
+    const peersAfterDisconnect = nextFrame<EventMsg>(pluginB, (m) => (m as EventMsg).type === 'PEERS');
+    pluginA.terminate(); // the pinned instance disconnects
+    // `handleClose` clears the pin + broadcasts PEERS to survivors in the SAME turn the
+    // registry drops A's entry — B (the only survivor) is trivially the recency target
+    // now, and no longer merely "the non-pinned one".
+    const peers = await peersAfterDisconnect;
+    expect(peers.data).toMatchObject({ isActiveTarget: true, pinned: false });
+
+    const cli = await connectSocket(port);
+    sendReadOnlyRequest(cli, 'req-pin-4');
+    // JOB_STATE means it was ADMITTED (dispatched to B via ordinary recency); a ReplyErr
+    // would mean it was REFUSED (E_TARGET_DISCONNECTED against the now-gone pin) —
+    // exactly the regression this test exists to catch.
+    const outcome = await admissionOutcome(cli, 'req-pin-4');
+    expect(outcome).toBe('dispatched');
+  });
+
+  it('SET_TARGET refuses a claimed instanceId that does not match the sender\'s OWN registered instance', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a5', 'PinFileA5');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b5', 'PinFileB5'); // recency-favored — proves the pin never took
+    await new Promise((resolve) => setTimeout(resolve, 50)); // drain the HELLO-triggered PEERS broadcast(s)
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+
+    setTarget(pluginA, 'inst-pin-b5'); // A claims to be B — must be refused
+    await new Promise((resolve) => setTimeout(resolve, 100)); // let the broker process it (no ack frame to await)
+
+    const cli = await connectSocket(port);
+    sendReadOnlyRequest(cli, 'req-pin-5');
+    await waitForJobState(cli);
+    await waitFor(() => framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-5'));
+
+    expect(framesB.frames.some((f) => (f as { id?: string }).id === 'req-pin-5')).toBe(true); // recency, unaffected
+    expect(framesA.frames.some((f) => (f as { id?: string }).id === 'req-pin-5')).toBe(false);
+  });
+
+  it('PEERS reflects the pin: `pinned`/`isActiveTarget` on the pinned entry, both false elsewhere; CLEAR_TARGET reverts to recency', async () => {
+    const port = await startTestBroker();
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-pin-a6', 'PinFileA6');
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-pin-b6', 'PinFileB6'); // recency-favored while unpinned
+    await new Promise((resolve) => setTimeout(resolve, 50)); // drain the HELLO-triggered PEERS broadcast(s)
+
+    const peersAAfterPin = nextFrame<EventMsg>(pluginA, (m) => (m as EventMsg).type === 'PEERS');
+    const peersBAfterPin = nextFrame<EventMsg>(pluginB, (m) => (m as EventMsg).type === 'PEERS');
+    setTarget(pluginA, 'inst-pin-a6');
+    const [helloA, helloB] = await Promise.all([peersAAfterPin, peersBAfterPin]);
+    expect(helloA.data).toMatchObject({ isActiveTarget: true, pinned: true });
+    expect(helloB.data).toMatchObject({ isActiveTarget: false, pinned: false });
+
+    const peersAAfterClear = nextFrame<EventMsg>(pluginA, (m) => (m as EventMsg).type === 'PEERS');
+    const peersBAfterClear = nextFrame<EventMsg>(pluginB, (m) => (m as EventMsg).type === 'PEERS');
+    clearTarget(pluginA, 'inst-pin-a6');
+    const [clearedA, clearedB] = await Promise.all([peersAAfterClear, peersBAfterClear]);
+    // Unpinned: recency decides — B HELLO'd after A, so B is the recency target, neither is pinned.
+    expect(clearedA.data).toMatchObject({ isActiveTarget: false, pinned: false });
+    expect(clearedB.data).toMatchObject({ isActiveTarget: true, pinned: false });
+  });
+});

--- a/tests/panel-model.test.ts
+++ b/tests/panel-model.test.ts
@@ -7,6 +7,7 @@ import {
   statusSentence, formatAge, showOnboarding, fileNote, PANEL_WIDTH, PANEL_HEIGHT,
   syncPromptLabel, syncResultLabel, syncNowLabel, shouldClearPendingCount,
   syncStartSentence, syncResultSentence, syncStuckSentence, syncSupersededSentence, SYNC_STUCK_TIMEOUT_MS,
+  targetButtonLabel,
 } from '../plugin/src/ui/panel-model.ts';
 
 describe('statusSentence — Block 1: the problem and the next action, six branches', () => {
@@ -80,6 +81,34 @@ describe('fileNote — Block 2: honest answer to "which file will my command hit
   it('multiple files, another is the target → says where commands go', () => {
     expect(fileNote(3, false)).toBe('2 other files — commands go elsewhere');
     expect(fileNote(2, false)).toBe('1 other file — commands go elsewhere');
+  });
+});
+
+// #35 P2 — `pinned` distinguishes "target because pinned" from "target because
+// most-recent"; omitted/false reproduces the pre-pin wording exactly (proven above).
+describe('fileNote — pinned distinction (#35 P2)', () => {
+  it('single file, pinned target → "pinned target" (never "command target")', () => {
+    expect(fileNote(1, true, true)).toBe('pinned target');
+  });
+  it('multiple files, pinned target → pinned + peer count', () => {
+    expect(fileNote(3, true, true)).toBe('pinned target · 2 other files');
+  });
+  it('not the target at all → the "elsewhere" wording, regardless of pinned (cannot happen today, but must never claim pinned falsely)', () => {
+    expect(fileNote(3, false, true)).toBe('2 other files — commands go elsewhere');
+  });
+  it('pinned omitted defaults to false — identical to the pre-#35 wording', () => {
+    expect(fileNote(2, true)).toBe(fileNote(2, true, false));
+    expect(fileNote(1, true)).toBe('command target');
+  });
+});
+
+describe('targetButtonLabel — the "Target this plugin" toggle (#35 P2)', () => {
+  it('unpinned → invites the click', () => {
+    expect(targetButtonLabel(false)).toBe('Target this plugin');
+  });
+  it('pinned → confirms state, doubles as the clear-it toggle', () => {
+    expect(targetButtonLabel(true)).toBe('Targeted ✓');
+    expect(targetButtonLabel(true)).not.toBe(targetButtonLabel(false));
   });
 });
 

--- a/tests/route-filter.test.ts
+++ b/tests/route-filter.test.ts
@@ -1,9 +1,10 @@
 // Phase 03 — the routing precedence rule, pure: --instance (exact, unique) > --file (exact)
-// > FIGMA_AGENT_FILE (substring) > active plugin. One comparison (`fileMatches`) backs both
-// name-routing and the plugin-side guard, so they can never disagree. `kind` on the resolved
-// filter tells the registry whether `value` is a name or an opaque instanceId.
+// > the daemon's targetInstancePin (#35 P2) > FIGMA_AGENT_FILE (substring) > active plugin.
+// One comparison (`fileMatches`) backs both name-routing and the plugin-side guard, so they
+// can never disagree. `kind` on the resolved filter tells the registry whether `value` is a
+// name or an opaque instanceId.
 import { describe, it, expect } from 'vitest';
-import { resolveRouteFilter, fileMatches } from '../cli/src/transport/route-filter.ts';
+import { resolveRouteFilter, fileMatches, pinDisconnected } from '../cli/src/transport/route-filter.ts';
 
 describe('resolveRouteFilter — precedence', () => {
   it('--instance set (alone) → flag wins, exact, kind:instance', () => {
@@ -55,6 +56,81 @@ describe('resolveRouteFilter — precedence', () => {
 
   it('a whitespace-only env pin with no --file → none', () => {
     expect(resolveRouteFilter(undefined, '   ')).toEqual({ value: null, exact: false, source: 'none', kind: 'name' });
+  });
+});
+
+// #35 P2 — the daemon's runtime `targetInstancePin` (panel "Target this plugin" button),
+// ranked between --file and the env pin. The caller passes the pin only once it has
+// already verified liveness (`pinDisconnected`, below) — a disconnected pin is never
+// passed through here at all.
+describe('resolveRouteFilter — the runtime target pin (#35 P2)', () => {
+  it('pin set alone (no --instance, no --file) → pin wins over the env pin, exact, kind:instance', () => {
+    expect(resolveRouteFilter(undefined, 'design', undefined, 'p_7_1712999')).toEqual({
+      value: 'p_7_1712999', exact: true, source: 'pin', kind: 'instance',
+    });
+  });
+
+  it('--instance set alongside a pin → --instance still wins (per-request always overrides)', () => {
+    expect(resolveRouteFilter(undefined, undefined, 'p_3_1712345', 'p_7_1712999')).toEqual({
+      value: 'p_3_1712345', exact: true, source: 'flag', kind: 'instance',
+    });
+  });
+
+  it('--file set alongside a pin → --file still wins (per-request always overrides)', () => {
+    expect(resolveRouteFilter('VSF - PCP', undefined, undefined, 'p_7_1712999')).toEqual({
+      value: 'VSF - PCP', exact: true, source: 'flag', kind: 'name',
+    });
+  });
+
+  it('pin set, no env → pin still applies (does not require an env pin to exist)', () => {
+    expect(resolveRouteFilter(undefined, undefined, undefined, 'p_7_1712999')).toEqual({
+      value: 'p_7_1712999', exact: true, source: 'pin', kind: 'instance',
+    });
+  });
+
+  it('no pin (null/undefined) → falls through to the env pin exactly as before', () => {
+    expect(resolveRouteFilter(undefined, 'design', undefined, null)).toEqual({
+      value: 'design', exact: false, source: 'env', kind: 'name',
+    });
+    expect(resolveRouteFilter(undefined, 'design', undefined, undefined)).toEqual({
+      value: 'design', exact: false, source: 'env', kind: 'name',
+    });
+  });
+
+  it('a whitespace-only pin is treated as unset — falls through to the env pin', () => {
+    expect(resolveRouteFilter(undefined, 'design', undefined, '   ')).toEqual({
+      value: 'design', exact: false, source: 'env', kind: 'name',
+    });
+  });
+});
+
+// The disconnected-pin refusal predicate: Law 1 (a standing pin must never silently
+// re-point at another plugin) means the daemon refuses outright instead of calling
+// resolveRouteFilter with a null pin — this is the pure seam that decision routes through.
+describe('pinDisconnected — Law 1: a dead pin refuses, never falls through (#35 P2)', () => {
+  it('no pin set at all → never disconnected (nothing to refuse)', () => {
+    expect(pinDisconnected(undefined, undefined, null, false)).toBe(false);
+    expect(pinDisconnected(undefined, undefined, undefined, false)).toBe(false);
+  });
+
+  it('pin set and live → not disconnected', () => {
+    expect(pinDisconnected(undefined, undefined, 'p_7_1712999', true)).toBe(false);
+  });
+
+  it('pin set and NOT live, no per-request flag → disconnected, must refuse', () => {
+    expect(pinDisconnected(undefined, undefined, 'p_7_1712999', false)).toBe(true);
+  });
+
+  it('pin set and NOT live, but --instance overrides it → never disconnected (per-request bypasses the pin entirely)', () => {
+    expect(pinDisconnected(undefined, 'p_3_1712345', 'p_7_1712999', false)).toBe(false);
+  });
+
+  it('pin set and NOT live, but --file overrides it → never disconnected', () => {
+    expect(pinDisconnected('VSF - PCP', undefined, 'p_7_1712999', false)).toBe(false);
+  });
+
+  it('a whitespace-only pin is treated as unset — never disconnected', () => {
+    expect(pinDisconnected(undefined, undefined, '   ', false)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

P1 (#36) gave the agent exact targeting via `--instance <id>`. This is P2: a
human one-click way to pin the daemon's routing to the plugin they're
looking at, so subsequent no-flag commands route there without juggling
instanceIds.

**Precedence chain** (extends P1's):
`--instance` (per-request) > `--file` (per-request) > **`targetInstancePin`
(daemon runtime, new)** > `FIGMA_AGENT_FILE` (env) > active (recency).

**Daemon** (`broker-daemon.ts`):
- `targetInstancePin: string | null` — set/cleared by the panel, consulted in
  `admitRequest` only when neither per-request flag is present. A live pin
  routes through P1's own `kind:'instance'` path (no new lookup). A pin
  pointing at a gone instance refuses the command outright
  (`E_TARGET_DISCONNECTED`, naming the instance) rather than silently
  falling through to the env pin or recency — a standing pin must never
  quietly re-point at another plugin.
- The pin clears automatically the moment its instance disconnects, so a
  dead pin can never wedge future no-flag commands.
- New panel→daemon messages `SET_TARGET`/`CLEAR_TARGET`, carrying the
  panel's own instanceId — validated against the sender's own registered
  socket, so a panel can only ever pin *itself*.
- `PEERS` gains a `pinned` boolean alongside `isActiveTarget`, so a panel can
  tell "target because pinned" from "target because most-recent".

**Routing** (`route-filter.ts`): `resolveRouteFilter` takes the (already
liveness-checked) pin as a new precedence tier; `pinDisconnected` is the pure
predicate for the refuse-vs-fall-through decision — both unit-tested
directly, independent of any registry/socket mocking.

**Panel**: a "Target this plugin" button (`panel.html`) that reads
"Targeted ✓" when this panel is the pin (click clears it), wired through
`ui-relay.ts`'s existing DOM-event plumbing (the same shape `SYNC_REQUEST`
already uses) and `panel-ui.ts`/`panel-model.ts` for the toggle label + the
pinned/active context note.

**Non-goals** (per spec): no change to `--instance`/`--file` semantics, no
auto-pinning, no persistence across broker restarts (runtime-only, like the
rest of the connection state).

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm run lint:comments` — clean (0 new citations)
- [x] `tests/route-filter.test.ts` — precedence + `pinDisconnected`, unit,
      pure (new + existing pass)
- [x] `tests/panel-model.test.ts` — `fileNote` pinned wording +
      `targetButtonLabel` (new + existing pass)
- [x] `tests/broker-daemon-harness.test.ts` — pin routing precedence
      (beats recency, per-request flags still override), `SET_TARGET`/
      `CLEAR_TARGET` lifecycle, disconnect-clears-pin, `PEERS`
      `pinned`/`isActiveTarget` (6 new tests + all 22 pre-existing pass, 28
      total) — uses the harness's own scratch `logFile`/ephemeral-port
      isolation, never touches a live broker session
- [ ] Manual: open two Figma files, click "Target this plugin" on one,
      confirm a no-flag `figma-agent` command lands there regardless of
      which file was most recently active

## Notes

- The E_TARGET_DISCONNECTED refusal path is unit-tested at the pure
  `pinDisconnected` seam (deterministic) rather than raced end-to-end in the
  harness — the daemon's own disconnect handler clears the pin synchronously
  with the registry removal, so there's no naturally reachable window in a
  harness test where the pin is live-set-but-dead; the pure predicate is the
  clearer, non-flaky place to prove that branch.