### PR TITLE
Add zombie-watchdog observability (transport vs app liveness)

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -23,7 +23,7 @@ import {
   ChunkAssembler, deleteConnectionChunk, envMs, getConnectionChunks, isChunkMsg, isEventMsg, isReplyMsg, isRequestMsg,
   parseWireMsg, rawToString, sendWireMsg, sweepAbandonedChunks, type ChunkBuffers,
 } from './protocol-helpers.ts';
-import { PluginRegistry, type PluginEntry } from './plugin-registry.ts';
+import { PluginRegistry, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
 import { pinDisconnected, resolveRouteFilter, type RouteFilter } from './route-filter.ts';
 import {
@@ -1289,7 +1289,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (!msg) return;
     // Hidden control frame from a newer CLI build replacing this broker.
     if ((msg as { type?: string }).type === 'BROKER_SHUTDOWN_REQUEST') shutdown(0, 'BROKER_SHUTDOWN_REQUEST');
-    const isPlugin = st.registry.touch(ws); // any plugin frame = LIVENESS (heartbeat cull)
+    // Any parsed frame here only exists because real JS constructed and sent it —
+    // this is the APP-liveness sensor (zombie-watchdog observability), distinct from
+    // the transport-only `touch` the raw WS 'pong' handler below uses.
+    const isPlugin = st.registry.touchApp(ws);
     if (isChunkMsg(msg)) {
       // Reply-side chunks (plugin → broker) pass straight to routeFromPlugin, which now
       // accumulates every frame onto the job record itself (concurrency & jobs, backlog
@@ -1530,8 +1533,15 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   wss.on('connection', onConnection);
   wss6?.on('connection', onConnection);
 
+  // Zombie-watchdog observability — last known `suspectedZombie` state per
+  // instanceId, scoped to this daemon run (a closure local, same lifetime as
+  // `senderMismatchCount` above) so a log line fires only on a FLIP, never once per
+  // tick. Deliberately observation-only: no socket here is ever terminated for this.
+  const zombieFlagged = new Map<string, boolean>();
+
   // Heartbeat: WS-ping on the heartbeat cadence; drop sockets that missed the
   // previous pong (broker→client liveness; browsers auto-pong at the WS layer).
+  // Piggybacks the zombie-watchdog flip check onto this SAME tick — no new interval.
   setInterval(() => {
     const allClients = [...wss!.clients, ...(wss6 ? wss6.clients : [])];
     for (const ws of allClients) {
@@ -1540,6 +1550,23 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       tracked.isAlive = false;
       tracked.ping();
     }
+    const now = Date.now();
+    const liveIds = new Set<string>();
+    for (const e of st.registry.liveEntries()) {
+      liveIds.add(e.instanceId);
+      const flagged = suspectedZombie(e, now);
+      if (flagged !== (zombieFlagged.get(e.instanceId) ?? false)) {
+        const fileName = (e.scene.fileName as string | undefined) ?? '(unnamed)';
+        log(flagged
+          ? `suspected zombie [${e.instanceId}] "${fileName}" — app-silence ${now - e.lastAppFrameAt}ms, same-scene streak ${e.sameSceneStreak}`
+          : `zombie flag cleared [${e.instanceId}] "${fileName}"`);
+      }
+      zombieFlagged.set(e.instanceId, flagged);
+    }
+    // Drop bookkeeping for instances no longer connected (disconnect, or an
+    // already-superseded entry) — this map must never grow across a long-lived
+    // daemon run.
+    for (const id of zombieFlagged.keys()) if (!liveIds.has(id)) zombieFlagged.delete(id);
   }, HEARTBEAT_MS);
 
   // Sweep parked requests: fail any that outlived their plugin-wait window, and

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -6,10 +6,38 @@
 // / cull / status contract is pure and unit-testable with fake sockets.
 import type { PluginScene, PluginStatusEntry } from '../../../shared/protocol.ts';
 import { fileMatches } from '../../../shared/file-match.ts';
+import { envMs } from './protocol-helpers.ts';
 import type { FilterKind } from './route-filter.ts';
 
 /** WebSocket.OPEN — inlined so the registry needs no `ws` import (kept pure). */
 export const WS_OPEN = 1;
+
+// Zombie-watchdog observability — the broker conflates two liveness layers today:
+// TRANSPORT liveness (a WS pong, which Chromium auto-answers from the network
+// process even while the iframe's JS is frozen) and APP liveness (a JS-originated
+// frame — HELLO/FILE_INFO/command reply/chunk — which dies the instant the freeze
+// hits). A frozen iframe still auto-pongs, so `lastSeenAt` alone reads as perfectly
+// healthy; `lastAppFrameAt` is the sensor that actually goes stale. A merely-
+// throttled (not frozen) background tab still services its ~10s app-level PING on a
+// slower cadence, so this threshold sits comfortably above that jitter — a
+// throttled tab is caught by the reconnect-streak path below instead. Env-
+// overridable via the same `envMs` knob pattern the daemon's other cadence
+// constants use, so a test can shrink it to observe a flip in real seconds.
+export const FROZEN_AFTER_MS = envMs('FIGMA_AGENT_ZOMBIE_MS', 75_000);
+
+// A throttled-background reconnect loop (the OTHER zombie mode: the tab never
+// fully freezes, but the browser throttles its timers enough that its socket
+// drops and reconnects on unchanged content) flags after this many same-scene
+// re-registers. Three is the register()-side floor: one reconnect is routine
+// network noise, two is still plausibly a blip, three with an unchanged scene is
+// a pattern.
+const FLAPPER_STREAK_THRESHOLD = 3;
+
+// A same-scene re-HELLO only ever COUNTS toward the flapper streak when it lands
+// within this long since the PREVIOUS re-HELLO — a daily sleep/wake reconnect
+// (hours apart, same scene) must never accumulate toward the threshold; only a
+// tight reconnect cadence indicates throttling.
+const REHELLO_STREAK_WINDOW_MS = 10 * 60_000;
 
 /** The minimal socket surface the registry reads. Real `ws` sockets satisfy it. */
 export interface RegistrySocket {
@@ -23,6 +51,22 @@ export interface PluginEntry<S extends RegistrySocket = RegistrySocket> {
   connectedAt: number; // first HELLO for this instance (survives same-instance re-HELLO)
   lastSeenAt: number; // any inbound frame/pong — LIVENESS only (heartbeat cull)
   lastActiveAt: number; // real interaction (HELLO/FILE_INFO/command traffic) — drives ROUTING recency
+  // Zombie-watchdog observability — bumped ONLY by `touchApp`/`register` (real
+  // JS-originated frames), NEVER by the transport-only `touch` a raw WS pong uses.
+  // This one split is the whole design: it is what lets a frozen-but-still-
+  // pinging iframe read as stale instead of healthy.
+  lastAppFrameAt: number;
+  // Diagnostic: total same-instance re-registers this run (any reconnect with a
+  // NEW socket for the same instanceId), regardless of scene or timing.
+  reHelloCount: number;
+  // Consecutive same-scene reconnects landing within `REHELLO_STREAK_WINDOW_MS`
+  // of each other — the throttled-flapper signal. Reset by any genuine app
+  // activity (`touchActive`) or a scene-CHANGING `updateScene`; a fresh instance
+  // starts at 1 (seen once, nothing to flap yet).
+  sameSceneStreak: number;
+  // When the last reconnect (superseded same-instance register) happened, or
+  // null before the first one — the anchor `sameSceneStreak` windows against.
+  lastReHelloAt: number | null;
 }
 
 // HELLO payload keys that are protocol plumbing, not scene identity.
@@ -33,6 +77,36 @@ export function extractScene(data: Record<string, unknown> | null | undefined): 
   const scene: PluginScene = {};
   for (const [k, v] of Object.entries(data ?? {})) if (!PROTOCOL_KEYS.has(k)) scene[k] = v;
   return scene;
+}
+
+/**
+ * Zombie-watchdog detection predicate, computed at READ time (no new timer): either
+ * the app-frame-silence sensor tripped (frozen — the primary, invisible-otherwise
+ * mode) or the same-scene reconnect streak did (throttled flapper — secondary).
+ * Absence of scene-changing activity is NEVER evidence on its own — an idle-healthy
+ * file with hours-old edits but a live 10s app PING trips neither branch.
+ */
+export function suspectedZombie<S extends RegistrySocket>(
+  e: PluginEntry<S>,
+  now: number,
+  thresholdMs: number = FROZEN_AFTER_MS,
+): boolean {
+  return now - e.lastAppFrameAt > thresholdMs || e.sameSceneStreak >= FLAPPER_STREAK_THRESHOLD;
+}
+
+/** The human-readable cause behind `suspectedZombie`, or null if neither branch
+ *  tripped. Checked in the same frozen-first order as the predicate: a fully-frozen
+ *  instance is the more severe/invisible failure mode, so its message wins even if a
+ *  stale flapper streak also happens to be sitting at/above threshold. */
+function zombieReason<S extends RegistrySocket>(e: PluginEntry<S>, now: number, thresholdMs: number): string | null {
+  const appSilenceMs = now - e.lastAppFrameAt;
+  if (appSilenceMs > thresholdMs) {
+    return `no app heartbeat for ${Math.round(appSilenceMs / 1000)}s — editor window likely backgrounded/frozen; focus it once to revive`;
+  }
+  if (e.sameSceneStreak >= FLAPPER_STREAK_THRESHOLD) {
+    return `${e.sameSceneStreak} reconnects with unchanged scene — editor window throttled in background; focus it once`;
+  }
+  return null;
 }
 
 /**
@@ -60,29 +134,57 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     const id = carried ?? this.instanceForWs(ws) ?? this.mint();
     const existing = this.plugins.get(id);
     const superseded = existing && existing.ws !== ws ? existing.ws : null;
+    const scene = extractScene(data);
+    // Zombie-watchdog flapper streak — only a reconnect on a NEW socket for this
+    // same instance (`superseded !== null`) is a candidate re-HELLO; a duplicate
+    // HELLO on the SAME still-open socket is not a reconnect at all, so it leaves
+    // the streak untouched.
+    let reHelloCount = existing?.reHelloCount ?? 0;
+    let sameSceneStreak = existing?.sameSceneStreak ?? 1;
+    let lastReHelloAt = existing?.lastReHelloAt ?? null;
+    if (superseded !== null) {
+      reHelloCount += 1;
+      const sameScene = JSON.stringify(scene) === JSON.stringify(existing!.scene);
+      const withinWindow = existing!.lastReHelloAt !== null && now - existing!.lastReHelloAt < REHELLO_STREAK_WINDOW_MS;
+      sameSceneStreak = sameScene && withinWindow ? existing!.sameSceneStreak + 1 : 1;
+      lastReHelloAt = now;
+    }
     this.plugins.set(id, {
       instanceId: id,
       ws,
-      scene: extractScene(data),
+      scene,
       connectedAt: existing ? existing.connectedAt : now,
       lastSeenAt: now,
       lastActiveAt: now,
+      lastAppFrameAt: now, // a HELLO is itself an app frame — real JS just spoke
+      reHelloCount,
+      sameSceneStreak,
+      lastReHelloAt,
     });
     return { instanceId: id, replaced: existing !== undefined, superseded };
   }
 
-  /** Merge a FILE_INFO scene update (page change) into the socket's entry. */
+  /** Merge a FILE_INFO scene update (page change) into the socket's entry. A scene
+   *  change is real activity AND proves the reconnect streak wasn't flapping on
+   *  unchanged content, so it resets `sameSceneStreak` — but only when the scene
+   *  actually changed; re-sending the same scene must not silently clear suspicion. */
   updateScene(ws: S, data: Record<string, unknown>): boolean {
     const entry = this.getByWs(ws);
     if (!entry) return false;
-    entry.scene = { ...entry.scene, ...extractScene(data) };
+    const merged = { ...entry.scene, ...extractScene(data) };
+    const changed = JSON.stringify(merged) !== JSON.stringify(entry.scene);
+    entry.scene = merged;
     entry.lastSeenAt = this.now();
     entry.lastActiveAt = entry.lastSeenAt;
+    if (changed) entry.sameSceneStreak = 0;
     return true;
   }
 
-  /** Bump liveness (routing recency) for the socket's entry. Returns false if
-   *  the socket is not a registered plugin (i.e. it is a CLI client). */
+  /** Bump TRANSPORT liveness only — a raw WS pong, which a browser answers from its
+   *  network process even while the tab's JS is frozen. Deliberately does NOT touch
+   *  `lastAppFrameAt`: a frozen iframe must stay flagged stale by the app-liveness
+   *  sensor no matter how healthy its transport still looks. Returns false if the
+   *  socket is not a registered plugin (i.e. it is a CLI client). */
   touch(ws: S): boolean {
     const entry = this.getByWs(ws);
     if (!entry) return false;
@@ -90,15 +192,29 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     return true;
   }
 
+  /** Bump APP liveness — a parsed frame that only real JS could have sent (any
+   *  message the daemon's socket handler receives at all). Also counts as transport
+   *  liveness (a superset), so it bumps `lastSeenAt` too. */
+  touchApp(ws: S): boolean {
+    const entry = this.getByWs(ws);
+    if (!entry) return false;
+    const now = this.now();
+    entry.lastSeenAt = now;
+    entry.lastAppFrameAt = now;
+    return true;
+  }
+
   /** Bump ROUTING recency too — only real interaction frames (command replies, chunks,
    *  FILE_INFO). Heartbeat PONGs must NOT call this: they fire for every connected file
    *  on a timer, which would flip the routing target on heartbeat phase instead of
-   *  tracking what the user actually touched. */
+   *  tracking what the user actually touched. Any real interaction also proves the
+   *  instance isn't flapping right now, so it clears `sameSceneStreak`. */
   touchActive(ws: S): boolean {
     const entry = this.getByWs(ws);
     if (!entry) return false;
     entry.lastSeenAt = this.now();
     entry.lastActiveAt = entry.lastSeenAt;
+    entry.sameSceneStreak = 0;
     return true;
   }
 
@@ -194,15 +310,25 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     const now = this.now();
     return this.liveEntries()
       .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
-      .map((e) => ({
-        instanceId: e.instanceId,
-        fileName: (e.scene.fileName as string | undefined) ?? null,
-        page: (e.scene.page as string | undefined) ?? null,
-        state: 'connected' as const,
-        lastHeartbeatAge: e.lastSeenAt ? now - e.lastSeenAt : null,
-        connectedAt: e.connectedAt,
-        fileKey: (e.scene.fileKey as string | null | undefined) ?? null,
-      }));
+      .map((e) => {
+        const reason = zombieReason(e, now, FROZEN_AFTER_MS);
+        return {
+          instanceId: e.instanceId,
+          fileName: (e.scene.fileName as string | undefined) ?? null,
+          page: (e.scene.page as string | undefined) ?? null,
+          state: 'connected' as const,
+          lastHeartbeatAge: e.lastSeenAt ? now - e.lastSeenAt : null,
+          connectedAt: e.connectedAt,
+          fileKey: (e.scene.fileKey as string | null | undefined) ?? null,
+          // Zombie-watchdog observability — the raw sensor is ALWAYS present (an agent
+          // can judge staleness itself); the derived flag/counter/reason are present
+          // only when they carry information, same present-only contract as
+          // senderMismatchCount on the top-level BROKER_HELLO payload.
+          appSilenceMs: now - e.lastAppFrameAt,
+          ...(e.reHelloCount > 0 && { reHelloCount: e.reHelloCount }),
+          ...(reason !== null && { suspectedZombie: true as const, zombieReason: reason }),
+        };
+      });
   }
 
   private mint(): string {

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -265,6 +265,36 @@ export interface PluginStatusEntry {
    * FileContext.fileKey.
    */
   fileKey?: string | null;
+  /**
+   * Zombie-watchdog observability — the raw APP-liveness sensor: ms since the last
+   * JS-originated frame (HELLO/FILE_INFO/command reply/chunk) from this instance.
+   * ALWAYS present, even at 0, so an agent can judge staleness for itself rather than
+   * trusting only the derived `suspectedZombie` flag. Deliberately distinct from
+   * `lastHeartbeatAge`: that ages on ANY frame including a transport-only WS pong,
+   * which a frozen (but not yet closed) iframe keeps answering from the browser's
+   * network process even after its JS stopped running.
+   */
+  appSilenceMs: number;
+  /**
+   * Total same-instance re-registers this broker run — a diagnostic counter, not a
+   * verdict by itself (a healthy reconnect after a real network blip also bumps it).
+   * Present only once > 0, same "discarded/stuck thing gets a machine-readable counter,
+   * but the common zero case stays byte-identical" contract as senderMismatchCount.
+   */
+  reHelloCount?: number;
+  /**
+   * True when either liveness sensor tripped: app-frame silence past the frozen
+   * threshold, or a same-scene reconnect streak past the flapper threshold. Present
+   * only when flagged — the common healthy case keeps this payload byte-identical to
+   * before the field existed.
+   */
+  suspectedZombie?: true;
+  /**
+   * Human-readable cause paired with `suspectedZombie` — the field an agent reads to
+   * decide what to do, not just that something is wrong. Present only alongside
+   * `suspectedZombie`.
+   */
+  zombieReason?: string;
 }
 
 // Chunked transport for payloads > CHUNK_LIMIT (both directions).

--- a/tests/plugin-registry.test.ts
+++ b/tests/plugin-registry.test.ts
@@ -3,7 +3,9 @@
 // the FIGMA_AGENT_FILE substring filter, the park→flush decision, and the status
 // list shape. Fake sockets are just `{ readyState }`; a mutable clock drives recency.
 import { describe, it, expect } from 'vitest';
-import { PluginRegistry, WS_OPEN, extractScene, type RegistrySocket } from '../cli/src/transport/plugin-registry.ts';
+import {
+  FROZEN_AFTER_MS, PluginRegistry, WS_OPEN, extractScene, suspectedZombie, type RegistrySocket,
+} from '../cli/src/transport/plugin-registry.ts';
 
 const CLOSED = 3; // WebSocket.CLOSED
 const sock = (open = true): RegistrySocket => ({ readyState: open ? WS_OPEN : CLOSED });
@@ -284,6 +286,7 @@ describe('statusList — the per-file rows, most-recent first', () => {
       lastHeartbeatAge: 0, // b was just registered at `now`
       connectedAt: bConnectedAt,
       fileKey: null, // absent from the HELLO payload here — registry-integrity phase 01 §2
+      appSilenceMs: 0, // b's HELLO IS an app frame — zombie-watchdog sensor, always present
     });
     expect(list[1]).toMatchObject({ instanceId: 'a', fileName: 'A', page: 'P1', connectedAt: aConnectedAt });
     expect(list[1].lastHeartbeatAge).toBe(20); // a last seen 20ms ago
@@ -342,6 +345,133 @@ describe('getByInstanceId — pinned-target resolution (concurrency & jobs)', ()
     reg.register(ws, { instanceId: 'p1', fileName: 'A' });
     reg.removeByWs(ws);
     expect(reg.getByInstanceId('p1')).toBeNull();
+  });
+});
+
+describe('zombie-watchdog — transport vs app liveness split', () => {
+  it('THE load-bearing test: a transport pong (touch) does NOT clear the frozen flag; only touchApp does', () => {
+    const { reg, tick, at } = makeReg();
+    const ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    tick(FROZEN_AFTER_MS + 1_000); // JS has gone silent long past the frozen threshold
+    expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(true);
+
+    reg.touch(ws); // a raw WS pong — Chromium auto-answers this even while frozen
+    expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(true); // still flagged — pong proves nothing
+
+    reg.touchApp(ws); // a real JS-originated frame
+    expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(false); // NOW it clears
+  });
+
+  it('suspectedZombie — FROZEN_AFTER_MS boundary: exactly at threshold not flagged, one ms over is', () => {
+    const { reg, tick, at } = makeReg();
+    const ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    tick(FROZEN_AFTER_MS);
+    expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(false); // == threshold, not over it
+    tick(1);
+    expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(true);
+  });
+});
+
+describe('zombie-watchdog — same-scene reconnect (throttled flapper) streak', () => {
+  it('3 same-scene reconnects within the window flag; a scene-changing updateScene resets it', () => {
+    const { reg, tick } = makeReg();
+    let ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' });
+    tick(1_000);
+    ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' }); // reconnect 1 — same scene
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(1);
+    tick(1_000);
+    ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' }); // reconnect 2 — same scene, within window
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(2);
+    expect(reg.statusList()[0].suspectedZombie).toBeUndefined(); // not yet at the threshold
+    tick(1_000);
+    ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' }); // reconnect 3 — flags
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(3);
+    expect(reg.statusList()[0].suspectedZombie).toBe(true);
+
+    reg.updateScene(ws, { page: 'P2' }); // scene actually CHANGED — proves this wasn't flapping
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(0);
+    expect(reg.statusList()[0].suspectedZombie).toBeUndefined();
+  });
+
+  it('touchActive (real interaction) resets the streak the same way', () => {
+    const { reg, tick } = makeReg();
+    let ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    for (let i = 0; i < 2; i++) {
+      tick(1_000);
+      ws = sock();
+      reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    }
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(2);
+    reg.touchActive(ws);
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(0);
+  });
+
+  it('re-sending the identical scene on updateScene does NOT reset the streak (no change = no proof)', () => {
+    const { reg, tick } = makeReg();
+    let ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' });
+    for (let i = 0; i < 2; i++) {
+      tick(1_000);
+      ws = sock();
+      reg.register(ws, { instanceId: 'a', fileName: 'F', page: 'P1' });
+    }
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(2);
+    reg.updateScene(ws, { page: 'P1' }); // identical — nothing actually changed
+    expect(reg.getByWs(ws)!.sameSceneStreak).toBe(2); // unchanged
+  });
+
+  it('daily-cadence re-HELLOs (>10 min apart) never accumulate toward the threshold', () => {
+    const { reg, tick } = makeReg();
+    let ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    for (let i = 0; i < 4; i++) {
+      tick(11 * 60_000); // 11 minutes — always outside the 10-minute streak-locality window
+      ws = sock();
+      reg.register(ws, { instanceId: 'a', fileName: 'F' });
+      expect(reg.getByWs(ws)!.sameSceneStreak).toBe(1); // never grows past 1
+    }
+  });
+});
+
+describe('statusList — zombie-watchdog present-only serialization', () => {
+  it('appSilenceMs always present; suspectedZombie/zombieReason/reHelloCount omitted in the healthy zero case', () => {
+    const { reg } = makeReg();
+    reg.register(sock(), { instanceId: 'a', fileName: 'F' });
+    const [row] = reg.statusList();
+    expect('appSilenceMs' in row).toBe(true);
+    expect(row.appSilenceMs).toBe(0);
+    expect('suspectedZombie' in row).toBe(false);
+    expect('zombieReason' in row).toBe(false);
+    expect('reHelloCount' in row).toBe(false);
+  });
+
+  it('reHelloCount appears once > 0, even before any flag trips', () => {
+    const { reg, tick } = makeReg();
+    let ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    tick(5);
+    ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' }); // one reconnect — not yet a flapper
+    const row = reg.statusList().find((p) => p.instanceId === 'a')!;
+    expect(row.reHelloCount).toBe(1);
+    expect('suspectedZombie' in row).toBe(false);
+  });
+
+  it('suspectedZombie + zombieReason appear together, with the reason naming the cause', () => {
+    const { reg, tick } = makeReg();
+    const ws = sock();
+    reg.register(ws, { instanceId: 'a', fileName: 'F' });
+    tick(FROZEN_AFTER_MS + 1_000);
+    const row = reg.statusList()[0];
+    expect(row.suspectedZombie).toBe(true);
+    expect(row.zombieReason).toMatch(/no app heartbeat for \d+s/);
   });
 });
 


