### PR TITLE
Surface awaitingReconnect visibility for plugins not yet reconnected after a broker restart

### DIFF
--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -88,5 +88,11 @@ export async function run(args: CommandArgs): Promise<unknown> {
   return {
     broker, plugins, activePlugin, plugin, protocolVersion: broker.protocolVersion,
     ...(wanted ? { pluginsAll: all } : {}),
+    // Broker-restart reconnect visibility — a HINT from last-known state, never a live
+    // plugin (it must never appear in `plugins`/`pluginsAll` above); present only when
+    // the broker actually has one to report, same mirror-only-when-non-empty contract
+    // as `senderMismatchCount`/`legacyMigrationDeferred` on `broker` above.
+    ...(Array.isArray(hello.awaitingReconnect) && hello.awaitingReconnect.length > 0
+      && { awaitingReconnect: hello.awaitingReconnect }),
   };
 }

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -25,6 +25,10 @@ import {
 } from './protocol-helpers.ts';
 import { PluginRegistry, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
+import {
+  clearReconnected, filterAwaitingReconnect, lastPluginsPathFor, readLastPlugins,
+  toAwaitingReconnectStatus, writeLastPluginsAtomic, type AwaitingReconnectEntry, type LastPluginRecord,
+} from './last-plugins-log.ts';
 import { pinDisconnected, resolveRouteFilter, type RouteFilter } from './route-filter.ts';
 import {
   appendChangeFrames, changeLogPathFor, migrateLegacyUnboundChanges, migrateStagedChanges,
@@ -97,6 +101,13 @@ const IMPLICIT_READ_ONLY = new Set(['STATUS', 'GET_SELECTION', 'EXPORT_PNG', 'SC
 const WATCHDOG_MARGIN_MS = 5_000;
 const WATCHDOG_TIMEOUT_MS = envMs('FIGMA_AGENT_WATCHDOG_MS', EXEC_JS_MAX_TIMEOUT_MS + WATCHDOG_MARGIN_MS);
 
+// Broker-restart reconnect visibility (last-plugins.json) — env-overridable via the
+// same envMs knob pattern as every other cadence constant above, so a test can shrink
+// all three windows to observe a real fire in bounded seconds rather than real minutes.
+const LAST_PLUGINS_DEBOUNCE_MS = envMs('FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS', 1_500);
+const AWAITING_RECONNECT_WINDOW_MS = envMs('FIGMA_AGENT_AWAITING_RECONNECT_WINDOW_MS', 10 * 60_000);
+const AWAITING_RECONNECT_EXPIRY_MS = envMs('FIGMA_AGENT_AWAITING_RECONNECT_EXPIRY_MS', 30 * 60_000);
+
 /** Optional routing pin: only route to a plugin whose fileName matches (case-
  *  insensitive substring). Read per-call so it reflects the broker's env. */
 function currentFilter(): string | null {
@@ -165,6 +176,12 @@ interface BrokerState {
   // frames forever — the park sweeper drops an entry whose last frame is older than one
   // sweep period, reusing the SAME interval rather than a new timer.
   pendingChunks: ChunkBuffers<WebSocket>;
+  // Broker-restart reconnect visibility — recently-seen-but-not-yet-reconnected plugins,
+  // seeded at startup from last-plugins.json, cleared per-entry on RE-HELLO (by
+  // instanceId or fileName), expired wholesale once this broker has been up
+  // AWAITING_RECONNECT_EXPIRY_MS. NEVER exposed in `plugins[]` — see last-plugins-log.ts's
+  // own Law 1 doc for why this stays a separate top-level `status` field.
+  awaitingReconnect: AwaitingReconnectEntry[];
 }
 
 function log(line: string): void {
@@ -446,11 +463,21 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     }
   }
 
+  // Broker-restart reconnect visibility — same dir as the advertisement file (broker-
+  // instance state, cwd-independent, never a project's `design/` dir). Seeded once, at
+  // startup, from whatever the PREVIOUS broker incarnation last persisted; a missing or
+  // corrupt file degrades to "nothing awaiting" (readLastPlugins's own contract).
+  const lastPluginsPath = lastPluginsPathFor(advertisePath);
+  const initialAwaitingReconnect = filterAwaitingReconnect(
+    readLastPlugins(lastPluginsPath), startedAt, AWAITING_RECONNECT_WINDOW_MS,
+  );
+
   const st: BrokerState = {
     registry: new PluginRegistry<WebSocket>(), cliClients: new Set(), pending: new Map(),
     dispatchedTo: new Map(), waiting: [], lastBusyAt: Date.now(),
     bindIndex, knownProjectDirs: new Set(usableDirs),
     jobs: new JobTable(), queues: new Map(), pendingChunks: new Map(),
+    awaitingReconnect: initialAwaitingReconnect,
   };
   // Sweep leftover `${advertisePath}.<pid>.tmp` files from a prior instance's hard
   // kill (SIGKILL between the temp write and the rename never runs its own cleanup)
@@ -494,6 +521,38 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const sendEvent = (ws: WebSocket, type: EventMsg['type'], data: Record<string, unknown>): void => {
     try { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type, data } satisfies EventMsg)); }
     catch { /* socket already gone */ }
+  };
+
+  // Broker-restart reconnect visibility — how many `writeLastPluginsAtomic` failures
+  // since this broker started, same "discarded thing gets a machine-readable counter"
+  // contract as errorLogAppendFailures/contentionLogAppendFailures above.
+  let lastPluginsAppendFailures = 0;
+  let lastPluginsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  /**
+   * Debounced write of the CURRENT live plugin set (register / disconnect / scene
+   * update all call this) — never on a shutdown hook, since the broker can be SIGKILL'd
+   * before any hook runs. Resetting the timer on every call (standard debounce) is what
+   * keeps the on-disk snapshot at most one `LAST_PLUGINS_DEBOUNCE_MS` window stale, per
+   * the spec's own flush requirement. Best-effort: a write failure is counted and
+   * logged, never a silent drop, and never disrupts the relay.
+   */
+  const schedulePluginSetPersist = (): void => {
+    if (lastPluginsDebounceTimer) clearTimeout(lastPluginsDebounceTimer);
+    lastPluginsDebounceTimer = setTimeout(() => {
+      lastPluginsDebounceTimer = null;
+      const records: LastPluginRecord[] = st.registry.liveEntries().map((e) => ({
+        instanceId: e.instanceId,
+        fileName: (e.scene.fileName as string | undefined) ?? null,
+        lastSeenAt: e.lastSeenAt,
+      }));
+      try {
+        writeLastPluginsAtomic(lastPluginsPath, records);
+      } catch (err) {
+        lastPluginsAppendFailures += 1;
+        log(`LAST_PLUGINS write failed (${lastPluginsAppendFailures} total): ${(err as Error).message}`);
+      }
+    }, LAST_PLUGINS_DEBOUNCE_MS);
   };
 
   // PEERS (panel IA v2): the target is RECENCY-based, so registration and disconnection
@@ -566,6 +625,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // ticks are reachable) must see `ownsAdvertisement === false` and skip re-writing
     // the file this call is about to deliberately remove.
     ownsAdvertisement = false;
+    // A clean exit does not flush a pending debounced persist — an abrupt SIGKILL never
+    // could either, and the whole design tolerates losing at most one debounce window
+    // (see schedulePluginSetPersist's own doc); this only stops the timer from keeping a
+    // test's `exit` stub (which throws rather than truly halting) reachable afterward.
+    if (lastPluginsDebounceTimer) { clearTimeout(lastPluginsDebounceTimer); lastPluginsDebounceTimer = null; }
     try {
       // Only remove the advertisement if it is still ours (a newer broker may own it).
       const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as BrokerAdvertisement;
@@ -1265,6 +1329,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // still-connected file must not be told the bridge is gone.
       if (remaining === 0) broadcastToClients(JSON.stringify({ type: 'PLUGIN_GONE', data: {} } satisfies EventMsg));
       broadcastPeers(); // a surviving panel's peer count/target may have just changed (no-op if none left)
+      schedulePluginSetPersist(); // broker-restart reconnect visibility — live set shrank
       return;
     }
     // A CLI client.
@@ -1361,6 +1426,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         // broker's own cwd default — there is nowhere else to read it from.
         const helloScene = st.registry.getByWs(ws)?.scene;
         const helloFileName = (helloScene?.fileName as string | undefined) ?? null;
+        // Broker-restart reconnect visibility — a RE-HELLO (by instanceId, or by
+        // fileName as the fallback key: a fresh iframe load mints a NEW instanceId
+        // across a restart) clears any held awaitingReconnect entry immediately; the
+        // live set changed either way, so the debounced snapshot is rescheduled too.
+        st.awaitingReconnect = clearReconnected(st.awaitingReconnect, instanceId, helloFileName);
+        schedulePluginSetPersist();
         const helloFileKey = (helloScene?.fileKey as string | null | undefined) ?? null;
         const helloBound = resolveProjectDir(fileIdentity(helloFileKey, helloFileName), st.bindIndex);
         sendEvent(ws, 'SYNC_CONFIG', { idleMs: helloBound ? readIdleMsFor(helloBound) : idleMs });
@@ -1380,6 +1451,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           broadcastToClients(text);
           broadcastPeers();
           promotePendingBind(ws); // registry-integrity phase 01 §2 — fill a pending fileKey on first sight
+          schedulePluginSetPersist(); // broker-restart reconnect visibility — scene changed
         }
       } else if (msg.type === 'DOC_CHANGE') {
         // Live-sync capture: append the plugin's coalesced batch to the change log.
@@ -1501,19 +1573,32 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     return { runningJob: running, queueDepth };
   };
 
