### PR TITLE
fix: deprioritize suspected-zombie plugins in default routing selection

### DIFF
--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -290,19 +290,34 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     }
     const live = this.liveEntries();
     const hits = f ? live.filter((e) => fileMatches(e.scene.fileName as string | undefined, f, opts?.exact === true)) : live;
+    // A named/filtered ask is a deliberate targeting decision — it always resolves by
+    // pure recency, reaching a suspected zombie if that's what the name (or instance,
+    // handled above) names. Only the UNFILTERED default selection deprioritizes a
+    // suspected zombie: it must never win the no-flag routing slot over a healthy
+    // plugin purely by having re-HELLO'd more recently. When every live candidate is
+    // suspected, the group collapses to one and recency alone decides — a fallback,
+    // never a refusal, since a suspected zombie is still a connected, usable plugin.
+    if (!f) {
+      const now = this.now();
+      return [...hits].sort((a, b) => {
+        const zombieRank = Number(suspectedZombie(a, now)) - Number(suspectedZombie(b, now));
+        return zombieRank !== 0 ? zombieRank : b.lastActiveAt - a.lastActiveAt;
+      });
+    }
     return [...hits].sort((a, b) => b.lastActiveAt - a.lastActiveAt);
   }
 
   /**
-   * The routing target: the live plugin with the most-recent `lastSeenAt` — "the
-   * file the user touched last". An optional fileName filter (case-insensitive
-   * substring by default, or `opts.exact` for a whole-name match — see `matching`)
-   * restricts candidates, or `opts.kind: 'instance'` resolves `filter` as an exact
-   * instanceId instead; no candidate matches → null. Ties keep the most-recent
-   * (see `matching`'s sort).
+   * The routing target: the live plugin with the most-recent `lastActiveAt` — "the
+   * file the user touched last" — EXCEPT when no filter is given at all, where a
+   * suspected zombie (see `suspectedZombie`) is deprioritized behind any healthy
+   * plugin (see `matching`). An optional fileName filter (case-insensitive substring
+   * by default, or `opts.exact` for a whole-name match — see `matching`) restricts
+   * candidates by pure recency instead — a named/instance ask is explicit targeting
+   * and reaches a suspected zombie on purpose; no candidate matches → null.
    */
   selectTarget(filter?: string | null, opts?: { exact?: boolean; kind?: FilterKind }): PluginEntry<S> | null {
-    return this.matching(filter, opts)[0] ?? null;   // unchanged semantics for existing callers
+    return this.matching(filter, opts)[0] ?? null;
   }
 
   /** The per-file list for BROKER_HELLO / `figma-agent status`, most-recent first. */

--- a/tests/plugin-registry.test.ts
+++ b/tests/plugin-registry.test.ts
@@ -262,6 +262,62 @@ describe('matching/selectTarget(filter, {kind:"instance"}) — instanceId target
   });
 });
 