### PR DESCRIPTION
## Why

The broker conflates two liveness layers today: **transport liveness** (a WS
`pong`, which Chromium auto-answers from its network process even while the
iframe's JS is frozen) and **app liveness** (a JS-originated frame — HELLO,
FILE_INFO, a command reply/chunk — which dies the instant the freeze hits).
Because the pong keeps `lastSeenAt` fresh, a fully-frozen plugin instance
reads as perfectly healthy today. That is the invisible failure mode this PR
makes visible.

A secondary, less severe mode also exists: a throttled-but-not-frozen
background tab whose socket drops and reconnects repeatedly with an
unchanged scene.

## What this PR adds (observability only)

- `PluginEntry` gains `lastAppFrameAt`, `reHelloCount`, `sameSceneStreak`,
  `lastReHelloAt`.
- The daemon's app-frame frame-receipt site now calls a new
  `registry.touchApp(ws)` (bumps `lastAppFrameAt` + `lastSeenAt`). The raw WS
  `'pong'` handler is unchanged — it still calls the existing `touch(ws)`
  (transport-only, never touches `lastAppFrameAt`). **This one split is the
  whole design.**
- `register()` tracks a same-scene reconnect streak, windowed to 10 minutes
  so a daily sleep/wake reconnect (same scene, hours apart) never
  accumulates toward the flapper threshold. `touchActive` and a
  scene-*changing* `updateScene` both reset the streak — any real activity
  proves the instance isn't flapping right now.
