### PR TITLE
feat(cli): status --peek, an emitted skill, and skill/hook installers

### DIFF
--- a/cli/src/command-catalog.ts
+++ b/cli/src/command-catalog.ts
@@ -1,0 +1,201 @@
+// The ONE structured source of every command's name/usage/description and every
+// global flag. `help-text.ts` renders `--help` from this; `skill-emitter.ts`
+// renders the skill's "Command reference" section from the SAME array — a
+// command can never be documented in one place and not the other (drift test:
+// tests/skill-emitter-drift.test.ts). Data only, no rendering, no fs.
+//
+// Content is a verbatim transcription of the former inline `HELP` template
+// literal (figma-agent.ts) — wording unchanged, only line-wrapping collapsed
+// into single `description` strings per entry.
+
+export interface CommandCatalogEntry {
+  /** The key COMMAND_MODULES (figma-agent.ts) dispatches on. */
+  name: string;
+  /** Usage + prose, exactly as it read in the old --help block (line-wraps collapsed). */
+  description: string;
+}
+
+export interface GlobalFlagEntry {
+  flag: string;
+  description: string;
+}
+
+export const HEADER_LINE = 'figma-agent — CLI bridge to the Figma plugin (via a local WS broker)';
+export const USAGE_LINE = 'Usage: figma-agent <command> [options]';
+export const FOOTER_LINE =
+  'All commands print one JSON object to stdout and exit 0, or {error:{code,message}} and exit 1.';
+
+export const COMMANDS: CommandCatalogEntry[] = [
+  {
+    name: 'status',
+    description:
+      'Broker + plugin connection info [--peek [--json]] — --peek reads only the /tmp broker '
+      + 'advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted '
+      + 'for compatibility but is a no-op: output is always the same single JSON object.',
+  },
+  { name: 'seat', description: 'Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]' },
+  {
+    name: 'bind',
+    description:
+      '--file "<name>" --dir <projectDir>   bind a file to a project for panel/idle sync '
+      + '(refuses to guess otherwise) [--list] [--unbind]',
+  },
+  { name: 'get-selection', description: 'Serialize the current selection [--depth 1]' },
+  { name: 'inspect', description: '[nodeId|--node id] [--out file.png --scale 1 --timeout ms]' },
+  {
+    name: 'job',
+    description:
+      '<jobId> [--wait] [--wait-timeout 60000] | --list [--file name] | <jobId> --cancel (queued only) | '
+      + '<jobId> --force-release [--force]   poll/wait/cancel/list a job the CLI stopped waiting for '
+      + '(backlog 1.1+2.6+4.3) — --force-release refuses a HEALTHY still-running job unless --force is '
+      + 'also passed — --force overrides the guard and discards its result, unverified; a '
+      + 'watchdog-wedged job still unwedges without --force',
+  },
+  {
+    name: 'scan-design-system',
+    description: 'Components/variables/styles registry [--out file.json --timeout ms]',
+  },
+  {
+    name: 'scan-node',
+    description: '[SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]',
+  },
+  {
+    name: 'mirror-verify',
+    description: 'Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]',
+  },
+  {
+    name: 'scan-conventions',
+    description:
+      'Convention-DNA walk over sections → usage-dna.json '
+      + '[<sectionId...> --out file.json --budget 14000 --timeout ms]',
+  },
+  {
+    name: 'audit-ds',
+    description:
+      "DS-hygiene audit of the open file's component library "
+      + '[--out file.json --sections "01 A,02 B" --facts raw.json --from-facts raw.json --timeout ms]',
+  },
+  { name: 'create-frame', description: '--name n --w 400 --h 300 [--parent id --x 0 --y 0]' },
+  {
+    name: 'connect',
+    description: '--from id --to id [--label t --intent flow|annotation --flow n --transition id]',
+  },
+  { name: 'disconnect', description: '--id conn-id | --from id --to id' },
+  { name: 'list-connections', description: '' },
+  { name: 'reroute', description: '[--id conn-id | --flow name]' },
+  { name: 'draw-flow', description: '--flow path/to/flow.json [--page name]' },
+  { name: 'verify-connections', description: '[--flow path/to/flow.json]' },
+  { name: 'create-instance', description: '--component <key|id> [--parent id]' },
+  { name: 'set-variant', description: '--node id --props k=v,k2=v2' },
+  {
+    name: 'create-variable',
+    description: '--collection c --name n --type COLOR|FLOAT|STRING|BOOLEAN --value v [--mode m]',
+  },
+  {
+    name: 'bind-variable',
+    description: "--node id --field fills|cornerRadius|... --variable <id|name>",
+  },
+  {
+    name: 'set-autolayout',
+    description:
+      '--node id --mode H|V|GRID|NONE [--gap n --pad t,r,b,l --align-primary --align-counter --wrap '
+      + '--sizing-h --sizing-v --rows n --cols n --col-sizes ...]',
+  },
+  {
+    name: 'set-constraints',
+    description: '--node id --h MIN|MAX|CENTER|STRETCH|SCALE --v MIN|MAX|CENTER|STRETCH|SCALE',
+  },
+  { name: 'set-text', description: '--node id --chars "..." [--font f --size n --weight n]' },
+  {
+    name: 'clone-traits',
+    description: '--source id --target id --traits layout,fills-variables,typography,spacing,text',
+  },
+  { name: 'sync-corrections', description: '[--dir project] sync Figma edge memory with design/memory' },
+  { name: 'export-png', description: '--node <id|selection> --out file.png [--scale 2]' },
+  {
+    name: 'html-to-figma',
+    description: '--html <file|-> [--width 1280 --x --y --parent id --replace id]',
+  },
+  {
+    name: 'exec-js',
+    description:
+      '<file|-> [--timeout ms (cap 120000)] [--undo-group] — --undo-group brackets the script in ONE '
+      + 'undo step and reverts it on error; the script must not call figma.commitUndo/triggerUndo itself, '
+      + 'and a timeout cannot stop a running script (the plugin has no cancellation). While it runs, '
+      + 'figma.currentPage carries one extra invisible child (the undo sentinel) — a script that '
+      + "enumerates or counts the page's children will see it. `console` and `ui` are injected — a "
+      + 'script cannot declare its own.',
+  },
+  {
+    name: 'capture',
+    description:
+      '<url> [--out dir --headless --channel chrome --width 1440 --timeout ms --carousel-window ms]',
+  },
+  { name: 'batch', description: '<file.json> [--stop-on-error]' },
+  {
+    name: 'changes',
+    description:
+      '[--since ts|iso --owner-only --actor owner|agent|ambiguous --file name|slug --limit 50 --page name]  '
+      + 'read the owner-edit feed (wave 4.4) — pure fs, works even with the plugin closed; --owner-only '
+      + 'is sugar for --actor owner',
+  },
+  {
+    name: 'errors',
+    description:
+      "[--since ts|iso --file name --limit 50]  read the broker's error log (backlog 4.6) — full "
+      + 'untruncated message + cmd/activity/code/fileName, for an agent to read-and-fix; --file filters '
+      + "by the entry's own fileName",
+  },
+  {
+    name: 'contention',
+    description:
+      '[--file name --since days]  read the durable per-file/per-day queued-time counter — total ms a '
+      + 'mutation waited in the FIFO before dispatch, plus jobCount, per UTC day; --file filters by '
+      + 'fileSlug, --since limits to the last N days; pure fs, works with the plugin closed',
+  },
+  {
+    name: 'install-skill',
+    description:
+      '[--folder ~/.claude/skills] [--with-craft|--no-craft] [--yes]   write this emitted SKILL.md to a '
+      + 'folder Claude Code reads skills from; prompts before overwriting an older installed version and '
+      + 'before bundling skills/es-figma-craft — a non-interactive run needs --with-craft/--no-craft '
+      + 'or it skips craft and says so',
+  },
+  {
+    name: 'install-hook',
+    description:
+      '[--dry-run] [--yes] [--settings <path>]   add a SessionStart hook to Claude Code settings that '
+      + 'runs "figma-agent status --peek" at the start of every session; confirms before writing, backs '
+      + "up the file first, and aborts untouched if it can't parse the file as JSON",
+  },
+];
+
+export const GLOBAL_FLAGS: GlobalFlagEntry[] = [
+  {
+    flag: '--file "<exact file name>"',
+    description:
+      "route to that file's plugin AND refuse to run anywhere else (exact, case-insensitive; beats "
+      + 'FIGMA_AGENT_FILE; payloads >512KB route by the env pin but are still guarded)',
+  },
+  {
+    flag: '--instance <instanceId>',
+    description:
+      "route to that EXACT plugin instance (from `status`'s instanceId column) — beats --file and "
+      + "FIGMA_AGENT_FILE; the one way to target a specific instance when --file's name is ambiguous "
+      + '(e.g. two unsaved files both named "Untitled"). Mutually exclusive with --file: passing both '
+      + 'refuses with E_INVALID_ARGS naming both, it never silently picks one.',
+  },
+  {
+    flag: '--dir <projectDir>',
+    description:
+      "this invocation's project root (default: cwd); stamped on every request so panel/idle sync can "
+      + 'apply into the right project once bound (`figma-agent bind`) — never a guess',
+  },
+  {
+    flag: '--read-only',
+    description:
+      'declare that this command only READS. Skips the per-file mutation queue (backlog 1.1+2.6+4.3). '
+      + 'TRUSTED, NOT ENFORCED — the plugin sandbox cannot verify it, so a mis-declared mutation can '
+      + "interleave with another agent's work.",
+  },
+];

--- a/cli/src/commands/install-hook.ts
+++ b/cli/src/commands/install-hook.ts
@@ -1,0 +1,119 @@
+// `figma-agent install-hook` — adds a Claude Code SessionStart hook that runs
+// `status --peek` at the start of every session. Order of operations is
+// non-negotiable: read → parse (abort untouched on invalid JSON, no backup) →
+// idempotency check → --dry-run preview → consent (refuse on non-TTY without
+// --yes) → backup → write. See plans/260812-2130-auto-connect/phase-01-*.md §1d.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+import type { CommandArgs } from '../figma-agent.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+
+// Absence of the CLI must fail silent and never block a session — `command -v`
+// guards that; `|| true` guards the exit code the hook runner sees either way.
+const HOOK_COMMAND = 'command -v figma-agent >/dev/null 2>&1 && figma-agent status --peek --json || true';
+
+interface HookEntry {
+  type: 'command';
+  command: string;
+}
+interface HookGroup {
+  hooks: HookEntry[];
+}
+interface InstallHookResult {
+  settingsPath: string;
+  backupPath: string | null;
+  hook: HookEntry;
+  status: 'installed' | 'unchanged' | 'dry-run';
+  preview?: string;
+}
+
+function hasHook(settings: Record<string, unknown>): boolean {
+  const hooksObj = settings.hooks;
+  if (!hooksObj || typeof hooksObj !== 'object') return false;
+  const sessionStart = (hooksObj as Record<string, unknown>).SessionStart;
+  if (!Array.isArray(sessionStart)) return false;
+  return sessionStart.some(
+    (group: unknown) =>
+      group !== null && typeof group === 'object' && Array.isArray((group as HookGroup).hooks)
+      && (group as HookGroup).hooks.some((h) => h?.command === HOOK_COMMAND),
+  );
+}
+
+function addHook(settings: Record<string, unknown>): Record<string, unknown> {
+  const hooksObj = settings.hooks && typeof settings.hooks === 'object' ? { ...(settings.hooks as Record<string, unknown>) } : {};
+  const sessionStart = Array.isArray(hooksObj.SessionStart) ? [...(hooksObj.SessionStart as HookGroup[])] : [];
+  sessionStart.push({ hooks: [{ type: 'command', command: HOOK_COMMAND }] });
+  return { ...settings, hooks: { ...hooksObj, SessionStart: sessionStart } };
+}
+
+/** Best-effort match of the existing file's own indentation — a fresh file gets 2. */
+function detectIndent(raw: string | null): number {
+  const match = raw?.match(/\n( +)"/);
+  return match ? match[1].length : 2;
+}
+
+async function confirm(question: string): Promise<boolean> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${question} [Y/n] `)).trim().toLowerCase();
+    return answer === '' || answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+export async function run(args: CommandArgs): Promise<InstallHookResult> {
+  const settingsPath = args.str('settings') ?? join(homedir(), '.claude', 'settings.json');
+  const dryRun = args.bool('dry-run');
+  const yes = args.bool('yes');
+  const hookEntry: HookEntry = { type: 'command', command: HOOK_COMMAND };
+
+  const existed = existsSync(settingsPath);
+  const raw = existed ? readFileSync(settingsPath, 'utf8') : null;
+  let settings: Record<string, unknown>;
+  if (raw === null) {
+    settings = {};
+  } else {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      throw new CliError('E_INVALID_ARGS', `${settingsPath} is not valid JSON — refusing to touch it (no backup, no write)`);
+    }
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      throw new CliError('E_INVALID_ARGS', `${settingsPath}'s root is not a JSON object — refusing to touch it`);
+    }
+    settings = parsed as Record<string, unknown>;
+  }
+
+  if (hasHook(settings)) {
+    return { settingsPath, backupPath: null, hook: hookEntry, status: 'unchanged' };
+  }
+
+  const updated = addHook(settings);
+  const serialized = `${JSON.stringify(updated, null, detectIndent(raw))}\n`;
+
+  if (dryRun) {
+    return { settingsPath, backupPath: null, hook: hookEntry, status: 'dry-run', preview: serialized };
+  }
+
+  if (!yes) {
+    if (!process.stdin.isTTY) {
+      throw new CliError('E_INVALID_ARGS', `${settingsPath} is yours — re-run with --yes or --dry-run`);
+    }
+    const ok = await confirm(`add a SessionStart hook to ${settingsPath}?`);
+    if (!ok) throw new CliError('E_INVALID_ARGS', 'declined — settings.json left untouched');
+  }
+
+  let backupPath: string | null = null;
+  if (existed) {
+    backupPath = `${settingsPath}.bak-${Date.now()}`;
+    writeFileSync(backupPath, raw as string);
+  }
+  mkdirSync(dirname(settingsPath), { recursive: true });
+  writeFileSync(settingsPath, serialized);
+
+  return { settingsPath, backupPath, hook: hookEntry, status: 'installed' };
+}