+describe('selectTarget — suspected-zombie deprioritization (no-filter recency path only)', () => {
+  /** Re-HELLOs the same instance on an unchanged scene enough times to trip the
+   *  throttled-flapper branch of `suspectedZombie` — each re-HELLO also bumps
+   *  `lastActiveAt`, so a flapping zombie can end up MORE recent than a healthy
+   *  plugin that has not touched anything in a while. Ticks stay well under
+   *  FROZEN_AFTER_MS so an untouched healthy fixture in the same test never
+   *  drifts into the OTHER (frozen) zombie branch purely from elapsed time. */
+  function flapToZombie(reg: ReturnType<typeof makeReg>['reg'], tick: (ms?: number) => number, instanceId: string, fileName: string) {
+    let ws = sock();
+    reg.register(ws, { instanceId, fileName });
+    for (let i = 0; i < 3; i++) {
+      tick(2_000); // within the streak-locality window, well outside a single tick
+      ws = sock();
+      reg.register(ws, { instanceId, fileName });
+    }
+    return ws;
+  }
+
+  it('a no-flag selectTarget prefers the HEALTHY plugin even though the zombie re-HELLO\'d more recently', () => {
+    const { reg, tick } = makeReg();
+    reg.register(sock(), { instanceId: 'h', fileName: 'Healthy' });
+    tick(5);
+    const healthy = reg.getByInstanceId('h')!;
+    const zombieWs = flapToZombie(reg, tick, 'z', 'Zombie');
+    const zombie = reg.getByWs(zombieWs)!;
+    expect(zombie.sameSceneStreak).toBe(3); // confirms it IS suspected
+    expect(zombie.lastActiveAt).toBeGreaterThan(healthy.lastActiveAt); // sanity: recency alone would pick the zombie
+    expect(reg.selectTarget()?.instanceId).toBe('h'); // healthy wins despite lower recency
+  });
+
+  it('explicit --instance and exact --file targeting still reach a suspected zombie', () => {
+    const { reg, tick } = makeReg();
+    reg.register(sock(), { instanceId: 'h', fileName: 'Healthy' });
+    tick(5);
+    flapToZombie(reg, tick, 'z', 'Zombie');
+    expect(reg.selectTarget('z', { kind: 'instance' })?.instanceId).toBe('z');
+    expect(reg.selectTarget('Zombie', { exact: true })?.instanceId).toBe('z');
+  });
+
+  it('all live entries suspected → most-recent among them, no refusal', () => {
+    const { reg, tick } = makeReg();
+    flapToZombie(reg, tick, 'z1', 'Z1');
+    tick(2_000);
+    flapToZombie(reg, tick, 'z2', 'Z2');
+    expect(reg.selectTarget()?.instanceId).toBe('z2'); // more-recently-flapped zombie, not a null refusal
+  });
+
+  it('with no suspected zombies, selectTarget stays pure recency (unchanged behavior)', () => {
+    const { reg, tick } = makeReg();
+    reg.register(sock(), { instanceId: 'a', fileName: 'A' });
+    tick(5);
+    reg.register(sock(), { instanceId: 'b', fileName: 'B' });
+    expect(reg.selectTarget()?.instanceId).toBe('b');
+  });
+});
+
 describe('park → flush decision (what the daemon keys off)', () => {
   it('filter set + only a NON-matching file → no target (park); matching file appears → target (flush)', () => {
     const { reg, tick } = makeReg();


### PR DESCRIPTION
## The trap

`register()` bumps `lastActiveAt` on every (re-)HELLO, and `matching()`/`selectTarget()` sort live entries by `lastActiveAt` descending. A throttled-background plugin that flaps (reconnects every ~1-5 min with an unchanged scene) keeps re-stealing the freshest `lastActiveAt`, so a no-flag command could silently route to a frozen/backgrounded editor instead of the one the user is actually working in — even though the zombie-watchdog detector (`suspectedZombie`) already exists and correctly flags it.

## Fix

`matching()`'s unfiltered (no `--file`/no `--instance`) branch now deprioritizes any live entry where `suspectedZombie(entry, now)` is true: non-suspected entries sort ahead of suspected ones, recency-ordered within each group. When every live entry is suspected, the group collapses to one and the most-recent among them is returned — a fallback, never a refusal, since a suspected zombie is still a connected, usable plugin.

Explicit targeting is untouched: `--instance <id>` resolves via `getByInstanceId` (bypasses this sort entirely) and a filtered `matching()`/`selectTarget()` call (`--file <name>`, exact or substring) keeps pure recency, so it still reaches a suspected zombie by name on purpose.

## Test-first

Added to `tests/plugin-registry.test.ts`:
1. One healthy + one flapping-zombie entry (zombie made the *more*-recent via `lastActiveAt`) — a no-flag `selectTarget()` returns the healthy one. Verified this fails against the pre-fix code (returns the zombie by recency).
2. `--instance <zombie-id>` and exact `--file <zombie-name>` still resolve to the zombie.
3. All live entries suspected → returns the most-recent among them, not null.
4. No suspected zombies → identical to prior pure-recency behavior.

## Gate tails

- `npm run typecheck` — clean
- `npm run build` — clean
- `npm run lint:comments` — clean (0 new citations)
- `npx vitest run tests/plugin-registry.test.ts` — 48/48 passed