- A pure predicate, computed at read time (no new timer):
  `suspectedZombie = appSilenceMs > FROZEN_AFTER_MS || sameSceneStreak >= 3`.
  `FROZEN_AFTER_MS` defaults to 75s, overridable via `FIGMA_AGENT_ZOMBIE_MS`
  (same `envMs` pattern as the daemon's other cadence knobs).
- `PluginStatusEntry` gains `appSilenceMs` (always present — the raw sensor,
  so an agent can judge staleness itself) and `reHelloCount` /
  `suspectedZombie` / `zombieReason` (present only when they carry
  information, same contract as the existing `senderMismatchCount` field —
  the healthy zero-case payload stays byte-identical).
- A log line fires only on a flag **flip**, piggybacked onto the existing
  WS-ping heartbeat interval — no new timer, no per-tick spam.

## Not building (deliberate, filed separately)

- **No remediation** — a zombie's socket is never terminated here. A frozen
  iframe can't run its own reconnect loop, so killing the socket would
  convert a visible zombie into an invisible absence.
- **No routing change** — a flapping zombie can still steal the routing
  target via `register()`'s recency bump. Left as a separate follow-up
  (deprioritizing a suspected zombie in `selectTarget`).
- No plugin-side/relay changes, no persistence (broker-restart blindness is
  a separate, optional follow-up).

## Tests

`tests/plugin-registry.test.ts` (all fake sockets + an injected clock, no
live broker):
- **The load-bearing assertion**: a transport `touch` (pong) does NOT clear
  the frozen flag; only `touchApp` does.
- Predicate boundary: exactly at `FROZEN_AFTER_MS` is not flagged, one ms
  over is.
- 3 same-scene reconnects within the window flag as a flapper; a
  scene-changing `updateScene` or `touchActive` resets the streak; an
  identical-scene `updateScene` does NOT reset it (no change = no proof);
  daily-cadence (>10 min apart) reconnects never accumulate past streak 1.
- Present-only serialization: `appSilenceMs` always present, zero-case
  payload has no `suspectedZombie`/`zombieReason`/`reHelloCount` keys;
  `reHelloCount` appears once > 0 even before any flag trips;
  `suspectedZombie` + `zombieReason` appear together once frozen.

## Gate

- `npm run typecheck` — pass
- `npm run build` — pass
- `npx vitest run tests/plugin-registry.test.ts tests/broker-status.test.ts tests/executor-ops-status.test.ts` — 67 passed
- `npm run lint:comments` — clean, 0 new citations

Did not run the full `npm test` suite per scope (broker-daemon-harness spawns
a live broker process; out of scope for this pure-registry/status change).

## Owner-manual (not done here, flagging)

Live smoke test: background a FigJam window for ~5 minutes, then confirm
`figma-agent status` shows `suspectedZombie: true` with a LOW
`lastHeartbeatAge` (transport still ponging) but a high `appSilenceMs`. This
also verifies the Chromium-auto-pong assumption this whole design rests on —
if the frozen iframe instead gets culled as WS-dead before this fires, the
failure mode is different from what's assumed here and the broker-restart
persistence follow-up becomes the primary fix instead.