--- a/cli/src/commands/install-hook.ts
+++ b/cli/src/commands/install-hook.ts
@@ -2,7 +2,8 @@
 // `status --peek` at the start of every session. Order of operations is
 // non-negotiable: read → parse (abort untouched on invalid JSON, no backup) →
 // idempotency check → --dry-run preview → consent (refuse on non-TTY without
-// --yes) → backup → write. See plans/260812-2130-auto-connect/phase-01-*.md §1d.
+// --yes) → backup → write. This is a user's own config file: every step exists
+// to make the write safe to reverse and impossible to trigger by accident.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
 import { dirname, join } from 'node:path';
@@ -48,9 +49,13 @@ function addHook(settings: Record<string, unknown>): Record<string, unknown> {
   return { ...settings, hooks: { ...hooksObj, SessionStart: sessionStart } };
 }
 
-/** Best-effort match of the existing file's own indentation — a fresh file gets 2. */
-function detectIndent(raw: string | null): number {
-  const match = raw?.match(/\n( +)"/);
+/** Best-effort match of the existing file's own indentation (tabs or spaces) — a
+ *  fresh file gets 2 spaces. Feeds JSON.stringify's own indent param directly:
+ *  a number for N spaces, or the literal tab character for a tab-indented file. */
+function detectIndent(raw: string | null): string | number {
+  if (raw === null) return 2;
+  if (/\n\t/.test(raw)) return '\t';
+  const match = raw.match(/\n( +)"/);
   return match ? match[1].length : 2;
 }
 
@@ -64,53 +69,78 @@ async function confirm(question: string): Promise<boolean> {
   }
 }
 
+interface ReadSettings {
+  existed: boolean;
+  raw: string | null;
+  settings: Record<string, unknown>;
+}
+
+/** Read + parse + validate settingsPath. Shared by the pre-prompt read and the
+ *  post-prompt re-read so both apply the identical invalid-JSON/non-object rules. */
+function readSettings(settingsPath: string): ReadSettings {
+  const existed = existsSync(settingsPath);
+  const raw = existed ? readFileSync(settingsPath, 'utf8') : null;
+  if (raw === null) return { existed, raw, settings: {} };
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CliError('E_INVALID_ARGS', `${settingsPath} is not valid JSON — refusing to touch it (no backup, no write)`);
+  }
+  if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new CliError('E_INVALID_ARGS', `${settingsPath}'s root is not a JSON object — refusing to touch it`);
+  }
+  return { existed, raw, settings: parsed as Record<string, unknown> };
+}
+
 export async function run(args: CommandArgs): Promise<InstallHookResult> {
   const settingsPath = args.str('settings') ?? join(homedir(), '.claude', 'settings.json');
   const dryRun = args.bool('dry-run');
   const yes = args.bool('yes');
   const hookEntry: HookEntry = { type: 'command', command: HOOK_COMMAND };
 
-  const existed = existsSync(settingsPath);
-  const raw = existed ? readFileSync(settingsPath, 'utf8') : null;
-  let settings: Record<string, unknown>;
-  if (raw === null) {
-    settings = {};
-  } else {
-    let parsed: unknown;
-    try {
-      parsed = JSON.parse(raw);
-    } catch {
-      throw new CliError('E_INVALID_ARGS', `${settingsPath} is not valid JSON — refusing to touch it (no backup, no write)`);
-    }
-    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
-      throw new CliError('E_INVALID_ARGS', `${settingsPath}'s root is not a JSON object — refusing to touch it`);
-    }
-    settings = parsed as Record<string, unknown>;
-  }
-
-  if (hasHook(settings)) {
+  const initial = readSettings(settingsPath);
+  if (hasHook(initial.settings)) {
     return { settingsPath, backupPath: null, hook: hookEntry, status: 'unchanged' };
   }
 
-  const updated = addHook(settings);
-  const serialized = `${JSON.stringify(updated, null, detectIndent(raw))}\n`;
-
   if (dryRun) {
-    return { settingsPath, backupPath: null, hook: hookEntry, status: 'dry-run', preview: serialized };
+    const preview = `${JSON.stringify(addHook(initial.settings), null, detectIndent(initial.raw))}\n`;
+    return { settingsPath, backupPath: null, hook: hookEntry, status: 'dry-run', preview };
   }
 
   if (!yes) {
     if (!process.stdin.isTTY) {
       throw new CliError('E_INVALID_ARGS', `${settingsPath} is yours — re-run with --yes or --dry-run`);
     }
+    // This prompt can sit for minutes waiting on the user — everything computed
+    // from `initial` above is now potentially stale, so it must never reach the
+    // write below. Re-read happens after this returns, not before.
     const ok = await confirm(`add a SessionStart hook to ${settingsPath}?`);
     if (!ok) throw new CliError('E_INVALID_ARGS', 'declined — settings.json left untouched');
   }
 
+  // Re-read right before writing — a concurrent writer's edits made during the
+  // confirm wait above must never be silently discarded by a write computed
+  // from the stale pre-prompt content. Byte-for-byte compare (not a semantic
+  // diff): any change at all means the write below would be answering a
+  // question the user didn't actually ask.
+  const fresh = readSettings(settingsPath);
+  if (fresh.raw !== initial.raw) {
+    throw new CliError(
+      'E_INVALID_ARGS',
+      `${settingsPath} changed on disk while waiting for confirmation — re-run install-hook to pick up the new content`,
+    );
+  }
+
+  const serialized = `${JSON.stringify(addHook(fresh.settings), null, detectIndent(fresh.raw))}\n`;
+
   let backupPath: string | null = null;
-  if (existed) {
+  if (fresh.existed) {
+    // Backs up exactly what is about to be overwritten (`fresh.raw`, not the
+    // earlier `initial.raw`) — the one job a backup has.
     backupPath = `${settingsPath}.bak-${Date.now()}`;
-    writeFileSync(backupPath, raw as string);
+    writeFileSync(backupPath, fresh.raw as string);
   }
   mkdirSync(dirname(settingsPath), { recursive: true });
   writeFileSync(settingsPath, serialized);

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -5,7 +5,7 @@
 // binary that installed it.
 import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { createInterface } from 'node:readline/promises';
-import { dirname, join, resolve } from 'node:path';
+import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import type { CommandArgs } from '../figma-agent.ts';
@@ -43,9 +43,55 @@ async function confirm(question: string): Promise<boolean> {
   }
 }
 
-/** This bundled CLI's own repo root — es-figma-craft ships alongside cli/dist/. */
+/**
+ * This install's own repo root — es-figma-craft ships alongside it, wherever
+ * "it" is. Counting a fixed number of `..` from `import.meta.url` is wrong on
+ * one of the two shapes this module ever runs as: three levels up is correct
+ * from source (`cli/src/commands/install-skill.ts`) but one level too many from
+ * the bundled entrypoint (`cli/dist/figma-agent.js`), landing ABOVE the repo.
+ * `package.json` is the one anchor present at the root in both shapes (source
+ * checkout and built/installed package alike) — walk up until it's found,
+ * instead of hardcoding how deep this file sits.
+ */
 function repoRoot(): string {
-  return resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+  let dir = dirname(fileURLToPath(import.meta.url));
+  for (let i = 0; i < 8; i++) {
+    if (existsSync(join(dir, 'package.json'))) return dir;
+    const parent = dirname(dir);
+    if (parent === dir) break; // reached the filesystem root without finding one
+    dir = parent;
+  }
+  // A plain Error, not CliError — printErrorJson maps any non-CliError to E_INTERNAL,
+  // and this really is an internal-consistency failure (a broken install), not a
+  // caller mistake with a code an agent should branch on.
+  throw new Error(`could not locate this install's own package.json while walking up from ${import.meta.url}`);
+}
+
+/**
+ * Copy `craftSrc` (skills/es-figma-craft) into `craftDest`, with the same
+ * never-overwrite-silently protection `run()` gives SKILL.md — an entire
+ * bundled skill folder has no single version field to compare, so this
+ * compares its anchor file's (SKILL.md) content instead: identical → no-op,
+ * different → confirm (or `--yes`) before clobbering a user's local edits.
+ */
+async function installCraftFolder(
+  craftSrc: string,
+  craftDest: string,
+  yes: boolean,
+): Promise<{ installed: boolean; reason: string }> {
+  if (existsSync(craftDest)) {
+    const srcSkill = join(craftSrc, 'SKILL.md');
+    const destSkill = join(craftDest, 'SKILL.md');
+    const identical = existsSync(destSkill) && existsSync(srcSkill)
+      && readFileSync(srcSkill, 'utf8') === readFileSync(destSkill, 'utf8');
+    if (identical) return { installed: false, reason: 'unchanged (already installed)' };
+    if (!yes) {
+      const ok = await confirm(`overwrite the existing ${CRAFT_SKILL_DIR} folder at ${craftDest}?`);
+      if (!ok) return { installed: false, reason: 'declined overwrite of existing install' };
+    }
+  }
+  cpSync(craftSrc, craftDest, { recursive: true });
+  return { installed: true, reason: '' };
 }
 
 export async function run(args: CommandArgs): Promise<InstallSkillResult> {
@@ -96,12 +142,19 @@ export async function run(args: CommandArgs): Promise<InstallSkillResult> {
 
   if (bundleCraft) {
     const craftSrc = join(repoRoot(), 'skills', CRAFT_SKILL_DIR);
-    if (existsSync(craftSrc)) {
-      cpSync(craftSrc, craftDest, { recursive: true });
-      installed.push(craftDest);
-    } else {
-      skipped.push({ path: craftDest, reason: `source skill not found at ${craftSrc} — this install may not bundle it` });
+    if (!existsSync(craftSrc)) {
+      // The caller explicitly asked for this (a flag, or a "yes" to the prompt) —
+      // an unsatisfiable explicit request must not report success. A non-zero exit
+      // is the one signal a script driving this CLI can't miss; the `skipped: []`
+      // paths above stay soft because there the caller never asked in the first place.
+      throw new CliError(
+        'E_INVALID_ARGS',
+        `--with-craft was requested but its source skill was not found at ${craftSrc} — this install does not bundle it`,
+      );
     }
+    const craftResult = await installCraftFolder(craftSrc, craftDest, yes);
+    if (craftResult.installed) installed.push(craftDest);
+    else skipped.push({ path: craftDest, reason: craftResult.reason });
   } else {
     skipped.push({ path: craftDest, reason: skipReason });
   }

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -1,0 +1,110 @@
+// `figma-agent install-skill` — writes THIS CLI's own emitted SKILL.md into a
+// Claude Code skills folder. Never copies the committed skills/figma-agent/SKILL.md
+// (that risks shipping a stale artifact) — always renders fresh from the SAME
+// emitter `npm run emit:skill` uses, so the installed copy always matches the
+// binary that installed it.
+import { cpSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { createInterface } from 'node:readline/promises';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { homedir } from 'node:os';
+import type { CommandArgs } from '../figma-agent.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+import { renderSkill } from '../skill-emitter.ts';
+import { CLI_VERSION } from '../version.ts';
+
+const CRAFT_SKILL_DIR = 'es-figma-craft';
+
+interface InstallSkillResult {
+  folder: string;
+  installed: string[];
+  skipped: { path: string; reason: string }[];
+  version: string;
+  verify: string;
+}
+
+/** Match only the FIRST `version:` line inside the leading `---` frontmatter block —
+ *  a stray `version:` mentioned later in the skill's prose must never be read as it. */
+function frontmatterVersion(content: string): string | null {
+  const fm = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!fm) return null;
+  const line = fm[1].split('\n').find((l) => l.startsWith('version:'));
+  return line ? line.slice('version:'.length).trim() : null;
+}
+
+async function confirm(question: string): Promise<boolean> {
+  if (!process.stdin.isTTY) return false; // a non-interactive default must never mean "yes"
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  try {
+    const answer = (await rl.question(`${question} [Y/n] `)).trim().toLowerCase();
+    return answer === '' || answer === 'y' || answer === 'yes';
+  } finally {
+    rl.close();
+  }
+}
+
+/** This bundled CLI's own repo root — es-figma-craft ships alongside cli/dist/. */
+function repoRoot(): string {
+  return resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+}
+
+export async function run(args: CommandArgs): Promise<InstallSkillResult> {
+  if (args.bool('with-craft') && args.bool('no-craft')) {
+    throw new CliError('E_INVALID_ARGS', '--with-craft and --no-craft are mutually exclusive');
+  }
+  const folder = args.str('folder') ?? join(homedir(), '.claude', 'skills');
+  const yes = args.bool('yes');
+  const installed: string[] = [];
+  const skipped: { path: string; reason: string }[] = [];
+
+  const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+  let writeSkill = true;
+  if (existsSync(skillPath)) {
+    const existingVersion = frontmatterVersion(readFileSync(skillPath, 'utf8'));
+    if (existingVersion === CLI_VERSION) {
+      writeSkill = false;
+      skipped.push({ path: skillPath, reason: `unchanged (already v${CLI_VERSION})` });
+    } else if (!yes) {
+      const label = existingVersion ?? 'unknown';
+      const ok = await confirm(`overwrite v${label} with v${CLI_VERSION}?`);
+      writeSkill = ok;
+      if (!ok) skipped.push({ path: skillPath, reason: `declined overwrite of v${label}` });
+    }
+  }
+  if (writeSkill) {
+    mkdirSync(join(folder, 'figma-agent'), { recursive: true });
+    writeFileSync(skillPath, renderSkill());
+    installed.push(skillPath);
+  }
+
+  // es-figma-craft bundling — a non-interactive run needs an explicit decision;
+  // silently defaulting a non-TTY run to "yes" would install an unrequested skill.
+  const withCraft = args.bool('with-craft');
+  const noCraft = args.bool('no-craft');
+  const craftDest = join(folder, CRAFT_SKILL_DIR);
+  let bundleCraft: boolean;
+  let skipReason = '';
+  if (withCraft) bundleCraft = true;
+  else if (noCraft) { bundleCraft = false; skipReason = 'skipped: --no-craft'; }
+  else if (process.stdin.isTTY) {
+    bundleCraft = await confirm('also install skills/es-figma-craft (Figma canvas engineering discipline)?');
+    if (!bundleCraft) skipReason = 'declined';
+  } else {
+    bundleCraft = false;
+    skipReason = 'skipped: non-interactive run — pass --with-craft or --no-craft to decide explicitly';
+  }
+
+  if (bundleCraft) {
+    const craftSrc = join(repoRoot(), 'skills', CRAFT_SKILL_DIR);
+    if (existsSync(craftSrc)) {
+      cpSync(craftSrc, craftDest, { recursive: true });
+      installed.push(craftDest);
+    } else {
+      skipped.push({ path: craftDest, reason: `source skill not found at ${craftSrc} — this install may not bundle it` });
+    }
+  } else {
+    skipped.push({ path: craftDest, reason: skipReason });
+  }
+
+  return { folder, installed, skipped, version: CLI_VERSION, verify: 'figma-agent status --peek' };
+}

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -9,6 +9,7 @@ import { fileMatches } from '../../../shared/file-match.ts';
 import type { CommandArgs } from '../figma-agent.ts';
 import { fetchBrokerHello, runCommand } from '../transport/broker-client.ts';
 import { ensureBroker } from '../transport/broker-discovery.ts';
+import { peek } from '../transport/broker-peek.ts';
 import { CliError } from '../transport/protocol-helpers.ts';
 // Concurrency & jobs (backlog 1.1+2.6+4.3), phase 02 §3 — each row now carries
 // `runningJob`/`queueDepth` (broker-status.ts's `buildBrokerHelloData`, given a
@@ -18,6 +19,12 @@ import { CliError } from '../transport/protocol-helpers.ts';
 import type { PluginStatusEntryWithJob } from '../transport/broker-status.ts';
 
 export async function run(args: CommandArgs): Promise<unknown> {
+  // auto-connect slice 1 — `--peek` short-circuits BEFORE `ensureBroker()` below, which
+  // spawns a broker on demand. A SessionStart hook calls this every session and must
+  // never be the thing that starts a broker nobody asked for. `--json` is accepted for
+  // compatibility but is a documented no-op: this CLI always prints one JSON object.
+  if (args.bool('peek')) return peek();
+
   const ad = await ensureBroker();
 
   let hello: Record<string, unknown> = {};

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -1,12 +1,21 @@
 // figma-agent CLI entry: plain argv dispatch (no arg-parsing dependency).
-// Hidden subcommand `__broker` runs the persistent relay daemon in-process.
+// Hidden subcommands `__broker` (persistent relay daemon) and `__emit-skill`
+// (prints the generated SKILL.md to stdout) run in-process.
 // Every visible command prints exactly ONE JSON object and exits 0/1.
+//
+// `main()` only auto-runs when this file is the actual process entrypoint (see
+// the import.meta.url/argv[1] guard at the bottom) — that lets a test import
+// this module (e.g. for COMMAND_MODULES) without accidentally dispatching a
+// command from the TEST RUNNER's own argv.
 import { resolve } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { runBrokerDaemon } from './transport/broker-daemon.ts';
 import { parseArgs, type CommandArgs } from './arg-parse.ts';
 import { CliError } from './transport/protocol-helpers.ts';
 import { getLastFileContext, setExpectedFile, setExpectedInstance, setProjectDir, setReadOnly } from './transport/broker-client.ts';
 import { printErrorJson, printJson, withFileContext } from './util/json-out.ts';
+import { HELP } from './help-text.ts';
+import { renderSkill } from './skill-emitter.ts';
 import * as batch from './commands/batch.ts';
 import * as changes from './commands/changes.ts';
 import * as contention from './commands/contention.ts';
@@ -42,11 +51,16 @@ import * as setText from './commands/set-text.ts';
 import * as setVariant from './commands/set-variant.ts';
 import * as status from './commands/status.ts';
 import * as syncCorrections from './commands/sync-corrections.ts';
+import * as installSkill from './commands/install-skill.ts';
+import * as installHook from './commands/install-hook.ts';
 
 // Re-exported so command files keep `import type { CommandArgs } from '../figma-agent.ts'`.
 export type { CommandArgs } from './arg-parse.ts';
 
-const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown> }> = {
+// Exported (not just module-local) so tests/skill-emitter-drift.test.ts can assert
+// every key here has a command-catalog.ts entry and vice versa, without re-declaring
+// this list a second time.
+export const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown> }> = {
   status,
   seat,
   bind,
@@ -82,86 +96,9 @@ const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown>
   changes,
   errors,
   contention,
+  'install-skill': installSkill,
+  'install-hook': installHook,
 };
-
-const HELP = `figma-agent — CLI bridge to the Figma plugin (via a local WS broker)
-
-Usage: figma-agent <command> [options]
-
-Commands:
-  status               Broker + plugin connection info
-  seat                 Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]
-  bind                 --file "<name>" --dir <projectDir>   bind a file to a project for
-                       panel/idle sync (refuses to guess otherwise) [--list] [--unbind]
-  get-selection        Serialize the current selection [--depth 1]
-  inspect              [nodeId|--node id] [--out file.png --scale 1 --timeout ms]
-  job                  <jobId> [--wait] [--wait-timeout 60000] | --list [--file name] |
-                       <jobId> --cancel (queued only) | <jobId> --force-release [--force]
-                       poll/wait/cancel/list a job the CLI stopped waiting for (backlog 1.1+2.6+4.3)
-                       --force-release refuses a HEALTHY still-running job unless --force is
-                       also passed — --force overrides the guard and discards its result,
-                       unverified; a watchdog-wedged job still unwedges without --force
-  scan-design-system   Components/variables/styles registry [--out file.json --timeout ms]
-  scan-node            [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
-  mirror-verify        Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]
-  scan-conventions     Convention-DNA walk over sections → usage-dna.json [<sectionId...> --out file.json --budget 14000 --timeout ms]
-  audit-ds             DS-hygiene audit of the open file's component library [--out file.json --sections "01 A,02 B" --facts raw.json --from-facts raw.json --timeout ms]
-  create-frame         --name n --w 400 --h 300 [--parent id --x 0 --y 0]
-  connect              --from id --to id [--label t --intent flow|annotation --flow n --transition id]
-  disconnect           --id conn-id | --from id --to id
-  list-connections
-  reroute              [--id conn-id | --flow name]
-  draw-flow            --flow path/to/flow.json [--page name]
-  verify-connections   [--flow path/to/flow.json]
-  create-instance      --component <key|id> [--parent id]
-  set-variant          --node id --props k=v,k2=v2
-  create-variable      --collection c --name n --type COLOR|FLOAT|STRING|BOOLEAN --value v [--mode m]
-  bind-variable        --node id --field fills|cornerRadius|... --variable <id|name>
-  set-autolayout       --node id --mode H|V|GRID|NONE [--gap n --pad t,r,b,l --align-primary --align-counter --wrap --sizing-h --sizing-v --rows n --cols n --col-sizes ...]
-  set-constraints      --node id --h MIN|MAX|CENTER|STRETCH|SCALE --v MIN|MAX|CENTER|STRETCH|SCALE
-  set-text             --node id --chars "..." [--font f --size n --weight n]
-  clone-traits         --source id --target id --traits layout,fills-variables,typography,spacing,text
-  sync-corrections     [--dir project] sync Figma edge memory with design/memory
-  export-png           --node <id|selection> --out file.png [--scale 2]
-  html-to-figma        --html <file|-> [--width 1280 --x --y --parent id --replace id]
-  exec-js              <file|-> [--timeout ms (cap 120000)] [--undo-group]
-                       --undo-group brackets the script in ONE undo step and reverts it on error;
-                       the script must not call figma.commitUndo/triggerUndo itself, and a timeout
-                       cannot stop a running script (the plugin has no cancellation). While it runs,
-                       figma.currentPage carries one extra invisible child (the undo sentinel) —
-                       a script that enumerates or counts the page's children will see it.
-                       \`console\` and \`ui\` are injected — a script cannot declare its own.
-  capture              <url> [--out dir --headless --channel chrome --width 1440 --timeout ms --carousel-window ms]
-  batch                <file.json> [--stop-on-error]
-  changes              [--since ts|iso --owner-only --actor owner|agent|ambiguous --file name|slug
-                       --limit 50 --page name]  read the owner-edit feed (wave 4.4) — pure fs,
-                       works even with the plugin closed; --owner-only is sugar for --actor owner
-  errors               [--since ts|iso --file name --limit 50]  read the broker's error log
-                       (backlog 4.6) — full untruncated message + cmd/activity/code/fileName,
-                       for an agent to read-and-fix; --file filters by the entry's own fileName
-  contention           [--file name --since days]  read the durable per-file/per-day
-                       queued-time counter — total ms a mutation waited in the FIFO before
-                       dispatch, plus jobCount, per UTC day; --file filters by fileSlug,
-                       --since limits to the last N days; pure fs, works with the plugin closed
-
-Global: --file "<exact file name>"   route to that file's plugin AND refuse to run anywhere else
-                                     (exact, case-insensitive; beats FIGMA_AGENT_FILE; payloads
-                                      >512KB route by the env pin but are still guarded)
-        --instance <instanceId>     route to that EXACT plugin instance (from \`status\`'s
-                                     instanceId column) — beats --file and FIGMA_AGENT_FILE; the
-                                     one way to target a specific instance when --file's name is
-                                     ambiguous (e.g. two unsaved files both named "Untitled").
-                                     Mutually exclusive with --file: passing both refuses with
-                                     E_INVALID_ARGS naming both, it never silently picks one.
-        --dir <projectDir>          this invocation's project root (default: cwd); stamped on
-                                     every request so panel/idle sync can apply into the right
-                                     project once bound (\`figma-agent bind\`) — never a guess
-        --read-only                 declare that this command only READS. Skips the per-file
-                                     mutation queue (backlog 1.1+2.6+4.3). TRUSTED, NOT ENFORCED —
-                                     the plugin sandbox cannot verify it, so a mis-declared
-                                     mutation can interleave with another agent's work.
-
-All commands print one JSON object to stdout and exit 0, or {error:{code,message}} and exit 1.`;
 
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
@@ -169,6 +106,10 @@ async function main(): Promise<void> {
 
   if (name === '__broker') {
     await runBrokerDaemon(); // daemon never returns until shutdown
+    return;
+  }
+  if (name === '__emit-skill') {
+    process.stdout.write(renderSkill()); // pure render, no fs — see skill-emitter.ts
     return;
   }
   if (!name || name === '--help' || name === '-h' || name === 'help') {
@@ -214,4 +155,11 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch((err) => printErrorJson(err));
+// Only auto-run when this file is the process entrypoint (`node cli/dist/figma-agent.js
+// <args>`), never on a plain `import` — the guard is what lets
+// tests/skill-emitter-drift.test.ts import COMMAND_MODULES from this module without
+// dispatching a command from the TEST RUNNER's own argv.
+const isEntrypoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (isEntrypoint) {
+  main().catch((err) => printErrorJson(err));
+}

--- a/cli/src/help-text.ts
+++ b/cli/src/help-text.ts
@@ -1,0 +1,43 @@
+// Renders `figma-agent --help` from the ONE command catalog (command-catalog.ts)
+// — no command name or flag text is declared here. Column widths may shift
+// from the old inline template; the WORDS must not (see phase notes: a
+// wording change in the catalog would be invisible in review, so this file
+// stays pure layout).
+import { COMMANDS, FOOTER_LINE, GLOBAL_FLAGS, HEADER_LINE, USAGE_LINE } from './command-catalog.ts';
+
+const NAME_COLUMN = 21;
+const FLAG_COLUMN = 29;
+
+function padTo(value: string, width: number): string {
+  return value.length >= width ? `${value} ` : value + ' '.repeat(width - value.length);
+}
+
+function renderCommands(): string {
+  return COMMANDS.map(({ name, description }) =>
+    `  ${padTo(name, NAME_COLUMN)}${description}`.trimEnd(),
+  ).join('\n');
+}
+
+function renderGlobalFlags(): string {
+  return GLOBAL_FLAGS.map(({ flag, description }, i) => {
+    const prefix = i === 0 ? 'Global: ' : '        ';
+    return `${prefix}${padTo(flag, FLAG_COLUMN)}${description}`;
+  }).join('\n');
+}
+
+export function renderHelp(): string {
+  return [
+    HEADER_LINE,
+    '',
+    USAGE_LINE,
+    '',
+    'Commands:',
+    renderCommands(),
+    '',
+    renderGlobalFlags(),
+    '',
+    FOOTER_LINE,
+  ].join('\n');
+}
+
+export const HELP = renderHelp();

--- a/cli/src/skill-emitter.ts
+++ b/cli/src/skill-emitter.ts
@@ -1,0 +1,51 @@
+// Renders the full skills/figma-agent/SKILL.md text: frontmatter + the prose in
+// skill-template.ts + a "Command reference" section built from command-catalog.ts
+// — the SAME catalog help-text.ts reads, so the skill's command list can never
+// drift from the CLI's own --help without the drift test (skill-emitter-drift.test.ts)
+// catching it. Pure string building: no fs read/write here (the CLI's
+// `__emit-skill` subcommand and `install-skill` are the only fs-touching callers).
+import { COMMANDS } from './command-catalog.ts';
+import {
+  SKILL_CONNECT_PROTOCOL,
+  SKILL_DESCRIPTION,
+  SKILL_ERROR_HINTS,
+  SKILL_INTRO,
+  SKILL_WORKFLOW,
+} from './skill-template.ts';
+import { CLI_VERSION } from './version.ts';
+
+function renderFrontmatter(): string {
+  return [
+    '---',
+    'name: figma-agent',
+    `description: "${SKILL_DESCRIPTION}"`,
+    `version: ${CLI_VERSION}`,
+    `requiresCli: ">=${CLI_VERSION}"`,
+    'cliBinary: figma-agent',
+    '---',
+  ].join('\n');
+}
+
+function renderCommandReference(): string {
+  const rows = COMMANDS.map(({ name, description }) =>
+    description ? `- \`${name}\` — ${description}` : `- \`${name}\``,
+  ).join('\n');
+  return `## Command reference\n\n${rows}`;
+}
+
+export function renderSkill(): string {
+  return [
+    renderFrontmatter(),
+    '',
+    SKILL_INTRO,
+    '',
+    SKILL_CONNECT_PROTOCOL,
+    '',
+    SKILL_WORKFLOW,
+    '',
+    SKILL_ERROR_HINTS,
+    '',
+    renderCommandReference(),
+    '',
+  ].join('\n');
+}

--- a/cli/src/skill-template.ts
+++ b/cli/src/skill-template.ts
@@ -20,9 +20,10 @@ export const SKILL_CONNECT_PROTOCOL = `## Connect protocol
    question. Idle (no broker, or the plugin not open) is a normal, non-error answer.
 2. Only run a real command (\`status\`, \`connect\`, \`create-frame\`, ...) once you need to
    act — those DO start a broker on demand if none is running.
-3. \`status\`'s \`versionMatch\`/\`protocolMatch\` fields tell you whether the connected
-   plugin build matches this CLI. \`null\` means the plugin didn't report a version (an
-   older bundle) — treat that as unknown, not as a mismatch.
+3. \`status --peek\`'s \`versionMatch\`/\`protocolMatch\` fields tell you whether the
+   connected plugin build matches this CLI. \`null\` means the plugin didn't report a
+   version (an older bundle) — treat that as unknown, not as a mismatch. Plain \`status\`
+   does not compute these fields itself — read them from \`--peek\`.
 4. If nothing is connected, the human's remaining step is opening the plugin panel in
    Figma desktop — this CLI cannot do that for them.`;
 

--- a/cli/src/skill-template.ts
+++ b/cli/src/skill-template.ts
@@ -1,0 +1,49 @@
+// The skill's own prose — everything in skills/figma-agent/SKILL.md that is
+// NOT the command reference (that section is rendered separately from
+// command-catalog.ts by skill-emitter.ts). Pure data, no fs, no catalog import.
+
+export const SKILL_DESCRIPTION =
+  'figma-agent — the CLI bridge between an agent and a live Figma file, over a local '
+  + 'WebSocket broker. Use it to read connection state at session start, then read/write '
+  + 'the open Figma document without the paid official write MCP.';
+
+export const SKILL_INTRO = `# figma-agent
+
+A thin CLI that talks to the Figma plugin "Ease Design Figma Agent" through a local
+broker (127.0.0.1, ports 9410-9419). One command per invocation; every command prints
+exactly one JSON object to stdout and exits 0, or \`{error:{code,message}}\` and exits 1.`;
+
+export const SKILL_CONNECT_PROTOCOL = `## Connect protocol
+
+1. Check state cheaply first: \`figma-agent status --peek\`. This never spawns a broker —
+   it only reads the \`/tmp\` broker advertisement and, if one is live, asks it one short
+   question. Idle (no broker, or the plugin not open) is a normal, non-error answer.
+2. Only run a real command (\`status\`, \`connect\`, \`create-frame\`, ...) once you need to
+   act — those DO start a broker on demand if none is running.
+3. \`status\`'s \`versionMatch\`/\`protocolMatch\` fields tell you whether the connected
+   plugin build matches this CLI. \`null\` means the plugin didn't report a version (an
+   older bundle) — treat that as unknown, not as a mismatch.
+4. If nothing is connected, the human's remaining step is opening the plugin panel in
+   Figma desktop — this CLI cannot do that for them.`;
+
+export const SKILL_WORKFLOW = `## Typical workflow
+
+1. \`figma-agent status --peek\` — is anything alive, and does it match this CLI build.
+2. \`figma-agent status\` — full detail on the active connection (spawns a broker if idle).
+3. Read before you write: \`get-selection\`, \`inspect\`, \`scan-design-system\`.
+4. Mutate with the typed commands (\`create-frame\`, \`set-text\`, \`clone-traits\`, ...)
+   before falling back to \`exec-js\` for anything they don't cover.
+5. \`changes\`/\`errors\`/\`contention\` read durable local logs — they work even with the
+   plugin closed, useful for catching up after a session gap.`;
+
+export const SKILL_ERROR_HINTS = `## Error hints
+
+- \`E_NO_BROKER\` — no broker answered; the plugin almost certainly isn't open. Peek first
+  next time, don't assume.
+- \`E_NO_PLUGIN\` — the broker is alive but no Figma file is connected right now.
+- \`E_WRONG_FILE\` — a command named \`--file\`/\`--instance\` and the plugin currently
+  answering doesn't match; open the right file, or drop the filter to see what IS live.
+- \`E_TIMEOUT\` (with a \`jobId\`) — the command is still running as a background job; poll
+  it with \`figma-agent job <jobId> --wait\` instead of re-issuing the same command.
+- \`E_VERSION_MISMATCH\` — the broker speaks a different protocol version than this CLI;
+  rebuild/reinstall one side.`;

--- a/cli/src/transport/broker-peek.ts
+++ b/cli/src/transport/broker-peek.ts
@@ -19,7 +19,10 @@ export interface PeekPluginEntry {
 }
 
 export interface PeekResult {
-  connected: boolean;
+  // `null` means "unknown" — the broker exists (a live advertisement said so) but
+  // didn't answer in time, or refused; that is NOT the same fact as `false` (no
+  // broker at all / a plugin genuinely absent). See the `idle`/`degraded` branches.
+  connected: boolean | null;
   idle?: true;
   reason?: string;
   degraded?: string;
@@ -35,14 +38,45 @@ function matchOrNull(actual: string | number | undefined, expected: string | num
   return actual === undefined ? null : actual === expected;
 }
 
-/** Race a promise against a plain deadline. The loser is never awaited again —
- *  its `.catch` here means a late rejection from the timed-out call can never
- *  surface as an unhandled rejection after this function has already returned. */
-function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T | 'timeout'> {
-  return Promise.race([
-    promise.catch(() => 'timeout' as const),
-    new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), ms)),
-  ]);
+function describeError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+type QueryOutcome<T> = { kind: 'ok'; value: T } | { kind: 'timeout' } | { kind: 'refused'; error: unknown };
+
+/**
+ * Race a promise against a plain deadline, WITHOUT collapsing a refusal and an
+ * actual timeout into the same outcome — a closed-port ECONNREFUSED and a
+ * silent-but-accepting listener are different facts and must produce different
+ * messages (a caller that reads `degraded` and believes "did not answer within
+ * Nms" for an instant refusal is told something false). The loser is never
+ * awaited again after this resolves; a late settle from the losing side is
+ * silently dropped (the `settled` guard), so it can never surface as an
+ * unhandled rejection.
+ */
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<QueryOutcome<T>> {
+  return new Promise((resolvePromise) => {
+    let settled = false;
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      resolvePromise({ kind: 'timeout' });
+    }, ms);
+    promise.then(
+      (value) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolvePromise({ kind: 'ok', value });
+      },
+      (error: unknown) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolvePromise({ kind: 'refused', error });
+      },
+    );
+  });
 }
 
 /**
@@ -58,15 +92,22 @@ export async function peek(opts?: { path?: string; queryMs?: number }): Promise<
   }
 
   const queryMs = opts?.queryMs ?? envMs('FIGMA_AGENT_PEEK_MS', 150);
-  const hello = await withDeadline(fetchBrokerHello(ad.port), queryMs);
-  if (hello === 'timeout') {
+  const outcome = await withDeadline(fetchBrokerHello(ad.port), queryMs);
+  if (outcome.kind !== 'ok') {
+    const degraded = outcome.kind === 'timeout'
+      ? `broker did not answer within ${queryMs}ms`
+      : `broker refused the connection: ${describeError(outcome.error)}`;
     return {
-      connected: false,
+      // Unknown, not "not connected" — a broker that is merely slow or that
+      // refused this one query is a different fact from no broker existing at
+      // all (the `idle` branch above, where `false` really is known).
+      connected: null,
       broker: { port: ad.port, pid: ad.pid },
-      degraded: `broker did not answer within ${queryMs}ms`,
+      degraded,
       cliVersion: CLI_VERSION,
     };
   }
+  const hello = outcome.value;
 
   const rawPlugins = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntry[]) : [];
   const plugins: PeekPluginEntry[] = rawPlugins.map((p) => ({

--- a/cli/src/transport/broker-peek.ts
+++ b/cli/src/transport/broker-peek.ts
@@ -1,0 +1,98 @@
+// The non-spawning read behind `status --peek` — a SessionStart hook must be
+// able to call this without ever starting a broker. NEVER calls `ensureBroker`
+// (broker-discovery.ts, which spawns); only reads the /tmp advertisement and,
+// if one looks live, asks that broker ONE short question with its own deadline.
+import { BROKER_FILE, PROTOCOL_VERSION, type PluginStatusEntry } from '../../../shared/protocol.ts';
+import { isAdvertisementLive, readAdvertisement } from './broker-discovery.ts';
+import { fetchBrokerHello } from './broker-client.ts';
+import { envMs } from './protocol-helpers.ts';
+import { CLI_VERSION } from '../version.ts';
+
+export interface PeekPluginEntry {
+  fileName: string | null;
+  page: string | null;
+  instanceId: string;
+  pluginVersion?: string;
+  protocolV?: number;
+  versionMatch: boolean | null;
+  protocolMatch: boolean | null;
+}
+
+export interface PeekResult {
+  connected: boolean;
+  idle?: true;
+  reason?: string;
+  degraded?: string;
+  broker: { port: number; pid: number; protocolVersion?: number; uptimeMs?: number } | null;
+  plugins?: PeekPluginEntry[];
+  cliVersion: string;
+  versionMatch?: boolean | null;
+  protocolMatch?: boolean | null;
+}
+
+/** `undefined` (the field was never sent) is UNKNOWN, not a mismatch. */
+function matchOrNull(actual: string | number | undefined, expected: string | number): boolean | null {
+  return actual === undefined ? null : actual === expected;
+}
+
+/** Race a promise against a plain deadline. The loser is never awaited again —
+ *  its `.catch` here means a late rejection from the timed-out call can never
+ *  surface as an unhandled rejection after this function has already returned. */
+function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T | 'timeout'> {
+  return Promise.race([
+    promise.catch(() => 'timeout' as const),
+    new Promise<'timeout'>((resolve) => setTimeout(() => resolve('timeout'), ms)),
+  ]);
+}
+
+/**
+ * `status --peek`'s implementation. Exits (returns) normally in every case —
+ * idle, a stale/dead advertisement, and a broker that doesn't answer in time
+ * are all honest, non-error answers, never a thrown failure.
+ */
+export async function peek(opts?: { path?: string; queryMs?: number }): Promise<PeekResult> {
+  const path = opts?.path ?? process.env.FIGMA_AGENT_BROKER_FILE ?? BROKER_FILE;
+  const ad = readAdvertisement(path);
+  if (!ad || !isAdvertisementLive(ad)) {
+    return { connected: false, broker: null, idle: true, reason: 'no live broker advertisement', cliVersion: CLI_VERSION };
+  }
+
+  const queryMs = opts?.queryMs ?? envMs('FIGMA_AGENT_PEEK_MS', 150);
+  const hello = await withDeadline(fetchBrokerHello(ad.port), queryMs);
+  if (hello === 'timeout') {
+    return {
+      connected: false,
+      broker: { port: ad.port, pid: ad.pid },
+      degraded: `broker did not answer within ${queryMs}ms`,
+      cliVersion: CLI_VERSION,
+    };
+  }
+
+  const rawPlugins = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntry[]) : [];
+  const plugins: PeekPluginEntry[] = rawPlugins.map((p) => ({
+    fileName: p.fileName ?? null,
+    page: p.page ?? null,
+    instanceId: p.instanceId,
+    ...(p.pluginVersion !== undefined && { pluginVersion: p.pluginVersion }),
+    ...(p.protocolV !== undefined && { protocolV: p.protocolV }),
+    versionMatch: matchOrNull(p.pluginVersion, CLI_VERSION),
+    protocolMatch: matchOrNull(p.protocolV, PROTOCOL_VERSION),
+  }));
+
+  const activeFileName = (hello.activePlugin as string | null | undefined) ?? null;
+  const active = activeFileName ? plugins.find((p) => p.fileName === activeFileName) : undefined;
+
+  return {
+    connected: (hello.pluginConnected as boolean | undefined) === true,
+    broker: {
+      port: ad.port,
+      pid: ad.pid,
+      protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
+      uptimeMs: (hello.uptimeMs as number | undefined) ?? undefined,
+    },
+    plugins,
+    cliVersion: CLI_VERSION,
+    versionMatch: active ? active.versionMatch : null,
+    protocolMatch: active ? active.protocolMatch : null,
+  };
+}

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -70,7 +70,8 @@ export interface PluginEntry<S extends RegistrySocket = RegistrySocket> {
   // auto-connect slice 1 — retained (not stripped like the rest of PROTOCOL_KEYS)
   // so `statusList()` can surface what build/protocol this instance is actually
   // running. `undefined` (never sent — an older plugin bundle) is distinct from
-  // any real value; see `statusList()`'s versionMatch/protocolMatch contract.
+  // any real value; `statusList()` itself only surfaces these raw fields — the
+  // computed versionMatch/protocolMatch comparison lives in broker-peek.ts.
   pluginVersion?: string;
   protocolV?: number;
 }

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -67,6 +67,12 @@ export interface PluginEntry<S extends RegistrySocket = RegistrySocket> {
   // When the last reconnect (superseded same-instance register) happened, or
   // null before the first one — the anchor `sameSceneStreak` windows against.
   lastReHelloAt: number | null;
+  // auto-connect slice 1 — retained (not stripped like the rest of PROTOCOL_KEYS)
+  // so `statusList()` can surface what build/protocol this instance is actually
+  // running. `undefined` (never sent — an older plugin bundle) is distinct from
+  // any real value; see `statusList()`'s versionMatch/protocolMatch contract.
+  pluginVersion?: string;
+  protocolV?: number;
 }
 
 // HELLO payload keys that are protocol plumbing, not scene identity.