-  const brokerHello = (): EventMsg => ({
-    type: 'BROKER_HELLO',
-    data: buildBrokerHelloData(
-      st.registry,
-      {
-        port, pid: process.pid, protocolV: PROTOCOL_VERSION, buildMtime: selfBuildMtime(),
-        uptimeMs: Date.now() - startedAt, senderMismatchCount, legacyMigrationDeferred,
+  const brokerHello = (): EventMsg => {
+    // Broker-restart reconnect visibility — present only once there's something to
+    // hold (same "byte-identical when the common case is empty" contract as
+    // senderMismatchCount/legacyMigrationDeferred just below); expires wholesale via
+    // `toAwaitingReconnectStatus` once this broker has been up AWAITING_RECONNECT_EXPIRY_MS,
+    // recomputed fresh on every call rather than mutating `st.awaitingReconnect` itself.
+    const awaitingReconnect = toAwaitingReconnectStatus(
+      st.awaitingReconnect, Date.now() - startedAt, AWAITING_RECONNECT_EXPIRY_MS,
+    );
+    return {
+      type: 'BROKER_HELLO',
+      data: {
+        ...buildBrokerHelloData(
+          st.registry,
+          {
+            port, pid: process.pid, protocolV: PROTOCOL_VERSION, buildMtime: selfBuildMtime(),
+            uptimeMs: Date.now() - startedAt, senderMismatchCount, legacyMigrationDeferred,
+          },
+          currentFilter(),
+          Date.now,
+          jobStatusFor,
+        ),
+        ...(awaitingReconnect.length > 0 && { awaitingReconnect }),
       },
-      currentFilter(),
-      Date.now,
-      jobStatusFor,
-    ),
-  });
+    };
+  };
 
   const onConnection = (ws: WebSocket, req: import('node:http').IncomingMessage): void => {
     const tracked = ws as TrackedWs;

--- a/cli/src/transport/last-plugins-log.ts
+++ b/cli/src/transport/last-plugins-log.ts
@@ -1,0 +1,137 @@
+// Broker-restart reconnect visibility (`last-plugins.json`) — fs layer for the broker.
+//
+// A freshly-spawned broker's registry starts EMPTY: a backgrounded editor (FigJam/Slides,
+// throttled by Figma so its reconnect loop stalls) that hasn't reconnected yet is
+// INVISIBLE after a restart — the owner's actual live symptom, the "focus-dance" of
+// clicking every window to revive it. This module persists the LIVE plugin set,
+// debounced, beside the broker's own advertisement file (broker-INSTANCE state, never a
+// project's `design/` dir — a project may not even be bound yet). On the next startup, a
+// recently-seen entry is held as `awaitingReconnect` until it re-HELLOs or ages out — a
+// HINT derived from last-known state, NEVER a claim of a live connection (see
+// `toAwaitingReconnectStatus`'s own doc). A JSON snapshot, not an append-only log (unlike
+// contention-log.ts/error-log.ts): only the LATEST live set matters here, never history —
+// same "near-copy, deliberately separate" contract as those two, not a shared util.
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+export const LAST_PLUGINS_FILENAME = 'last-plugins.json';
+
+/** One persisted plugin's last-known identity + liveness, as of the most recent
+ *  debounced write. Never anything beyond these three fields — not scene, not jobs
+ *  (spec non-goal: this is a reconnect hint, not a state mirror). */
+export interface LastPluginRecord {
+  instanceId: string;
+  fileName: string | null;
+  lastSeenAt: number;
+}
+
+/** The broker's own in-memory bookkeeping between startup and either a clear (RE-HELLO)
+ *  or a wholesale expiry — carries `instanceId` internally so `clearReconnected` can
+ *  match it, but `instanceId` never reaches `status` (see `AwaitingReconnectStatusEntry`). */
+export interface AwaitingReconnectEntry {
+  instanceId: string;
+  fileName: string | null;
+  lastSeenAt: number;
+}
+
+/** The `awaitingReconnect` shape surfaced on `status` — deliberately WITHOUT
+ *  `instanceId`: an agent/human reading `status` must never mistake this for an
+ *  addressable live target (`plugins[]` is the only truth for that). */
+export interface AwaitingReconnectStatusEntry {
+  fileName: string | null;
+  lastSeenBeforeShutdown: number;
+}
+
+/** `<dirname(advertisePath)>/last-plugins.json` — the SAME directory as the broker's own
+ *  advertisement file (cwd-independent, one per broker instance), never a project's
+ *  `design/` dir: this is broker-instance state, unrelated to any project binding and
+ *  readable before one exists. */
+export function lastPluginsPathFor(advertisePath: string): string {
+  return join(dirname(advertisePath), LAST_PLUGINS_FILENAME);
+}
+
+function isValidRecord(v: unknown): v is LastPluginRecord {
+  if (v === null || typeof v !== 'object') return false;
+  const r = v as Record<string, unknown>;
+  return typeof r.instanceId === 'string' &&
+    (r.fileName === null || typeof r.fileName === 'string') &&
+    typeof r.lastSeenAt === 'number' && Number.isFinite(r.lastSeenAt);
+}
+
+/** Reads the persisted plugin set. A missing or corrupt file reads as empty — no prior
+ *  broker ever persisted one (or left a torn write behind), never an error; degrades to
+ *  "nothing to hold as awaiting" rather than blocking startup (same contract as
+ *  contention-log.ts's `readContentionStore`). A parsed-but-malformed entry is dropped
+ *  individually, never one bad entry discarding the whole file. */
+export function readLastPlugins(path: string): LastPluginRecord[] {
+  if (!existsSync(path)) return [];
+  try {
+    const raw: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    return Array.isArray(raw) ? raw.filter(isValidRecord) : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Atomic write (mirrors broker-discovery.ts's `writeFileAtomic` for the advertisement
+ *  file — deliberately a separate copy, not a shared util, per this repo's own
+ *  "near-copy, kept separate" contract for these small fs helpers): full write to a
+ *  process-unique temp file, then `renameSync`. This file is read only ONCE, at broker
+ *  startup — before this same broker's own debounced writer has ever run — so there is
+ *  no self-race to guard against; the atomic rename instead protects the NEXT broker's
+ *  startup read from ever seeing a half-written blob left by a SIGKILL mid-write
+ *  (`readLastPlugins`'s try/catch would degrade that to empty regardless, but the atomic
+ *  rename avoids losing the previous good snapshot to the corruption in the first place). */
+export function writeLastPluginsAtomic(path: string, records: readonly LastPluginRecord[]): void {
+  mkdirSync(dirname(path), { recursive: true });
+  const tmpPath = `${path}.${process.pid}.tmp`;
+  writeFileSync(tmpPath, JSON.stringify(records));
+  try {
+    renameSync(tmpPath, path);
+  } catch (err) {
+    try { unlinkSync(tmpPath); } catch { /* best-effort cleanup — the rename error below still wins */ }
+    throw err;
+  }
+}
+
+/** Filter persisted records down to those "recently seen" as of `startedAt` (THIS
+ *  broker's own start time, injected — never `Date.now()` read here) — held as
+ *  `awaitingReconnect` until cleared by a RE-HELLO or expired wholesale. `thresholdMs` is
+ *  the spec's "< 10 min before this broker's start", passed in rather than hardcoded so a
+ *  test can shrink it without a second copy of the production value. */
+export function filterAwaitingReconnect(
+  records: readonly LastPluginRecord[], startedAt: number, thresholdMs: number,
+): AwaitingReconnectEntry[] {
+  return records
+    .filter((r) => startedAt - r.lastSeenAt < thresholdMs)
+    .map((r) => ({ instanceId: r.instanceId, fileName: r.fileName, lastSeenAt: r.lastSeenAt }));
+}
+
+/** Clear the entry for a RE-HELLO — matched by `instanceId` first (the stable key across
+ *  an ordinary same-session reconnect), falling back to `fileName` when no instanceId
+ *  matches: a fresh iframe load mints a NEW instanceId (plugin-registry.ts's `register`
+ *  contract), so the instanceId a broker restart persisted is never the one a
+ *  post-restart reconnect re-HELLOs with. Returns a NEW array (pure) — never mutates
+ *  `entries`, so the daemon's own closure state is always reassigned explicitly. */
+export function clearReconnected(
+  entries: readonly AwaitingReconnectEntry[], instanceId: string, fileName: string | null,
+): AwaitingReconnectEntry[] {
+  const byInstance = entries.filter((e) => e.instanceId !== instanceId);
+  if (byInstance.length !== entries.length) return byInstance; // matched by instanceId
+  if (fileName === null) return byInstance;
+  return byInstance.filter((e) => e.fileName !== fileName);
+}
+
+/** The `status`-surfaced shape: EMPTY once this broker has been up `expiryMs` or more (a
+ *  plugin that hasn't reconnected in that long is not "awaiting" — the user closed it or
+ *  moved on; never nag forever) — else the internal entries stripped of `instanceId`
+ *  (Law 1: `awaitingReconnect` must never read as addressable the way a live `plugins[]`
+ *  row does). `uptimeMs` is `now - startedAt`, computed by the caller (this module never
+ *  reads the clock itself, so both the threshold and the expiry stay deterministic for
+ *  tests). */
+export function toAwaitingReconnectStatus(
+  entries: readonly AwaitingReconnectEntry[], uptimeMs: number, expiryMs: number,
+): AwaitingReconnectStatusEntry[] {
+  if (uptimeMs >= expiryMs) return [];
+  return entries.map((e) => ({ fileName: e.fileName, lastSeenBeforeShutdown: e.lastSeenAt }));
+}

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -1207,3 +1207,72 @@ describe('daemon harness — target pin (#35 P2): SET_TARGET/CLEAR_TARGET, prece
     expect(clearedB.data).toMatchObject({ isActiveTarget: true, pinned: false });
   });
 });
+
+// Broker-restart reconnect visibility (last-plugins.json) — the owner's actual live
+// symptom: a fresh broker's registry starts EMPTY, so a backgrounded editor that hasn't
+// reconnected yet (Figma throttles it) is invisible after a restart. These tests exercise
+// the REAL `runBrokerDaemon` end to end across TWO daemon instances sharing the SAME
+// scratch advertisement path (the harness's own stand-in for "the same machine, a
+// restarted broker process") — never a live plugin session's real /tmp files.
+interface AwaitingReconnectHelloData {
+  plugins?: unknown[];
+  awaitingReconnect?: { fileName: string | null; lastSeenBeforeShutdown: number }[];
+}
+
+describe('daemon harness — broker-restart reconnect visibility (last-plugins.json)', () => {
+  it('a recently-seen plugin survives a broker restart as awaitingReconnect — never inside plugins[] — and clears the moment it re-HELLOs (by fileName, a fresh instanceId)', async () => {
+    const lastPluginsPath = join(scratchDir, 'last-plugins.json');
+
+    const port1 = await startTestBroker({ FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS: '30' });
+    const plugin1 = await connectSocket(port1);
+    await helloPlugin(plugin1, 'inst-restart-old', 'Restart File');
+    await waitFor(() => existsSync(lastPluginsPath) && readFileSync(lastPluginsPath, 'utf8').includes('inst-restart-old'));
+
+    // The old advertisement no longer describes a live broker (what a genuine process
+    // restart leaves behind) — the persisted last-plugins.json is untouched by this,
+    // exactly the point: it survives independently of the advertisement file's lifecycle.
+    rmSync(advertisePath, { force: true });
+
+    const port2 = await startTestBroker({ FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS: '30' });
+    const { hello: helloBeforeReconnect } = await connectAndAwaitBrokerHello(port2);
+    const dataBefore = helloBeforeReconnect.data as AwaitingReconnectHelloData;
+    expect(dataBefore.plugins).toEqual([]); // the fresh registry is genuinely empty
+    expect(dataBefore.awaitingReconnect).toEqual([
+      { fileName: 'Restart File', lastSeenBeforeShutdown: expect.any(Number) as number },
+    ]);
+
+    // Reconnect against the NEW broker — a fresh iframe load mints a NEW instanceId (the
+    // exact reason the clear falls back to fileName), same fileName as before the restart.
+    const plugin2 = await connectSocket(port2);
+    await helloPlugin(plugin2, 'inst-restart-new', 'Restart File');
+
+    const { hello: helloAfterReconnect } = await connectAndAwaitBrokerHello(port2);
+    const dataAfter = helloAfterReconnect.data as AwaitingReconnectHelloData;
+    expect(dataAfter.awaitingReconnect).toBeUndefined(); // cleared — present-only-when-non-empty
+    expect(dataAfter.plugins).toHaveLength(1);
+    expect((dataAfter.plugins![0] as { fileName?: string }).fileName).toBe('Restart File');
+  });
+
+  it('awaitingReconnect goes empty once this broker has been up past the expiry window, even though nothing ever reconnected', async () => {
+    const lastPluginsPath = join(scratchDir, 'last-plugins.json');
+
+    const port1 = await startTestBroker({ FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS: '30' });
+    const plugin1 = await connectSocket(port1);
+    await helloPlugin(plugin1, 'inst-expire-old', 'Expire File');
+    await waitFor(() => existsSync(lastPluginsPath) && readFileSync(lastPluginsPath, 'utf8').includes('inst-expire-old'));
+    rmSync(advertisePath, { force: true });
+
+    const port2 = await startTestBroker({
+      FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS: '30',
+      FIGMA_AGENT_AWAITING_RECONNECT_EXPIRY_MS: '150',
+    });
+    const { hello: helloEarly } = await connectAndAwaitBrokerHello(port2);
+    expect((helloEarly.data as AwaitingReconnectHelloData).awaitingReconnect).toEqual([
+      { fileName: 'Expire File', lastSeenBeforeShutdown: expect.any(Number) as number },
+    ]);
+
+    await new Promise((resolve) => setTimeout(resolve, 250)); // past the shrunk 150ms expiry window
+    const { hello: helloLate } = await connectAndAwaitBrokerHello(port2);
+    expect((helloLate.data as AwaitingReconnectHelloData).awaitingReconnect).toBeUndefined();
+  });
+});

--- a/tests/last-plugins-log.test.ts
+++ b/tests/last-plugins-log.test.ts
@@ -1,0 +1,178 @@
+// Broker-restart reconnect visibility (`last-plugins.json`) — the fs layer + pure
+// filtering functions, tested without a live broker (mkdtempSync scratch dirs only, per
+// this repo's own convention for fs-layer modules — see contention-log.ts's own tests).
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  clearReconnected, filterAwaitingReconnect, lastPluginsPathFor, readLastPlugins,
+  toAwaitingReconnectStatus, writeLastPluginsAtomic, type AwaitingReconnectEntry, type LastPluginRecord,
+} from '../cli/src/transport/last-plugins-log.ts';
+
+const TEN_MIN_MS = 10 * 60_000;
+const THIRTY_MIN_MS = 30 * 60_000;
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-last-plugins-'));
+});
+
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('lastPluginsPathFor', () => {
+  it('resolves beside the advertisement file, never a project dir', () => {
+    expect(lastPluginsPathFor('/tmp/figma-agent-broker.json')).toBe('/tmp/last-plugins.json');
+    expect(lastPluginsPathFor(join(scratchDir, 'broker.json'))).toBe(join(scratchDir, 'last-plugins.json'));
+  });
+});
+
+describe('readLastPlugins', () => {
+  it('a missing file reads as empty, not an error', () => {
+    expect(readLastPlugins(join(scratchDir, 'nope.json'))).toEqual([]);
+  });
+
+  it('a corrupt (unparsable) file reads as empty', () => {
+    const path = join(scratchDir, 'corrupt.json');
+    writeLastPluginsAtomic(path, []); // create it, then corrupt it
+    writeFileSync(path, '{ not json', 'utf8');
+    expect(readLastPlugins(path)).toEqual([]);
+  });
+
+  it('a malformed entry is dropped, valid entries survive', () => {
+    const path = join(scratchDir, 'mixed.json');
+    writeFileSync(
+      path,
+      JSON.stringify([
+        { instanceId: 'p1', fileName: 'F1', lastSeenAt: 1000 },
+        { instanceId: 'p2' }, // missing lastSeenAt — invalid
+        'garbage',
+        { instanceId: 'p3', fileName: null, lastSeenAt: 2000 },
+      ]),
+      'utf8',
+    );
+    expect(readLastPlugins(path)).toEqual([
+      { instanceId: 'p1', fileName: 'F1', lastSeenAt: 1000 },
+      { instanceId: 'p3', fileName: null, lastSeenAt: 2000 },
+    ]);
+  });
+});
+
+describe('writeLastPluginsAtomic + readLastPlugins — round trip', () => {
+  it('what is written is exactly what is read back', () => {
+    const path = join(scratchDir, 'last-plugins.json');
+    const records: LastPluginRecord[] = [
+      { instanceId: 'p1', fileName: 'FigJam A', lastSeenAt: 5000 },
+      { instanceId: 'p2', fileName: null, lastSeenAt: 6000 },
+    ];
+    writeLastPluginsAtomic(path, records);
+    expect(existsSync(path)).toBe(true);
+    expect(readLastPlugins(path)).toEqual(records);
+    // No leftover temp file after a successful rename.
+    expect(existsSync(`${path}.${process.pid}.tmp`)).toBe(false);
+  });
+
+  it('creates the parent directory if it does not exist yet', () => {
+    const path = join(scratchDir, 'nested', 'dir', 'last-plugins.json');
+    writeLastPluginsAtomic(path, [{ instanceId: 'p1', fileName: 'F', lastSeenAt: 1 }]);
+    expect(readFileSync(path, 'utf8')).toContain('p1');
+  });
+
+  it('a later write fully replaces the earlier snapshot (no accumulation)', () => {
+    const path = join(scratchDir, 'last-plugins.json');
+    writeLastPluginsAtomic(path, [{ instanceId: 'p1', fileName: 'F1', lastSeenAt: 1 }]);
+    writeLastPluginsAtomic(path, [{ instanceId: 'p2', fileName: 'F2', lastSeenAt: 2 }]);
+    expect(readLastPlugins(path)).toEqual([{ instanceId: 'p2', fileName: 'F2', lastSeenAt: 2 }]);
+  });
+});
+
+describe('filterAwaitingReconnect — test 1 (round-trip threshold)', () => {
+  it('a plugin last seen recently (< 10 min before start) is held; a stale one (>= 10 min) is not', () => {
+    const startedAt = 1_000_000;
+    const records: LastPluginRecord[] = [
+      { instanceId: 'recent', fileName: 'Recent File', lastSeenAt: startedAt - 60_000 }, // 1 min before
+      { instanceId: 'boundary', fileName: 'Boundary File', lastSeenAt: startedAt - (TEN_MIN_MS - 1) }, // just inside
+      { instanceId: 'stale', fileName: 'Stale File', lastSeenAt: startedAt - TEN_MIN_MS }, // exactly at threshold — excluded
+      { instanceId: 'very-stale', fileName: 'Very Stale File', lastSeenAt: startedAt - (TEN_MIN_MS + 60_000) },
+    ];
+    const held = filterAwaitingReconnect(records, startedAt, TEN_MIN_MS);
+    expect(held.map((e) => e.instanceId).sort()).toEqual(['boundary', 'recent']);
+  });
+
+  it('an empty persisted set holds nothing', () => {
+    expect(filterAwaitingReconnect([], 1_000_000, TEN_MIN_MS)).toEqual([]);
+  });
+});
+
+describe('clearReconnected — test 2 (clear-on-reconnect)', () => {
+  const entries: AwaitingReconnectEntry[] = [
+    { instanceId: 'old-inst-a', fileName: 'File A', lastSeenAt: 100 },
+    { instanceId: 'old-inst-b', fileName: 'File B', lastSeenAt: 200 },
+  ];
+
+  it('clears by instanceId when it matches directly', () => {
+    const result = clearReconnected(entries, 'old-inst-a', 'File A');
+    expect(result).toEqual([{ instanceId: 'old-inst-b', fileName: 'File B', lastSeenAt: 200 }]);
+  });
+
+  it('falls back to fileName when the instanceId is a FRESH one (iframe reload mints a new id)', () => {
+    const result = clearReconnected(entries, 'brand-new-instance-id', 'File A');
+    expect(result).toEqual([{ instanceId: 'old-inst-b', fileName: 'File B', lastSeenAt: 200 }]);
+  });
+
+  it('a fileName of null never matches by fallback (no accidental mass-clear of unnamed files)', () => {
+    const withUnnamed: AwaitingReconnectEntry[] = [
+      { instanceId: 'inst-unnamed', fileName: null, lastSeenAt: 100 },
+    ];
+    const result = clearReconnected(withUnnamed, 'brand-new-id', null);
+    expect(result).toEqual(withUnnamed); // untouched — null is never a fallback key
+  });
+
+  it('no match (different instanceId AND different fileName) leaves the list untouched', () => {
+    const result = clearReconnected(entries, 'unrelated-instance', 'Unrelated File');
+    expect(result).toEqual(entries);
+  });
+
+  it('is pure — never mutates the input array', () => {
+    const original = [...entries];
+    clearReconnected(entries, 'old-inst-a', 'File A');
+    expect(entries).toEqual(original);
+  });
+});
+
+describe('toAwaitingReconnectStatus — test 3 (expiry) + status shape', () => {
+  const entries: AwaitingReconnectEntry[] = [
+    { instanceId: 'p1', fileName: 'F1', lastSeenAt: 500 },
+    { instanceId: 'p2', fileName: null, lastSeenAt: 600 },
+  ];
+
+  it('strips instanceId, renames lastSeenAt → lastSeenBeforeShutdown, while under the expiry window', () => {
+    const status = toAwaitingReconnectStatus(entries, THIRTY_MIN_MS - 1, THIRTY_MIN_MS);
+    expect(status).toEqual([
+      { fileName: 'F1', lastSeenBeforeShutdown: 500 },
+      { fileName: null, lastSeenBeforeShutdown: 600 },
+    ]);
+  });
+
+  it('goes empty once uptime reaches the expiry window, even with unreconnected entries still held', () => {
+    expect(toAwaitingReconnectStatus(entries, THIRTY_MIN_MS, THIRTY_MIN_MS)).toEqual([]);
+    expect(toAwaitingReconnectStatus(entries, THIRTY_MIN_MS + 1, THIRTY_MIN_MS)).toEqual([]);
+  });
+
+  it('an empty entries list stays empty regardless of uptime', () => {
+    expect(toAwaitingReconnectStatus([], 0, THIRTY_MIN_MS)).toEqual([]);
+  });
+});
+
+describe('test 4 — awaitingReconnect is structurally distinct from a live plugins[] row', () => {
+  it('the status entry shape carries no instanceId/ws-identifying field at all', () => {
+    const status = toAwaitingReconnectStatus(
+      [{ instanceId: 'p1', fileName: 'F1', lastSeenAt: 1 }], 0, THIRTY_MIN_MS,
+    );
+    expect(Object.keys(status[0]!).sort()).toEqual(['fileName', 'lastSeenBeforeShutdown']);
+    expect('instanceId' in status[0]!).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- A freshly-spawned broker's registry starts empty, so a backgrounded editor (FigJam/Slides, throttled by Figma so its reconnect loop stalls) is invisible after a broker restart until it happens to reconnect — the focus-dance of clicking every window to revive it.
- The broker now persists the live plugin set (`{instanceId, fileName, lastSeenAt}` only), debounced (~1-2s, flushed on every change so the on-disk snapshot is at most one window stale), to `last-plugins.json` beside its own advertisement file — never relying on a shutdown hook, since the broker can be SIGKILL'd.
- On startup, entries last seen within 10 minutes of this broker's start are held as a top-level `status.awaitingReconnect: [{ fileName, lastSeenBeforeShutdown }]` hint. An entry clears the moment that instanceId — or fileName as a fallback, since a fresh iframe load mints a new instanceId — re-HELLOs. The whole list expires once this broker has been up 30 minutes, even if nothing reconnected.
- `awaitingReconnect` is a hint from last-known state, never a claim of a live connection: it is never mixed into the live `plugins[]` array, and its own shape carries no `instanceId` so it can't be mistaken for an addressable target.

Non-goals: no auto-reconnect (that needs the owner's manual GUI click), no change to the existing zombie-watchdog detection or the live `plugins[]` truth.

## Test plan

- [x] `npm run typecheck` — pass
- [x] `npm run build` — pass
- [x] `npm run lint:comments` — clean
- [x] `npx vitest run tests/last-plugins-log.test.ts` — 18/18 pass (pure fs-layer + filtering functions: round-trip persistence, threshold filtering, clear-on-reconnect by instanceId/fileName-fallback, 30-minute expiry, status shape never carries instanceId)
- [x] `npx vitest run tests/broker-daemon-harness.test.ts` — 30/30 pass, including two new end-to-end scenarios across two real in-process broker instances sharing a scratch advertisement path: a restart surfaces `awaitingReconnect` while `plugins[]` stays genuinely empty, then a fileName-matched re-HELLO clears it; and the list expires after a shrunk uptime window even with nothing reconnected
- [ ] **Owner-manual, not claimed here**: restart the real broker with a backgrounded FigJam window connected — confirm `figma-agent status` reports it under `awaitingReconnect` until the window is focused and reconnects

## Notes

- Only ran the specific test files above per the task's constraint — never the full `npm test` / a live broker — and everything uses scratch advertisement dirs/log files, never the real `/tmp/figma-agent-broker.json`.