@@ -160,6 +166,11 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
       reHelloCount,
       sameSceneStreak,
       lastReHelloAt,
+      // auto-connect slice 1 — read straight off THIS HELLO's data, not carried over
+      // from `existing`: a reconnect after a plugin rebuild must report the NEW build's
+      // version, never a stale one left over from the superseded socket.
+      pluginVersion: typeof data.pluginVersion === 'string' ? data.pluginVersion : undefined,
+      protocolV: typeof data.protocolV === 'number' ? data.protocolV : undefined,
     });
     return { instanceId: id, replaced: existing !== undefined, superseded };
   }
@@ -342,6 +353,11 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
           appSilenceMs: now - e.lastAppFrameAt,
           ...(e.reHelloCount > 0 && { reHelloCount: e.reHelloCount }),
           ...(reason !== null && { suspectedZombie: true as const, zombieReason: reason }),
+          // auto-connect slice 1 — present only when the HELLO actually carried it (an
+          // older plugin bundle omits both), same "common case stays byte-identical"
+          // contract as reHelloCount/suspectedZombie above.
+          ...(e.pluginVersion !== undefined && { pluginVersion: e.pluginVersion }),
+          ...(e.protocolV !== undefined && { protocolV: e.protocolV }),
         };
       });
   }

--- a/cli/src/version.ts
+++ b/cli/src/version.ts
@@ -1,0 +1,6 @@
+// Single source of the CLI's own version string — bundled at build time
+// (esbuild inlines this constant; no runtime fs read, no package.json parse in
+// the shipped binary). Kept in lockstep with package.json's "version" field by
+// tests/cli-version.test.ts, the only place in this repo that reads
+// package.json at test time to prove it.
+export const CLI_VERSION = '0.1.0';

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build:cli": "node scripts/build.mjs cli",
     "build:plugin-main": "node scripts/build.mjs plugin-main",
     "build:plugin-ui": "node scripts/build.mjs plugin-ui",
+    "emit:skill": "npm run build:cli --silent && node cli/dist/figma-agent.js __emit-skill > skills/figma-agent/SKILL.md",
     "typecheck": "tsc -p cli --noEmit && tsc -p plugin --noEmit",
     "test": "vitest run --config vitest.config.ts",
     "lint:comments": "node scripts/check-comment-hygiene.mjs",

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -303,6 +303,16 @@ export interface PluginStatusEntry {
    * `suspectedZombie`.
    */
   zombieReason?: string;
+  /**
+   * auto-connect slice 1 — the plugin bundle's own version/protocol, carried in every
+   * PLUGIN_HELLO (`pluginVersion`, `protocolV`) and retained here instead of stripped
+   * (`plugin-registry.ts`'s `extractScene` still strips both from `scene`; this is a
+   * SEPARATE, additive pair). Present only when the connecting plugin actually sent
+   * them — absent (not `false`) on an older bundle that never did, so `status --peek`
+   * can tell "mismatched" apart from "unknown" instead of guessing.
+   */
+  pluginVersion?: string;
+  protocolV?: number;
 }
 
 // Chunked transport for payloads > CHUNK_LIMIT (both directions).

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: figma-agent
+description: "figma-agent — the CLI bridge between an agent and a live Figma file, over a local WebSocket broker. Use it to read connection state at session start, then read/write the open Figma document without the paid official write MCP."
+version: 0.1.0
+requiresCli: ">=0.1.0"
+cliBinary: figma-agent
+---
+
+# figma-agent
+
+A thin CLI that talks to the Figma plugin "Ease Design Figma Agent" through a local
+broker (127.0.0.1, ports 9410-9419). One command per invocation; every command prints
+exactly one JSON object to stdout and exits 0, or `{error:{code,message}}` and exits 1.
+
+## Connect protocol
+
+1. Check state cheaply first: `figma-agent status --peek`. This never spawns a broker —
+   it only reads the `/tmp` broker advertisement and, if one is live, asks it one short
+   question. Idle (no broker, or the plugin not open) is a normal, non-error answer.
+2. Only run a real command (`status`, `connect`, `create-frame`, ...) once you need to
+   act — those DO start a broker on demand if none is running.
+3. `status`'s `versionMatch`/`protocolMatch` fields tell you whether the connected
+   plugin build matches this CLI. `null` means the plugin didn't report a version (an
+   older bundle) — treat that as unknown, not as a mismatch.
+4. If nothing is connected, the human's remaining step is opening the plugin panel in
+   Figma desktop — this CLI cannot do that for them.
+
+## Typical workflow
+
+1. `figma-agent status --peek` — is anything alive, and does it match this CLI build.
+2. `figma-agent status` — full detail on the active connection (spawns a broker if idle).
+3. Read before you write: `get-selection`, `inspect`, `scan-design-system`.
+4. Mutate with the typed commands (`create-frame`, `set-text`, `clone-traits`, ...)
+   before falling back to `exec-js` for anything they don't cover.
+5. `changes`/`errors`/`contention` read durable local logs — they work even with the
+   plugin closed, useful for catching up after a session gap.
+
+## Error hints
+
+- `E_NO_BROKER` — no broker answered; the plugin almost certainly isn't open. Peek first
+  next time, don't assume.
+- `E_NO_PLUGIN` — the broker is alive but no Figma file is connected right now.
+- `E_WRONG_FILE` — a command named `--file`/`--instance` and the plugin currently
+  answering doesn't match; open the right file, or drop the filter to see what IS live.
+- `E_TIMEOUT` (with a `jobId`) — the command is still running as a background job; poll
+  it with `figma-agent job <jobId> --wait` instead of re-issuing the same command.
+- `E_VERSION_MISMATCH` — the broker speaks a different protocol version than this CLI;
+  rebuild/reinstall one side.
+
+## Command reference
+
+- `status` — Broker + plugin connection info [--peek [--json]] — --peek reads only the /tmp broker advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted for compatibility but is a no-op: output is always the same single JSON object.
+- `seat` — Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]
+- `bind` — --file "<name>" --dir <projectDir>   bind a file to a project for panel/idle sync (refuses to guess otherwise) [--list] [--unbind]
+- `get-selection` — Serialize the current selection [--depth 1]
+- `inspect` — [nodeId|--node id] [--out file.png --scale 1 --timeout ms]
+- `job` — <jobId> [--wait] [--wait-timeout 60000] | --list [--file name] | <jobId> --cancel (queued only) | <jobId> --force-release [--force]   poll/wait/cancel/list a job the CLI stopped waiting for (backlog 1.1+2.6+4.3) — --force-release refuses a HEALTHY still-running job unless --force is also passed — --force overrides the guard and discards its result, unverified; a watchdog-wedged job still unwedges without --force
+- `scan-design-system` — Components/variables/styles registry [--out file.json --timeout ms]
+- `scan-node` — [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
+- `mirror-verify` — Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]
+- `scan-conventions` — Convention-DNA walk over sections → usage-dna.json [<sectionId...> --out file.json --budget 14000 --timeout ms]
+- `audit-ds` — DS-hygiene audit of the open file's component library [--out file.json --sections "01 A,02 B" --facts raw.json --from-facts raw.json --timeout ms]
+- `create-frame` — --name n --w 400 --h 300 [--parent id --x 0 --y 0]
+- `connect` — --from id --to id [--label t --intent flow|annotation --flow n --transition id]
+- `disconnect` — --id conn-id | --from id --to id
+- `list-connections`
+- `reroute` — [--id conn-id | --flow name]
+- `draw-flow` — --flow path/to/flow.json [--page name]
+- `verify-connections` — [--flow path/to/flow.json]
+- `create-instance` — --component <key|id> [--parent id]
+- `set-variant` — --node id --props k=v,k2=v2
+- `create-variable` — --collection c --name n --type COLOR|FLOAT|STRING|BOOLEAN --value v [--mode m]
+- `bind-variable` — --node id --field fills|cornerRadius|... --variable <id|name>
+- `set-autolayout` — --node id --mode H|V|GRID|NONE [--gap n --pad t,r,b,l --align-primary --align-counter --wrap --sizing-h --sizing-v --rows n --cols n --col-sizes ...]
+- `set-constraints` — --node id --h MIN|MAX|CENTER|STRETCH|SCALE --v MIN|MAX|CENTER|STRETCH|SCALE
+- `set-text` — --node id --chars "..." [--font f --size n --weight n]
+- `clone-traits` — --source id --target id --traits layout,fills-variables,typography,spacing,text
+- `sync-corrections` — [--dir project] sync Figma edge memory with design/memory
+- `export-png` — --node <id|selection> --out file.png [--scale 2]
+- `html-to-figma` — --html <file|-> [--width 1280 --x --y --parent id --replace id]
+- `exec-js` — <file|-> [--timeout ms (cap 120000)] [--undo-group] — --undo-group brackets the script in ONE undo step and reverts it on error; the script must not call figma.commitUndo/triggerUndo itself, and a timeout cannot stop a running script (the plugin has no cancellation). While it runs, figma.currentPage carries one extra invisible child (the undo sentinel) — a script that enumerates or counts the page's children will see it. `console` and `ui` are injected — a script cannot declare its own.
+- `capture` — <url> [--out dir --headless --channel chrome --width 1440 --timeout ms --carousel-window ms]
+- `batch` — <file.json> [--stop-on-error]
+- `changes` — [--since ts|iso --owner-only --actor owner|agent|ambiguous --file name|slug --limit 50 --page name]  read the owner-edit feed (wave 4.4) — pure fs, works even with the plugin closed; --owner-only is sugar for --actor owner
+- `errors` — [--since ts|iso --file name --limit 50]  read the broker's error log (backlog 4.6) — full untruncated message + cmd/activity/code/fileName, for an agent to read-and-fix; --file filters by the entry's own fileName
+- `contention` — [--file name --since days]  read the durable per-file/per-day queued-time counter — total ms a mutation waited in the FIFO before dispatch, plus jobCount, per UTC day; --file filters by fileSlug, --since limits to the last N days; pure fs, works with the plugin closed
+- `install-skill` — [--folder ~/.claude/skills] [--with-craft|--no-craft] [--yes]   write this emitted SKILL.md to a folder Claude Code reads skills from; prompts before overwriting an older installed version and before bundling skills/es-figma-craft — a non-interactive run needs --with-craft/--no-craft or it skips craft and says so
+- `install-hook` — [--dry-run] [--yes] [--settings <path>]   add a SessionStart hook to Claude Code settings that runs "figma-agent status --peek" at the start of every session; confirms before writing, backs up the file first, and aborts untouched if it can't parse the file as JSON

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -19,9 +19,10 @@ exactly one JSON object to stdout and exits 0, or `{error:{code,message}}` and e
    question. Idle (no broker, or the plugin not open) is a normal, non-error answer.
 2. Only run a real command (`status`, `connect`, `create-frame`, ...) once you need to
    act — those DO start a broker on demand if none is running.
-3. `status`'s `versionMatch`/`protocolMatch` fields tell you whether the connected
-   plugin build matches this CLI. `null` means the plugin didn't report a version (an
-   older bundle) — treat that as unknown, not as a mismatch.
+3. `status --peek`'s `versionMatch`/`protocolMatch` fields tell you whether the
+   connected plugin build matches this CLI. `null` means the plugin didn't report a
+   version (an older bundle) — treat that as unknown, not as a mismatch. Plain `status`
+   does not compute these fields itself — read them from `--peek`.
 4. If nothing is connected, the human's remaining step is opening the plugin panel in
    Figma desktop — this CLI cannot do that for them.
 

--- a/tests/cli-version.test.ts
+++ b/tests/cli-version.test.ts
@@ -1,0 +1,15 @@
+// CLI_VERSION (cli/src/version.ts) is a bundled constant, not a runtime
+// package.json read — this is the ONE test allowed to open package.json and
+// prove the two never drift apart.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { CLI_VERSION } from '../cli/src/version.ts';
+
+describe('CLI_VERSION stays in lockstep with package.json', () => {
+  it('matches package.json\'s own "version" field', () => {
+    const pkgPath = fileURLToPath(new URL('../package.json', import.meta.url));
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+    expect(CLI_VERSION).toBe(pkg.version);
+  });
+});

--- a/tests/install-hook.test.ts
+++ b/tests/install-hook.test.ts
@@ -1,0 +1,103 @@
+// `install-hook` unit tests — always pass an explicit --settings pointing inside
+// a scratch tmpdir. NEVER writes to the real ~/.claude/settings.json — this is a
+// one-way-door file (a user's real config), so this suite is fixture-only by
+// construction, never conditionally, and there is no code path here that can
+// reach the real path.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+import { run } from '../cli/src/commands/install-hook.ts';
+
+function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
+  return {
+    positionals: [],
+    str: (name) => (typeof flags[name] === 'string' ? (flags[name] as string) : undefined),
+    req: (name) => {
+      const v = flags[name];
+      if (typeof v !== 'string') throw new Error(`missing --${name}`);
+      return v;
+    },
+    num: (name) => (typeof flags[name] === 'string' ? Number(flags[name]) : undefined),
+    bool: (name) => flags[name] === true || flags[name] === 'true',
+  };
+}
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-install-hook-'));
+});
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('install-hook — fixture-only, never the real settings.json', () => {
+  it('file does not exist yet, --yes → creates it with the SessionStart hook', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    const result = await run(fakeArgs({ settings, yes: true }));
+    expect(result.status).toBe('installed');
+    expect(existsSync(settings)).toBe(true);
+    const written = JSON.parse(readFileSync(settings, 'utf8')) as { hooks: { SessionStart: { hooks: { command: string }[] }[] } };
+    expect(written.hooks.SessionStart[0].hooks[0].command).toContain('figma-agent status --peek');
+    expect(result.backupPath).toBeNull(); // nothing existed to back up
+  });
+
+  it('existing valid settings.json, --yes → backs up before writing, preserves other keys', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    writeFileSync(settings, JSON.stringify({ someOtherKey: true }, null, 2));
+    const result = await run(fakeArgs({ settings, yes: true }));
+    expect(result.status).toBe('installed');
+    expect(result.backupPath).toMatch(/\.bak-\d+$/);
+    expect(existsSync(result.backupPath as string)).toBe(true);
+    const written = JSON.parse(readFileSync(settings, 'utf8')) as Record<string, unknown>;
+    expect(written.someOtherKey).toBe(true);
+  });
+
+  it('already contains the identical hook command → unchanged, no write, no backup', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    const already = {
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: 'command -v figma-agent >/dev/null 2>&1 && figma-agent status --peek --json || true' }] },
+        ],
+      },
+    };
+    writeFileSync(settings, JSON.stringify(already, null, 2));
+    const before = readFileSync(settings, 'utf8');
+    const result = await run(fakeArgs({ settings, yes: true }));
+    expect(result.status).toBe('unchanged');
+    expect(readFileSync(settings, 'utf8')).toBe(before);
+    expect(result.backupPath).toBeNull();
+  });
+
+  it('--dry-run prints the resulting JSON but writes nothing', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    const result = await run(fakeArgs({ settings, 'dry-run': true }));
+    expect(result.status).toBe('dry-run');
+    expect(existsSync(settings)).toBe(false);
+    expect(result.preview).toContain('figma-agent status --peek');
+  });
+
+  it('invalid JSON → aborts untouched, no backup, no write', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    writeFileSync(settings, '{ not valid json');
+    await expect(run(fakeArgs({ settings, yes: true }))).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    expect(readFileSync(settings, 'utf8')).toBe('{ not valid json');
+    expect(readdirSync(scratchDir)).toEqual(['settings.json']); // no .bak file created
+  });
+
+  it('non-interactive, no --yes, no --dry-run → refuses without writing', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    await expect(run(fakeArgs({ settings }))).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    expect(existsSync(settings)).toBe(false);
+  });
+
+  it("preserves the original file's indentation width", async () => {
+    const settings = join(scratchDir, 'settings.json');
+    writeFileSync(settings, JSON.stringify({ a: 1 }, null, 4));
+    await run(fakeArgs({ settings, yes: true }));
+    expect(readFileSync(settings, 'utf8')).toMatch(/\n    "a": 1/);
+  });
+});

--- a/tests/install-hook.test.ts
+++ b/tests/install-hook.test.ts
@@ -3,12 +3,34 @@
 // one-way-door file (a user's real config), so this suite is fixture-only by
 // construction, never conditionally, and there is no code path here that can
 // reach the real path.
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { CommandArgs } from '../cli/src/arg-parse.ts';
-import { run } from '../cli/src/commands/install-hook.ts';
+
+// Hoisted mutable slot the mocked readline prompt reads/writes — lets a single
+// test simulate "a concurrent writer edited settings.json WHILE the confirm
+// prompt was pending" without a real TTY or a real multi-second wait.
+const concurrentEdit: { path: string | null; content: string | null; answer: string } = {
+  path: null,
+  content: null,
+  answer: 'y',
+};
+
+vi.mock('node:readline/promises', () => ({
+  createInterface: () => ({
+    question: async () => {
+      if (concurrentEdit.path && concurrentEdit.content !== null) {
+        writeFileSync(concurrentEdit.path, concurrentEdit.content);
+      }
+      return concurrentEdit.answer;
+    },
+    close: () => {},
+  }),
+}));
+
+const { run } = await import('../cli/src/commands/install-hook.ts');
 
 function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
   return {
@@ -99,5 +121,67 @@ describe('install-hook — fixture-only, never the real settings.json', () => {
     writeFileSync(settings, JSON.stringify({ a: 1 }, null, 4));
     await run(fakeArgs({ settings, yes: true }));
     expect(readFileSync(settings, 'utf8')).toMatch(/\n    "a": 1/);
+  });
+
+  it('preserves TAB indentation instead of reformatting to 2 spaces', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    writeFileSync(settings, '{\n\t"a": 1\n}');
+    await run(fakeArgs({ settings, yes: true }));
+    const written = readFileSync(settings, 'utf8');
+    expect(written).toMatch(/\n\t"a": 1/);
+    expect(written).not.toMatch(/\n {2}"a": 1/); // must not have been silently reformatted to spaces
+  });
+
+  it('appends alongside an existing UNRELATED SessionStart group, never replacing it', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    const already = {
+      hooks: {
+        SessionStart: [
+          { hooks: [{ type: 'command', command: 'echo some-other-teams-hook' }] },
+        ],
+      },
+    };
+    writeFileSync(settings, JSON.stringify(already, null, 2));
+    const result = await run(fakeArgs({ settings, yes: true }));
+    expect(result.status).toBe('installed');
+    const written = JSON.parse(readFileSync(settings, 'utf8')) as { hooks: { SessionStart: { hooks: { command: string }[] }[] } };
+    expect(written.hooks.SessionStart).toHaveLength(2);
+    expect(written.hooks.SessionStart[0].hooks[0].command).toBe('echo some-other-teams-hook');
+    expect(written.hooks.SessionStart[1].hooks[0].command).toContain('figma-agent status --peek');
+  });
+});
+
+describe('install-hook — TOCTOU: the confirm prompt is a real wait, not an instant', () => {
+  beforeEach(() => {
+    concurrentEdit.path = null;
+    concurrentEdit.content = null;
+    concurrentEdit.answer = 'y';
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+  });
+
+  it('a file edited on disk WHILE the confirm prompt is pending is never silently clobbered', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    writeFileSync(settings, JSON.stringify({ someOtherKey: 'original' }, null, 2));
+    const concurrentContent = JSON.stringify({ someOtherKey: 'edited-by-someone-else-during-the-prompt' }, null, 2);
+    concurrentEdit.path = settings;
+    concurrentEdit.content = concurrentContent;
+
+    await expect(run(fakeArgs({ settings }))).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    // The concurrent edit must survive — install-hook must never overwrite it
+    // with a write computed from the STALE pre-prompt read.
+    expect(readFileSync(settings, 'utf8')).toBe(concurrentContent);
+  });
+
+  it('the backup (when no concurrent edit happened) reflects the content actually being overwritten', async () => {
+    const settings = join(scratchDir, 'settings.json');
+    const original = JSON.stringify({ someOtherKey: 'original' }, null, 2);
+    writeFileSync(settings, original);
+    concurrentEdit.path = null; // no race this time
+    const result = await run(fakeArgs({ settings }));
+    expect(result.status).toBe('installed');
+    expect(readFileSync(result.backupPath as string, 'utf8')).toBe(original);
   });
 });

--- a/tests/install-skill.test.ts
+++ b/tests/install-skill.test.ts
@@ -4,14 +4,20 @@
 // the non-interactive branches; the interactive Y/n prompt path is covered
 // indirectly via --yes (its "skip the prompt" branch) since driving a real
 // readline prompt from a non-TTY test process is not a meaningful seam here.
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, renameSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { CommandArgs } from '../cli/src/arg-parse.ts';
 import { run } from '../cli/src/commands/install-skill.ts';
 import { CLI_VERSION } from '../cli/src/version.ts';
 import { renderSkill } from '../cli/src/skill-emitter.ts';
+
+const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const CLI_DIST = join(ROOT, 'cli', 'dist', 'figma-agent.js');
+const CRAFT_SKILL_DIR = 'es-figma-craft';
 
 function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
   return {
@@ -99,11 +105,84 @@ describe('install-skill — writes the emitted SKILL.md, never a stale copy', ()
     expect(existsSync(join(folder, 'es-figma-craft'))).toBe(false);
   });
 
-  it("--with-craft copies the repo's skills/es-figma-craft directory", async () => {
+  it("--with-craft copies the repo's skills/es-figma-craft directory (source-tree seam)", async () => {
+    // Exercises the path arithmetic when this module is imported straight from
+    // cli/src/commands/ (what THIS test process does) — see the describe block
+    // below for the same behavior exercised against the built cli/dist bundle,
+    // which is what a real install actually runs.
     const folder = join(scratchDir, 'skills');
     const result = await run(fakeArgs({ folder, 'with-craft': true }));
     const craftDest = join(folder, 'es-figma-craft');
     expect(existsSync(join(craftDest, 'SKILL.md'))).toBe(true);
     expect(result.installed).toContain(craftDest);
+  });
+
+  it('--with-craft on an already-installed craft folder: unchanged if identical, refuses to silently overwrite if edited', async () => {
+    const folder = join(scratchDir, 'skills');
+    await run(fakeArgs({ folder, 'with-craft': true }));
+    const craftDest = join(folder, 'es-figma-craft');
+    const before = readFileSync(join(craftDest, 'SKILL.md'), 'utf8');
+
+    // Re-running with an identical install is a no-op, not a re-copy.
+    const same = await run(fakeArgs({ folder, 'with-craft': true }));
+    expect(readFileSync(join(craftDest, 'SKILL.md'), 'utf8')).toBe(before);
+    expect(same.skipped.some((s) => s.path === craftDest && s.reason.includes('unchanged'))).toBe(true);
+
+    // A user-edited craft folder must not be silently clobbered without --yes.
+    writeFileSync(join(craftDest, 'SKILL.md'), 'a user made local edits here');
+    const edited = await run(fakeArgs({ folder, 'with-craft': true }));
+    expect(readFileSync(join(craftDest, 'SKILL.md'), 'utf8')).toBe('a user made local edits here');
+    expect(edited.installed).not.toContain(craftDest);
+    expect(edited.skipped.some((s) => s.path === craftDest && s.reason.includes('declined'))).toBe(true);
+  });
+});
+
+describe('install-skill --with-craft — subprocess, against the BUILT cli/dist bundle', () => {
+  beforeAll(() => {
+    execFileSync(process.execPath, ['scripts/build.mjs', 'cli'], { cwd: ROOT });
+  });
+
+  it('copies skills/es-figma-craft from the shipped binary, not just from source', () => {
+    const folder = join(scratchDir, 'skills');
+    const out = execFileSync(process.execPath, [CLI_DIST, 'install-skill', '--folder', folder, '--with-craft', '--yes'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    const result = JSON.parse(out) as { installed: string[]; skipped: { path: string; reason: string }[] };
+    const craftDest = join(folder, 'es-figma-craft');
+    expect(existsSync(join(craftDest, 'SKILL.md'))).toBe(true);
+    expect(result.installed).toContain(craftDest);
+    expect(result.skipped).toEqual([]);
+  });
+
+  it('an explicit --with-craft that cannot be satisfied exits non-zero with a named reason, never a silent success', () => {
+    // Simulate "unsatisfiable" against the REAL built bundle + real repoRoot()
+    // resolution by briefly renaming the repo's own skills/es-figma-craft out of
+    // the way — this exercises the actual anchor-walk this fix relies on,
+    // without needing a relocated copy of node_modules for a bundle that
+    // externals `ws`. Window is a single synchronous subprocess call.
+    const realCraft = join(ROOT, 'skills', CRAFT_SKILL_DIR);
+    const movedAside = `${realCraft}.__test-moved-aside__`;
+    renameSync(realCraft, movedAside);
+    try {
+      const folder = join(scratchDir, 'skills-2');
+      let threw: { status: number | null; stdout: string } | null = null;
+      try {
+        execFileSync(process.execPath, [CLI_DIST, 'install-skill', '--folder', folder, '--with-craft', '--yes'], {
+          cwd: ROOT,
+          encoding: 'utf8',
+        });
+      } catch (err) {
+        const e = err as { status: number | null; stdout: string };
+        threw = { status: e.status, stdout: e.stdout };
+      }
+      expect(threw).not.toBeNull();
+      expect(threw?.status).not.toBe(0);
+      const parsed = JSON.parse(threw?.stdout ?? '{}') as { error?: { code?: string; message?: string } };
+      expect(parsed.error?.code).toBe('E_INVALID_ARGS');
+      expect(parsed.error?.message).toContain('with-craft');
+    } finally {
+      renameSync(movedAside, realCraft);
+    }
   });
 });

--- a/tests/install-skill.test.ts
+++ b/tests/install-skill.test.ts
@@ -1,0 +1,109 @@
+// `install-skill` unit tests — always pass an explicit --folder inside a scratch
+// tmpdir; NEVER exercises the real ~/.claude/skills folder. vitest's own process
+// has no controlling TTY, so the default (no explicit flag) path below exercises
+// the non-interactive branches; the interactive Y/n prompt path is covered
+// indirectly via --yes (its "skip the prompt" branch) since driving a real
+// readline prompt from a non-TTY test process is not a meaningful seam here.
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+import { run } from '../cli/src/commands/install-skill.ts';
+import { CLI_VERSION } from '../cli/src/version.ts';
+import { renderSkill } from '../cli/src/skill-emitter.ts';
+
+function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
+  return {
+    positionals: [],
+    str: (name) => (typeof flags[name] === 'string' ? (flags[name] as string) : undefined),
+    req: (name) => {
+      const v = flags[name];
+      if (typeof v !== 'string') throw new Error(`missing --${name}`);
+      return v;
+    },
+    num: (name) => (typeof flags[name] === 'string' ? Number(flags[name]) : undefined),
+    bool: (name) => flags[name] === true || flags[name] === 'true',
+  };
+}
+
+let scratchDir: string;
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-install-skill-'));
+});
+afterEach(() => {
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('install-skill — writes the emitted SKILL.md, never a stale copy', () => {
+  it('fresh folder: creates figma-agent/SKILL.md matching renderSkill()', async () => {
+    const folder = join(scratchDir, 'skills');
+    const result = await run(fakeArgs({ folder, 'no-craft': true }));
+    const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+    expect(existsSync(skillPath)).toBe(true);
+    expect(readFileSync(skillPath, 'utf8')).toBe(renderSkill());
+    expect(result.installed).toContain(skillPath);
+    expect(result.version).toBe(CLI_VERSION);
+  });
+
+  it('same version already installed → unchanged, no write', async () => {
+    const folder = join(scratchDir, 'skills');
+    await run(fakeArgs({ folder, 'no-craft': true }));
+    const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+    const before = readFileSync(skillPath, 'utf8');
+    const result = await run(fakeArgs({ folder, 'no-craft': true }));
+    expect(readFileSync(skillPath, 'utf8')).toBe(before);
+    expect(result.skipped.some((s) => s.path === skillPath && s.reason.includes('unchanged'))).toBe(true);
+  });
+
+  it('older version present, --yes → overwrites without prompting', async () => {
+    const folder = join(scratchDir, 'skills');
+    mkdirSync(join(folder, 'figma-agent'), { recursive: true });
+    writeFileSync(join(folder, 'figma-agent', 'SKILL.md'), '---\nname: figma-agent\nversion: 0.0.1\n---\nstale');
+    const result = await run(fakeArgs({ folder, 'no-craft': true, yes: true }));
+    const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+    expect(readFileSync(skillPath, 'utf8')).toBe(renderSkill());
+    expect(result.installed).toContain(skillPath);
+  });
+
+  it('older version present, non-interactive, no --yes → refuses to overwrite silently', async () => {
+    const folder = join(scratchDir, 'skills');
+    mkdirSync(join(folder, 'figma-agent'), { recursive: true });
+    const stale = '---\nname: figma-agent\nversion: 0.0.1\n---\nstale';
+    writeFileSync(join(folder, 'figma-agent', 'SKILL.md'), stale);
+    const result = await run(fakeArgs({ folder, 'no-craft': true }));
+    expect(readFileSync(join(folder, 'figma-agent', 'SKILL.md'), 'utf8')).toBe(stale);
+    expect(result.installed).toEqual([]);
+    expect(result.skipped.some((s) => s.reason.includes('declined'))).toBe(true);
+  });
+
+  it('--with-craft and --no-craft together refuse with E_INVALID_ARGS', async () => {
+    await expect(
+      run(fakeArgs({ folder: join(scratchDir, 'skills'), 'with-craft': true, 'no-craft': true })),
+    ).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+  });
+
+  it('non-interactive with neither --with-craft nor --no-craft skips craft and says so', async () => {
+    const folder = join(scratchDir, 'skills');
+    const result = await run(fakeArgs({ folder }));
+    const craftEntry = result.skipped.find((s) => s.path === join(folder, 'es-figma-craft'));
+    expect(craftEntry?.reason).toContain('non-interactive');
+  });
+
+  it('--no-craft skips it explicitly, no prompt', async () => {
+    const folder = join(scratchDir, 'skills');
+    const result = await run(fakeArgs({ folder, 'no-craft': true }));
+    const craftEntry = result.skipped.find((s) => s.path === join(folder, 'es-figma-craft'));
+    expect(craftEntry?.reason).toBe('skipped: --no-craft');
+    expect(existsSync(join(folder, 'es-figma-craft'))).toBe(false);
+  });
+
+  it("--with-craft copies the repo's skills/es-figma-craft directory", async () => {
+    const folder = join(scratchDir, 'skills');
+    const result = await run(fakeArgs({ folder, 'with-craft': true }));
+    const craftDest = join(folder, 'es-figma-craft');
+    expect(existsSync(join(craftDest, 'SKILL.md'))).toBe(true);
+    expect(result.installed).toContain(craftDest);
+  });
+});

--- a/tests/skill-emitter-drift.test.ts
+++ b/tests/skill-emitter-drift.test.ts
@@ -7,7 +7,8 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { renderSkill } from '../cli/src/skill-emitter.ts';
-import { COMMANDS } from '../cli/src/command-catalog.ts';
+import { COMMANDS, GLOBAL_FLAGS } from '../cli/src/command-catalog.ts';
+import { renderHelp } from '../cli/src/help-text.ts';
 import { COMMAND_MODULES } from '../cli/src/figma-agent.ts';
 
 const SKILL_PATH = fileURLToPath(new URL('../skills/figma-agent/SKILL.md', import.meta.url));
@@ -33,5 +34,39 @@ describe('skill-emitter-drift', () => {
     const moduleNames = Object.keys(COMMAND_MODULES).sort();
     const catalogNames = COMMANDS.map((c) => c.name).sort();
     expect(catalogNames).toEqual(moduleNames);
+  });
+
+  // Coverage gap noted in review: the two checks above catch a MISSING command,
+  // not a flag that quietly went stale in the catalog's free-text description
+  // while the runtime path that reads it changed name. --help itself was also
+  // asserted nowhere. Cheapest honest version: --help must actually render
+  // every command + its description (help-text.ts is genuinely read), and every
+  // args.bool/str flag THIS SLICE'S commands read at runtime must appear in
+  // their own catalog description — not a general flag/description parser.
+  it('renderHelp() actually contains every catalog command name and description', () => {
+    const help = renderHelp();
+    for (const c of COMMANDS) {
+      expect(help, `--help is missing the "${c.name}" command line`).toContain(c.name);
+      if (c.description) expect(help, `--help text for "${c.name}" is stale`).toContain(c.description);
+    }
+  });
+
+  it("this slice's commands: every args.bool/str flag they read is named in their own catalog description or GLOBAL_FLAGS", () => {
+    const commandFiles: Record<string, string> = {
+      status: '../cli/src/commands/status.ts',
+      'install-skill': '../cli/src/commands/install-skill.ts',
+      'install-hook': '../cli/src/commands/install-hook.ts',
+    };
+    const globalFlagNames = new Set(GLOBAL_FLAGS.map((f) => f.flag.match(/--([a-z-]+)/)?.[1]));
+    for (const [name, relPath] of Object.entries(commandFiles)) {
+      const src = readFileSync(fileURLToPath(new URL(relPath, import.meta.url)), 'utf8');
+      const flags = new Set([...src.matchAll(/args\.(?:bool|str)\('([a-z][a-z-]*)'\)/g)].map((m) => m[1]));
+      const entry = COMMANDS.find((c) => c.name === name);
+      expect(entry, `catalog is missing an entry for "${name}"`).toBeDefined();
+      for (const flag of flags) {
+        if (globalFlagNames.has(flag)) continue; // documented once, in GLOBAL_FLAGS, not per-command
+        expect(entry?.description, `catalog entry for "${name}" doesn't mention --${flag}`).toContain(`--${flag}`);
+      }
+    }
   });
 });

--- a/tests/skill-emitter-drift.test.ts
+++ b/tests/skill-emitter-drift.test.ts
@@ -1,0 +1,37 @@
+// Drift guard: skills/figma-agent/SKILL.md is a COMMITTED, generated artifact
+// (`npm run emit:skill`) — this test fails the moment it stops matching a fresh
+// render, and separately fails the moment a command is added to COMMAND_MODULES
+// without a matching command-catalog.ts entry (or vice versa) — the point where
+// "added a command, forgot the doc" is actually catchable.
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { renderSkill } from '../cli/src/skill-emitter.ts';
+import { COMMANDS } from '../cli/src/command-catalog.ts';
+import { COMMAND_MODULES } from '../cli/src/figma-agent.ts';
+
+const SKILL_PATH = fileURLToPath(new URL('../skills/figma-agent/SKILL.md', import.meta.url));
+
+describe('skill-emitter-drift', () => {
+  it('the committed SKILL.md matches a fresh renderSkill() output', () => {
+    const committed = readFileSync(SKILL_PATH, 'utf8');
+    const fresh = renderSkill();
+    if (committed !== fresh) {
+      const committedLines = committed.split('\n');
+      const freshLines = fresh.split('\n');
+      const at = committedLines.findIndex((line, i) => line !== freshLines[i]);
+      throw new Error(
+        `skills/figma-agent/SKILL.md is stale at line ${at + 1} — run \`npm run emit:skill\` to regenerate it.\n`
+        + `  committed: ${JSON.stringify(committedLines[at] ?? '<eof>')}\n`
+        + `  emitted:   ${JSON.stringify(freshLines[at] ?? '<eof>')}`,
+      );
+    }
+    expect(committed).toBe(fresh);
+  });
+
+  it('every COMMAND_MODULES key has a command-catalog.ts entry, and vice versa', () => {
+    const moduleNames = Object.keys(COMMAND_MODULES).sort();
+    const catalogNames = COMMANDS.map((c) => c.name).sort();
+    expect(catalogNames).toEqual(moduleNames);
+  });
+});

--- a/tests/status-peek.test.ts
+++ b/tests/status-peek.test.ts
@@ -8,11 +8,26 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { execFileSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { createServer, type Server } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
 import { peek } from '../cli/src/transport/broker-peek.ts';
+
+/** Accepts a TCP connection and then says nothing, forever — the ONLY way to
+ *  actually exercise the deadline-timer branch of peek()'s race (a closed port
+ *  refuses instantly and never reaches it). */
+function startSilentListener(): Promise<{ server: Server; port: number }> {
+  return new Promise((resolvePromise) => {
+    const server = createServer(() => { /* accept, then never speak */ });
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      const port = typeof addr === 'object' && addr !== null ? addr.port : 0;
+      resolvePromise({ server, port });
+    });
+  });
+}
 
 const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
 const CLI_DIST = join(ROOT, 'cli', 'dist', 'figma-agent.js');
@@ -130,13 +145,34 @@ describe('peek() — in-process, real broker + fake plugin', () => {
     expect(result).toMatchObject({ connected: false, idle: true });
   });
 
-  it('a live pid that refuses to answer within the deadline reports degraded, not connected', async () => {
-    // A live pid (this test process) advertised on a port nothing is listening on.
+  it('a closed port refuses INSTANTLY — reports the real refusal reason, never a fabricated timeout label', async () => {
+    // A live pid (this test process) advertised on a port nothing is listening on:
+    // the WS connect fails with a real refusal, well before any deadline could fire.
     writeFileSync(advertisePath, JSON.stringify({ port: 65530, pid: process.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() }));
+    const started = Date.now();
     const result = await peek({ path: advertisePath, queryMs: 200 });
-    expect(result.connected).toBe(false);
+    const elapsed = Date.now() - started;
+    expect(result.connected).toBeNull(); // unknown, not a fabricated "not connected"
     expect(result.degraded).toBeDefined();
+    expect(result.degraded).not.toMatch(/did not answer within 200ms/); // must not relabel a refusal as a timeout
+    expect(elapsed).toBeLessThan(150); // refused well short of the 200ms deadline
     expect(result.broker).toMatchObject({ port: 65530, pid: process.pid });
+  });
+
+  it('a broker that accepts the socket and then goes silent hits the REAL deadline — connected:null, degraded names the timeout', async () => {
+    const { server, port } = await startSilentListener();
+    try {
+      writeFileSync(advertisePath, JSON.stringify({ port, pid: process.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() }));
+      const started = Date.now();
+      const result = await peek({ path: advertisePath, queryMs: 200 });
+      const elapsed = Date.now() - started;
+      expect(result.connected).toBeNull();
+      expect(result.degraded).toMatch(/did not answer within 200ms/);
+      expect(elapsed).toBeGreaterThanOrEqual(190); // actually waited out the deadline, not an instant refusal
+      expect(result.broker).toMatchObject({ port, pid: process.pid });
+    } finally {
+      server.close();
+    }
   });
 });
 

--- a/tests/status-peek.test.ts
+++ b/tests/status-peek.test.ts
@@ -1,0 +1,181 @@
+// `status --peek` must never spawn a broker (see broker-peek.ts's header) — this
+// suite proves it two ways: (1) in-process against a REAL broker + a fake plugin
+// WS, using the same daemon-harness isolation broker-daemon-harness.test.ts
+// established (scratch tmpdir advertisement, ports:[0], a throwing `exit` stub,
+// CHANGES_DIR/BINDS_FILE/UNBOUND_DIR redirected so this never touches the real
+// /tmp state); (2) a real subprocess run of the BUILT cli/dist bundle with no
+// broker at all, proving idle peek exits 0 and creates nothing on disk.
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import WebSocket from 'ws';
+import { peek } from '../cli/src/transport/broker-peek.ts';
+
+const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const CLI_DIST = join(ROOT, 'cli', 'dist', 'figma-agent.js');
+
+type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts');
+
+let scratchDir: string;
+let advertisePath: string;
+let sockets: WebSocket[];
+
+/** Mirrors tests/broker-daemon-harness.test.ts's loadBrokerDaemon — the module-load-time
+ *  CHANGES_DIR/BINDS_FILE/UNBOUND_DIR constants need env vars set BEFORE a fresh import. */
+async function loadBrokerDaemon(): Promise<BrokerDaemonModule> {
+  process.env.FIGMA_AGENT_CHANGES_DIR = scratchDir;
+  process.env.FIGMA_AGENT_BINDS_FILE = join(scratchDir, 'binds.json');
+  process.env.FIGMA_AGENT_UNBOUND_DIR = join(scratchDir, 'unbound-root');
+  vi.resetModules();
+  return import('../cli/src/transport/broker-daemon.ts');
+}
+
+function testExit(): (code: number) => never {
+  return (code: number): never => {
+    throw new Error(`__TEST_BROKER_EXIT__ code=${code}`);
+  };
+}
+
+function connectSocket(port: number): Promise<WebSocket> {
+  return new Promise((resolvePromise, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.once('open', () => resolvePromise(ws));
+    ws.once('error', reject);
+    sockets.push(ws);
+  });
+}
+
+async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, pluginVersion: string, protocolV: number): Promise<void> {
+  ws.send(JSON.stringify({
+    type: 'PLUGIN_HELLO',
+    data: { instanceId, fileName, fileKey: null, caps: ['fileGuard'], pluginVersion, protocolV },
+  }));
+  await new Promise<void>((resolvePromise) => {
+    const handler = (raw: WebSocket.RawData): void => {
+      const msg = JSON.parse(raw.toString()) as { type?: string };
+      if (msg.type === 'SYNC_CONFIG') {
+        ws.off('message', handler);
+        resolvePromise();
+      }
+    };
+    ws.on('message', handler);
+  });
+}
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-peek-'));
+  advertisePath = join(scratchDir, 'broker.json');
+  sockets = [];
+});
+
+afterEach(async () => {
+  for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
+  rmSync(scratchDir, { recursive: true, force: true });
+});
+
+describe('peek() — in-process, real broker + fake plugin', () => {
+  it('idle: no advertisement at all → connected:false, idle:true, no error', async () => {
+    const result = await peek({ path: join(scratchDir, 'none.json') });
+    expect(result).toMatchObject({ connected: false, broker: null, idle: true });
+  });
+
+  it('live broker, no plugin connected → connected:false, broker present, plugins empty', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const result = await peek({ path: advertisePath });
+    expect(result.connected).toBe(false);
+    expect(result.broker).not.toBeNull();
+    expect(result.broker?.pid).toBe(process.pid);
+    expect(result.plugins).toEqual([]);
+  });
+
+  it('a matching plugin build reports versionMatch/protocolMatch true', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number };
+    const ws = await connectSocket(ad.port);
+    await helloPlugin(ws, 'p_1', 'Test File', '0.1.0', 1);
+    const result = await peek({ path: advertisePath });
+    expect(result.connected).toBe(true);
+    expect(result.plugins?.[0]).toMatchObject({ fileName: 'Test File', pluginVersion: '0.1.0', protocolV: 1, versionMatch: true, protocolMatch: true });
+    expect(result.versionMatch).toBe(true);
+    expect(result.protocolMatch).toBe(true);
+  });
+
+  it('a plugin build with no version at all reports versionMatch/protocolMatch null (unknown, not mismatched)', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number };
+    const ws = await connectSocket(ad.port);
+    ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId: 'p_1', fileName: 'Old Build', fileKey: null, caps: ['fileGuard'] } }));
+    await new Promise<void>((resolvePromise) => {
+      const handler = (raw: WebSocket.RawData): void => {
+        const msg = JSON.parse(raw.toString()) as { type?: string };
+        if (msg.type === 'SYNC_CONFIG') { ws.off('message', handler); resolvePromise(); }
+      };
+      ws.on('message', handler);
+    });
+    const result = await peek({ path: advertisePath });
+    expect(result.plugins?.[0]).toMatchObject({ fileName: 'Old Build', versionMatch: null, protocolMatch: null });
+    expect(result.plugins?.[0]).not.toHaveProperty('pluginVersion');
+    expect(result.versionMatch).toBeNull();
+  });
+
+  it('a dead/stale advertisement (pid never existed) reads as idle, never as connected', async () => {
+    writeFileSync(advertisePath, JSON.stringify({ port: 9999, pid: 999999, protocolV: 1, buildMtime: 0, startedAt: 0, lastSeen: Date.now() }));
+    const result = await peek({ path: advertisePath });
+    expect(result).toMatchObject({ connected: false, idle: true });
+  });
+
+  it('a live pid that refuses to answer within the deadline reports degraded, not connected', async () => {
+    // A live pid (this test process) advertised on a port nothing is listening on.
+    writeFileSync(advertisePath, JSON.stringify({ port: 65530, pid: process.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() }));
+    const result = await peek({ path: advertisePath, queryMs: 200 });
+    expect(result.connected).toBe(false);
+    expect(result.degraded).toBeDefined();
+    expect(result.broker).toMatchObject({ port: 65530, pid: process.pid });
+  });
+});
+
+describe('status --peek — subprocess, no broker present', () => {
+  beforeAll(() => {
+    execFileSync(process.execPath, ['scripts/build.mjs', 'cli'], { cwd: ROOT }); // measured ~134ms
+  });
+
+  it('exits 0, reports connected:false, and creates no advertisement file', () => {
+    const noneDir = mkdtempSync(join(tmpdir(), 'fa-peek-subprocess-'));
+    const nonePath = join(noneDir, 'none.json');
+    try {
+      const out = execFileSync(process.execPath, [CLI_DIST, 'status', '--peek', '--json'], {
+        cwd: ROOT,
+        env: { ...process.env, FIGMA_AGENT_BROKER_FILE: nonePath },
+        encoding: 'utf8',
+      });
+      const parsed = JSON.parse(out) as { connected: boolean; idle?: boolean };
+      expect(parsed.connected).toBe(false);
+      expect(parsed.idle).toBe(true);
+      expect(existsSync(nonePath)).toBe(false);
+      expect(readdirSync(noneDir)).toEqual([]); // nothing at all was written, not even a temp file
+    } finally {
+      rmSync(noneDir, { recursive: true, force: true });
+    }
+  });
+
+  it('completes well under the 200ms budget when idle', () => {
+    const noneDir = mkdtempSync(join(tmpdir(), 'fa-peek-budget-'));
+    try {
+      const nonePath = join(noneDir, 'none.json');
+      const started = Date.now();
+      execFileSync(process.execPath, [CLI_DIST, 'status', '--peek'], {
+        cwd: ROOT,
+        env: { ...process.env, FIGMA_AGENT_BROKER_FILE: nonePath },
+      });
+      expect(Date.now() - started).toBeLessThan(2_000); // generous subprocess-startup allowance; peek() itself is <200ms
+    } finally {
+      rmSync(noneDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Supersedes #58 (auto-closed when its stacked base merged in #57 and the branch was deleted; GitHub refuses reopening). Same content, rebased onto main. Part of #56 (slice 1).

**What ships**
- `status --peek`: reads the broker advertisement + one short WS probe; never spawns a broker; exit 0 when idle; reports `versionMatch`/`protocolMatch` (plugin hello metadata now retained). Degraded probe reports `connected: null` with a named reason — never a fabricated `false`.
- `skills/figma-agent/SKILL.md`: thin agent skill whose command reference is emitted from the same catalog that renders `--help`; a drift test fails when the committed artifact differs (also covers `renderHelp` output).
- `install-skill --folder <dir>`: installs the skill (optionally `es-figma-craft`); never overwrites silently; an explicitly requested, unsatisfiable `--with-craft` exits non-zero. Path resolution anchored by package.json walk-up — works from both source and the shipped bundle (verified by a subprocess test of `cli/dist`).
- `install-hook [--dry-run]`: SessionStart hook for Claude Code settings; confirm before write, timestamped backup, abort on invalid JSON or on concurrent modification during the prompt; preserves tab/space indentation.

**Review record**: stage-4 review + fix round + focused re-verify all on #58 (both blockers reproduced, fixed test-first, then re-verified dead from the built bundle).

**Gates** (worktree, rebased head): typecheck 0, lint:comments 0, build 0, tests 1480/1481 — the one failure is the pre-existing load-dependent harness flake tracked in #59, reproduced on untouched main.

**Not verified (owner live-test items)**: hook firing in a real session; `versionMatch: true` against a live plugin build; real `~/.claude/settings.json` install (tests are fixture-only by design).