### PR TITLE
feat(cli,plugin): agent presence label, status --wait, and a relaunch button

### DIFF
--- a/cli/src/command-catalog.ts
+++ b/cli/src/command-catalog.ts
@@ -206,9 +206,10 @@ export const GLOBAL_FLAGS: GlobalFlagEntry[] = [
     flag: '--agent <id> | FIGMA_AGENT_ID',
     description:
       'which harness sent this (the flag wins over the env var) — shown in the panel activity feed '
-      + '("claude · Created frame ..."). Trimmed, control characters stripped, capped at 32 chars. '
-      + "Omitted entirely when unset — an unlabelled request's wire frame is byte-identical to a "
-      + "pre-flag CLI's; the panel's own \"cli\" default is applied at render time, never stamped "
-      + 'onto the wire.',
+      + '("claude · Created frame ..."). Trimmed, then validated against an ALLOWLIST: lowercase '
+      + 'letters, digits, ".", "_", "-" only, 1-32 characters — anything else refuses with '
+      + "E_INVALID_ARGS naming the allowed set, it is never silently sanitized. Omitted entirely "
+      + "when unset — an unlabelled request's wire frame is byte-identical to a pre-flag CLI's; the "
+      + 'panel\'s own "cli" default is applied at render time, never stamped onto the wire.',
   },
 ];

--- a/cli/src/command-catalog.ts
+++ b/cli/src/command-catalog.ts
@@ -29,9 +29,13 @@ export const COMMANDS: CommandCatalogEntry[] = [
   {
     name: 'status',
     description:
-      'Broker + plugin connection info [--peek [--json]] — --peek reads only the /tmp broker '
-      + 'advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted '
-      + 'for compatibility but is a no-op: output is always the same single JSON object.',
+      'Broker + plugin connection info [--peek [--json]] [--wait [--timeout N]] — --peek reads '
+      + 'only the /tmp broker advertisement plus one short broker query; it NEVER spawns a broker. '
+      + '--json is accepted for compatibility but is a no-op: output is always the same single JSON '
+      + 'object. --wait blocks (MAY spawn a broker) until a matching plugin registers, printing a '
+      + 'figma:// deep link (when one can be built) to stderr immediately; --timeout N is in '
+      + 'SECONDS, default 60 — on timeout this exits non-zero with E_NO_PLUGIN instead of the '
+      + 'normal payload.',
   },
   { name: 'seat', description: 'Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]' },
   {
@@ -197,5 +201,14 @@ export const GLOBAL_FLAGS: GlobalFlagEntry[] = [
       'declare that this command only READS. Skips the per-file mutation queue (backlog 1.1+2.6+4.3). '
       + 'TRUSTED, NOT ENFORCED — the plugin sandbox cannot verify it, so a mis-declared mutation can '
       + "interleave with another agent's work.",
+  },
+  {
+    flag: '--agent <id> | FIGMA_AGENT_ID',
+    description:
+      'which harness sent this (the flag wins over the env var) — shown in the panel activity feed '
+      + '("claude · Created frame ..."). Trimmed, control characters stripped, capped at 32 chars. '
+      + "Omitted entirely when unset — an unlabelled request's wire frame is byte-identical to a "
+      + "pre-flag CLI's; the panel's own \"cli\" default is applied at render time, never stamped "
+      + 'onto the wire.',
   },
 ];

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -10,7 +10,41 @@ import type { CommandArgs } from '../figma-agent.ts';
 import { fetchBrokerHello, runCommand } from '../transport/broker-client.ts';
 import { ensureBroker } from '../transport/broker-discovery.ts';
 import { peek } from '../transport/broker-peek.ts';
+import { waitForPlugin } from '../transport/plugin-wait.ts';
+import { buildDeepLink, type DeepLinkEntry } from '../transport/figma-deep-link.ts';
+import { fileIdentity, readBindCache, readBindMarker } from '../transport/project-bind.ts';
 import { CliError } from '../transport/protocol-helpers.ts';
+
+// auto-connect slice 2 — `--wait`'s own default, in SECONDS (not ms — every other
+// `--timeout` in this CLI is ms; this one follows the usecases.md gherkin's own
+// "--timeout 5" ⇒ "5s budget" wording, so `--help`/the skill say so explicitly).
+const DEFAULT_WAIT_SECONDS = 60;
+
+/**
+ * Find the bind-marker entry that `status --wait` should build a deep link from:
+ * an exact fileNameSlug match for `--file` when given, else the single most-
+ * recently-bound entry across every known project (an unambiguous best guess is
+ * more useful than no link at all when the caller didn't say which file). Reads
+ * the restart-survival cache + each project's own durable marker — the same
+ * source `figma-agent bind --list` reads.
+ */
+function findBoundEntry(wantedFile: string | undefined): DeepLinkEntry | null {
+  const cache = readBindCache();
+  const wantedSlug = wantedFile ? fileIdentity(null, wantedFile) : null;
+  let best: { fileKey: string | null; boundAt: number } | null = null;
+  for (const projectDir of cache.projectDirs) {
+    const marker = readBindMarker(projectDir);
+    if (!marker) continue;
+    for (const entry of marker.bindings) {
+      if (wantedSlug !== null) {
+        if (entry.fileNameSlug === wantedSlug) return { fileKey: entry.fileKey };
+        continue;
+      }
+      if (!best || entry.boundAt > best.boundAt) best = { fileKey: entry.fileKey, boundAt: entry.boundAt };
+    }
+  }
+  return wantedSlug !== null ? null : (best ? { fileKey: best.fileKey } : null);
+}
 // Concurrency & jobs (backlog 1.1+2.6+4.3), phase 02 §3 — each row now carries
 // `runningJob`/`queueDepth` (broker-status.ts's `buildBrokerHelloData`, given a
 // `jobStatusFor`). This CLI is JSON-only (no `--json` flag exists — figma-agent always
@@ -25,7 +59,37 @@ export async function run(args: CommandArgs): Promise<unknown> {
   // compatibility but is a documented no-op: this CLI always prints one JSON object.
   if (args.bool('peek')) return peek();
 
+  // auto-connect slice 2 — `--wait` MAY spawn: a plugin has nowhere to register
+  // with otherwise. Unlike `--peek`, `ensureBroker()` below runs unconditionally.
+  const waiting = args.bool('wait');
+  const wantedFile = args.str('file');
+  let waitedMs: number | undefined;
+
   const ad = await ensureBroker();
+
+  if (waiting) {
+    const timeoutMs = (args.num('timeout') ?? DEFAULT_WAIT_SECONDS) * 1_000;
+    // Computed and printed BEFORE the wait (Hick's Law, usecases.md:128) — the
+    // human's next action must be visible the instant the wait starts, not only
+    // after it fails.
+    const link = buildDeepLink(findBoundEntry(wantedFile));
+    process.stderr.write(link.url ? `${link.url}\n` : `(no deep link: ${link.reason})\n`);
+    process.stderr.write('Open the file above, then open the figma-agent plugin panel.\n');
+
+    const result = await waitForPlugin({
+      port: ad.port,
+      timeoutMs,
+      fileFilter: wantedFile,
+      instanceFilter: args.str('instance'),
+    });
+    if (!result.registered) {
+      throw new CliError(
+        'E_NO_PLUGIN',
+        `${wantedFile ?? 'no file specified'} — open Plugins > figma-agent (deep link already printed to stderr)`,
+      );
+    }
+    waitedMs = result.waitedMs;
+  }
 
   let hello: Record<string, unknown> = {};
   try {
@@ -55,15 +119,14 @@ export async function run(args: CommandArgs): Promise<unknown> {
   // FIGMA_AGENT_FILE only, while the STATUS round-trip below now carries `expectedFile`
   // (the global --file flag, set once in figma-agent.ts main()) — so filter `plugins[]`
   // and derive activePlugin/connected LOCALLY instead of trusting the broker's env-only view.
-  const wanted = args.str('file');            // status takes the same global flag
-  const plugins = wanted ? all.filter((p) => fileMatches(p.fileName, wanted, true)) : all;
-  const activePlugin = wanted
+  const plugins = wantedFile ? all.filter((p) => fileMatches(p.fileName, wantedFile, true)) : all;
+  const activePlugin = wantedFile
     ? plugins[0]?.fileName ?? null                       // the file the caller asked about
     : (hello.activePlugin as string | null | undefined) ?? null;
 
   // The ACTIVE plugin's liveness (legacy mirror source). `pluginConnected` is true
   // only when a routable target exists (respects --file / FIGMA_AGENT_FILE).
-  let connected = wanted ? plugins.length > 0 : hello.pluginConnected === true;
+  let connected = wantedFile ? plugins.length > 0 : hello.pluginConnected === true;
   let state = (hello.pluginState as string | undefined) ?? (connected ? 'connected' : 'disconnected');
   let lastHeartbeatAge = (hello.lastHeartbeatAge as number | null | undefined) ?? null;
   let scene: Record<string, unknown> | null =
@@ -94,12 +157,15 @@ export async function run(args: CommandArgs): Promise<unknown> {
   // still see what IS connected even though it doesn't match what they asked about.
   return {
     broker, plugins, activePlugin, plugin, protocolVersion: broker.protocolVersion,
-    ...(wanted ? { pluginsAll: all } : {}),
+    ...(wantedFile ? { pluginsAll: all } : {}),
     // Broker-restart reconnect visibility — a HINT from last-known state, never a live
     // plugin (it must never appear in `plugins`/`pluginsAll` above); present only when
     // the broker actually has one to report, same mirror-only-when-non-empty contract
     // as `senderMismatchCount`/`legacyMigrationDeferred` on `broker` above.
     ...(Array.isArray(hello.awaitingReconnect) && hello.awaitingReconnect.length > 0
       && { awaitingReconnect: hello.awaitingReconnect }),
+    // auto-connect slice 2 — present only when `--wait` actually waited (mirror-only-
+    // when-relevant contract, same as the fields above).
+    ...(waitedMs !== undefined && { waitedMs }),
   };
 }

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -100,42 +100,39 @@ export const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<u
   'install-hook': installHook,
 };
 
-const AGENT_MAX_LEN = 32;
-
-/**
- * Drop C0 control characters (code points below 32) and DEL (127) — a plain numeric
- * code-point filter, not a regex character class, so this source file never has to
- * carry an actual control byte or an escape sequence for one.
- */
-function stripControlChars(value: string): string {
-  let out = '';
-  for (const ch of value) {
-    const code = ch.codePointAt(0) ?? 0;
-    if (code >= 32 && code !== 127) out += ch;
-  }
-  return out;
-}
+// Fix round (finding: a blocklist-based filter let C1 controls, bidi override/format
+// characters, and a surrogate-splitting truncation all through). An ALLOWLIST closes
+// all three at once: lowercase ASCII letters, digits, dot, underscore, hyphen, 1-32
+// characters — nothing outside that set can carry a control/bidi/format character or
+// need mid-codepoint truncation, so no separate strip/cap step is needed at all.
+const AGENT_ALLOWLIST_RE = /^[a-z0-9._-]{1,32}$/;
+const AGENT_ALLOWLIST_DESCRIPTION = 'lowercase letters, digits, ".", "_", "-" only, 1-32 characters';
 
 /**
  * `--agent <id>` or `FIGMA_AGENT_ID` (flag wins) — which harness the panel's activity
  * feed should attribute this request to. Same empty-value guard shape as `--file`/
- * `--instance` below; trimmed, control characters stripped, capped at 32 before it can
- * ever reach a DOM span (the panel renders it via `textContent`, never `innerHTML`, but
- * a control char is still garbage in a UI label). Returns `undefined` for "unset" so the
- * envelope stays additive — the `cli` default is applied at RENDER time in the panel,
- * never stamped onto the wire here.
+ * `--instance` below; trimmed, then validated against `AGENT_ALLOWLIST_RE` — anything
+ * outside it refuses with `E_INVALID_ARGS` naming the allowed set, it is never
+ * silently sanitized. Returns `undefined` for "unset" so the envelope stays
+ * additive — the `cli` default is applied at RENDER time in the panel, never
+ * stamped onto the wire here.
  */
 // Exported so tests/agent-label-envelope.test.ts can unit-test the guards (empty/
-// length/control-char) directly, the same way COMMAND_MODULES is exported above —
-// without needing a live broker or a subprocess just to exercise pure validation.
+// allowlist) directly, the same way COMMAND_MODULES is exported above — without
+// needing a live broker or a subprocess just to exercise pure validation.
 export function resolveAgent(args: CommandArgs): string | undefined {
   if (args.bool('agent') && (args.str('agent') ?? '').trim() === '') {
     printErrorJson(new CliError('E_INVALID_ARGS', '--agent needs a value, e.g. --agent claude'));
   }
   const raw = (args.str('agent') ?? process.env.FIGMA_AGENT_ID ?? '').trim();
   if (raw === '') return undefined;
-  const clean = stripControlChars(raw);
-  return clean === '' ? undefined : clean.slice(0, AGENT_MAX_LEN);
+  if (!AGENT_ALLOWLIST_RE.test(raw)) {
+    printErrorJson(new CliError(
+      'E_INVALID_ARGS',
+      `--agent value is invalid — allowed: ${AGENT_ALLOWLIST_DESCRIPTION} (got ${JSON.stringify(raw)})`,
+    ));
+  }
+  return raw;
 }
 
 async function main(): Promise<void> {

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -12,7 +12,7 @@ import { pathToFileURL } from 'node:url';
 import { runBrokerDaemon } from './transport/broker-daemon.ts';
 import { parseArgs, type CommandArgs } from './arg-parse.ts';
 import { CliError } from './transport/protocol-helpers.ts';
-import { getLastFileContext, setExpectedFile, setExpectedInstance, setProjectDir, setReadOnly } from './transport/broker-client.ts';
+import { getLastFileContext, setAgent, setExpectedFile, setExpectedInstance, setProjectDir, setReadOnly } from './transport/broker-client.ts';
 import { printErrorJson, printJson, withFileContext } from './util/json-out.ts';
 import { HELP } from './help-text.ts';
 import { renderSkill } from './skill-emitter.ts';
@@ -100,6 +100,44 @@ export const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<u
   'install-hook': installHook,
 };
 
+const AGENT_MAX_LEN = 32;
+
+/**
+ * Drop C0 control characters (code points below 32) and DEL (127) — a plain numeric
+ * code-point filter, not a regex character class, so this source file never has to
+ * carry an actual control byte or an escape sequence for one.
+ */
+function stripControlChars(value: string): string {
+  let out = '';
+  for (const ch of value) {
+    const code = ch.codePointAt(0) ?? 0;
+    if (code >= 32 && code !== 127) out += ch;
+  }
+  return out;
+}
+
+/**
+ * `--agent <id>` or `FIGMA_AGENT_ID` (flag wins) — which harness the panel's activity
+ * feed should attribute this request to. Same empty-value guard shape as `--file`/
+ * `--instance` below; trimmed, control characters stripped, capped at 32 before it can
+ * ever reach a DOM span (the panel renders it via `textContent`, never `innerHTML`, but
+ * a control char is still garbage in a UI label). Returns `undefined` for "unset" so the
+ * envelope stays additive — the `cli` default is applied at RENDER time in the panel,
+ * never stamped onto the wire here.
+ */
+// Exported so tests/agent-label-envelope.test.ts can unit-test the guards (empty/
+// length/control-char) directly, the same way COMMAND_MODULES is exported above —
+// without needing a live broker or a subprocess just to exercise pure validation.
+export function resolveAgent(args: CommandArgs): string | undefined {
+  if (args.bool('agent') && (args.str('agent') ?? '').trim() === '') {
+    printErrorJson(new CliError('E_INVALID_ARGS', '--agent needs a value, e.g. --agent claude'));
+  }
+  const raw = (args.str('agent') ?? process.env.FIGMA_AGENT_ID ?? '').trim();
+  if (raw === '') return undefined;
+  const clean = stripControlChars(raw);
+  return clean === '' ? undefined : clean.slice(0, AGENT_MAX_LEN);
+}
+
 async function main(): Promise<void> {
   const argv = process.argv.slice(2);
   const name = argv[0];
@@ -146,6 +184,7 @@ async function main(): Promise<void> {
   setExpectedInstance(args.str('instance')); // global flag, same choke point as --file
   setProjectDir(resolve(args.str('dir') ?? process.cwd())); // registry-integrity phase 01 §1
   setReadOnly(args.bool('read-only')); // concurrency & jobs (backlog 1.1+2.6+4.3) — TRUSTED, not enforced
+  setAgent(resolveAgent(args)); // auto-connect slice 2 — same choke point as --file/--instance
   try {
     const result = await command.run(args);
     printJson(withFileContext(result));

--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -46,6 +46,7 @@ let expectedInstance: string | undefined;
 let lastFileContext: FileContext | undefined;
 let projectDir: string | undefined;
 let readOnlyGlobal = false;
+let agentId: string | undefined;
 
 /** Set once per CLI invocation from the global --file flag; stamped on every request envelope. */
 export function setExpectedFile(name: string | undefined): void { expectedFile = name; }
@@ -74,6 +75,13 @@ export function setProjectDir(dir: string | undefined): void { projectDir = dir;
  * wins over this global — see `runCommand`'s own `opts?.readOnly ?? readOnlyGlobal`.
  */
 export function setReadOnly(v: boolean): void { readOnlyGlobal = v; }
+
+/**
+ * Set once per CLI invocation from the global `--agent`/`FIGMA_AGENT_ID` value; stamped
+ * on every request envelope the SAME choke point `setExpectedFile` uses (auto-connect
+ * slice 2). `undefined` (the default) leaves the frame byte-identical to a pre-flag CLI's.
+ */
+export function setAgent(id: string | undefined): void { agentId = id; }
 
 /**
  * Stage-4 fix round (minor 8, ruling Q4) — `--read-only` is a PARTIAL hardening, not a
@@ -187,7 +195,7 @@ export function exchange(
     ws.on('error', (err) => finish(() => reject(new CliError('E_NO_BROKER', `broker socket error: ${err.message}`))));
 
     try {
-      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity, expectedFile, projectDir, readOnly, expectedInstance));
+      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity, expectedFile, projectDir, readOnly, expectedInstance, agentId));
     } catch (err) {
       finish(() => reject(new CliError('E_NO_BROKER', `failed to send request: ${(err as Error).message}`)));
     }

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -776,7 +776,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // HELLO time, before this binding existed — its idle timer is still running on the
     // broker's cwd default (or a stale project's). Push the newly-bound project's own
     // idle window now, so it takes effect without waiting for a reconnect.
-    if (hit) sendEvent(hit.ws, 'SYNC_CONFIG', { idleMs: readIdleMsFor(projectDir) });
+    // `bound: true` — a plugin already connected when this bind lands now qualifies for
+    // the relaunch button too, same as one that connects AFTER the bind already existed.
+    if (hit) sendEvent(hit.ws, 'SYNC_CONFIG', { idleMs: readIdleMsFor(projectDir), bound: true });
     reply({ fileName, projectDir, fileKey, pendingKey: fileKey === null, migratedCount, migratedEditCount, migratedErrorCount });
   };
 
@@ -1434,7 +1436,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         schedulePluginSetPersist();
         const helloFileKey = (helloScene?.fileKey as string | null | undefined) ?? null;
         const helloBound = resolveProjectDir(fileIdentity(helloFileKey, helloFileName), st.bindIndex);
-        sendEvent(ws, 'SYNC_CONFIG', { idleMs: helloBound ? readIdleMsFor(helloBound) : idleMs });
+        // auto-connect slice 2 (fix round) — `bound` rides the SAME lookup already done
+        // for `idleMs` above (no second bind-index query). The plugin's own main thread
+        // has no filesystem access and cannot read design/figma-bind.json itself; this is
+        // the one place that already resolves "is this file bound" at HELLO time, so it
+        // is the cheapest correct place to also answer it — main.ts gates
+        // `setRelaunchData` on this flag instead of writing to every unbound document.
+        sendEvent(ws, 'SYNC_CONFIG', { idleMs: helloBound ? readIdleMsFor(helloBound) : idleMs, bound: Boolean(helloBound) });
         flushWaiting(); // deliver any requests parked during the reconnect gap
         broadcastPeers();
       } else if (msg.type === 'PING') {

--- a/cli/src/transport/figma-deep-link.ts
+++ b/cli/src/transport/figma-deep-link.ts
@@ -27,6 +27,12 @@ const NO_FILE_KEY_REASON = 'file has no fileKey (Free plan) — open the file ma
  */
 export function buildDeepLink(entry: DeepLinkEntry | null): DeepLinkResult {
   if (entry === null) return { url: null, reason: NO_BINDING_REASON };
-  if (entry.fileKey === null) return { url: null, reason: NO_FILE_KEY_REASON };
+  // `entry.fileKey` is typed `string | null`, but the value crossed a trust boundary
+  // (JSON parsed from a file a user or another tool can hand-edit) before it got here —
+  // an `=== null` check alone is a type-level guard on a runtime value the type cannot
+  // actually promise. A missing/wrong-typed/empty fileKey must land on the SAME honest
+  // "no link" answer as the documented null case, never `figma://file/undefined` or
+  // `figma://file/`.
+  if (typeof entry.fileKey !== 'string' || entry.fileKey === '') return { url: null, reason: NO_FILE_KEY_REASON };
   return { url: `figma://file/${entry.fileKey}`, reason: null };
 }

--- a/cli/src/transport/figma-deep-link.ts
+++ b/cli/src/transport/figma-deep-link.ts
@@ -1,0 +1,32 @@
+// Pure: a bind-marker entry (or its absence) → a `figma://` deep link, or an honest
+// `null` + a named reason. Never fabricates a link — a URL that opens nothing is worse
+// than admitting there isn't one (house rule: honest reporting). Consumed by
+// `status --wait` (cli/src/commands/status.ts), which does the (impure) lookup of
+// WHICH entry applies; this module only turns one entry into a URL or a reason.
+
+/** The one field this module actually needs — a structural subset of
+ *  `BindMarkerEntry` (project-bind.ts) so this stays independently testable
+ *  without importing that module's fs-touching neighbors. */
+export interface DeepLinkEntry {
+  fileKey: string | null;
+}
+
+export interface DeepLinkResult {
+  url: string | null;
+  reason: string | null;
+}
+
+const NO_BINDING_REASON = 'no file bound — run `figma-agent bind --file "<name>" --dir <projectDir>`';
+const NO_FILE_KEY_REASON = 'file has no fileKey (Free plan) — open the file manually';
+
+/**
+ * `entry === null` → no binding at all was found for the file in question.
+ * `entry.fileKey === null` → bound, but the file has never carried an org fileKey
+ * (a Figma Free file, or one bound before its first connect) — a deep link cannot be
+ * built for it. `entry.fileKey` a string → `figma://file/<fileKey>`.
+ */
+export function buildDeepLink(entry: DeepLinkEntry | null): DeepLinkResult {
+  if (entry === null) return { url: null, reason: NO_BINDING_REASON };
+  if (entry.fileKey === null) return { url: null, reason: NO_FILE_KEY_REASON };
+  return { url: `figma://file/${entry.fileKey}`, reason: null };
+}

--- a/cli/src/transport/plugin-wait.ts
+++ b/cli/src/transport/plugin-wait.ts
@@ -1,0 +1,70 @@
+// The poll-until-registered loop behind `status --wait` — unlike `broker-peek.ts`,
+// this MAY spawn a broker (a plugin has nowhere to register with otherwise); the
+// caller (status.ts) is responsible for `ensureBroker()` before calling this.
+// Injectable clock/sleep/fetch so the timeout path is unit-testable without a real
+// 500ms-stepped clock.
+import { fetchBrokerHello } from './broker-client.ts';
+import { fileMatches } from '../../../shared/file-match.ts';
+import type { PluginStatusEntry } from '../../../shared/protocol.ts';
+
+export interface WaitOptions {
+  port: number;
+  timeoutMs: number;
+  /** `--file` — matched loosely (substring, case-insensitive), same as routing. */
+  fileFilter?: string | null;
+  /** `--instance` — matched exactly; beats `fileFilter` when both are somehow set. */
+  instanceFilter?: string | null;
+  pollIntervalMs?: number;
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+  fetchHello?: (port: number) => Promise<Record<string, unknown>>;
+}
+
+export interface WaitResult {
+  registered: boolean;
+  waitedMs: number;
+  /** The BROKER_HELLO data from the poll that matched — present only when registered. */
+  hello?: Record<string, unknown>;
+}
+
+const DEFAULT_POLL_MS = 500;
+
+function matchesFilter(
+  plugins: readonly PluginStatusEntry[],
+  fileFilter?: string | null,
+  instanceFilter?: string | null,
+): boolean {
+  if (instanceFilter) return plugins.some((p) => p.instanceId === instanceFilter);
+  if (fileFilter) return plugins.some((p) => fileMatches(p.fileName ?? undefined, fileFilter, true));
+  return plugins.length > 0;
+}
+
+/** Poll `fetchBrokerHello(port)` every `pollIntervalMs` until a matching plugin
+ *  registers or `timeoutMs` elapses. A broker hiccup mid-wait (a failed fetch) is
+ *  NOT a failure of the wait itself — it just tries again next tick, same as a
+ *  poll that simply found nothing yet. */
+export async function waitForPlugin(opts: WaitOptions): Promise<WaitResult> {
+  const pollMs = opts.pollIntervalMs ?? DEFAULT_POLL_MS;
+  const now = opts.now ?? Date.now;
+  const sleep = opts.sleep ?? ((ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms)));
+  const fetchHello = opts.fetchHello ?? fetchBrokerHello;
+  const startedAt = now();
+  const deadline = startedAt + opts.timeoutMs;
+
+  for (;;) {
+    let hello: Record<string, unknown> | null = null;
+    try {
+      hello = await fetchHello(opts.port);
+    } catch {
+      hello = null;
+    }
+    const plugins = Array.isArray(hello?.plugins) ? (hello.plugins as PluginStatusEntry[]) : [];
+    if (matchesFilter(plugins, opts.fileFilter, opts.instanceFilter)) {
+      return { registered: true, waitedMs: now() - startedAt, hello: hello ?? undefined };
+    }
+    if (now() >= deadline) {
+      return { registered: false, waitedMs: now() - startedAt };
+    }
+    await sleep(pollMs);
+  }
+}

--- a/cli/src/transport/plugin-wait.ts
+++ b/cli/src/transport/plugin-wait.ts
@@ -4,13 +4,18 @@
 // Injectable clock/sleep/fetch so the timeout path is unit-testable without a real
 // 500ms-stepped clock.
 import { fetchBrokerHello } from './broker-client.ts';
-import { fileMatches } from '../../../shared/file-match.ts';
+import { fileIdentity } from './project-bind.ts';
 import type { PluginStatusEntry } from '../../../shared/protocol.ts';
 
 export interface WaitOptions {
   port: number;
   timeoutMs: number;
-  /** `--file` — matched loosely (substring, case-insensitive), same as routing. */
+  /**
+   * `--file` — matched via the SAME name-identity normalization
+   * (`fileIdentity(null, name)`, i.e. `project-bind.ts`'s `safeSlug`) that
+   * `figma-deep-link.ts`'s bind-marker lookup already uses (fix round: these two
+   * halves of one `--wait` command must never disagree about which file was meant).
+   */
   fileFilter?: string | null;
   /** `--instance` — matched exactly; beats `fileFilter` when both are somehow set. */
   instanceFilter?: string | null;
@@ -35,7 +40,10 @@ function matchesFilter(
   instanceFilter?: string | null,
 ): boolean {
   if (instanceFilter) return plugins.some((p) => p.instanceId === instanceFilter);
-  if (fileFilter) return plugins.some((p) => fileMatches(p.fileName ?? undefined, fileFilter, true));
+  if (fileFilter) {
+    const wantedSlug = fileIdentity(null, fileFilter);
+    return plugins.some((p) => fileIdentity(null, p.fileName ?? null) === wantedSlug);
+  }
   return plugins.length > 0;
 }
 

--- a/cli/src/transport/project-bind.ts
+++ b/cli/src/transport/project-bind.ts
@@ -114,15 +114,36 @@ export function bindMarkerPath(projectDir: string): string {
   return join(projectDir, 'design', BIND_MARKER_FILENAME);
 }
 
+/**
+ * Fix round — `bindings` being an array said nothing about what its ENTRIES look
+ * like; a hand-edited or corrupted marker could hand a caller (figma-deep-link.ts,
+ * bind.ts's `listBindings`) a `fileKey` of the wrong type, an empty/wrong-typed
+ * `fileNameSlug`, or a non-finite `boundAt` — and `figma-deep-link.ts`'s `=== null`
+ * check is a type-level guard on a value that crossed exactly this trust boundary.
+ * `fileKey: null` is legitimate (a Free-plan file, or one bound before its first
+ * connect) and passes; anything NOT `string | null` does not.
+ */
+function isValidBindMarkerEntry(value: unknown): value is BindMarkerEntry {
+  if (value === null || typeof value !== 'object') return false;
+  const e = value as Record<string, unknown>;
+  const fileKeyOk = e.fileKey === null || typeof e.fileKey === 'string';
+  const slugOk = typeof e.fileNameSlug === 'string' && e.fileNameSlug !== '';
+  const boundAtOk = typeof e.boundAt === 'number' && Number.isFinite(e.boundAt);
+  return fileKeyOk && slugOk && boundAtOk;
+}
+
 /** Read a project's own binding marker. Malformed/absent → null — never throws, so a
- *  broken marker can't crash the broker; the caller treats it as "nothing recorded here". */
+ *  broken marker can't crash the broker; the caller treats it as "nothing recorded here".
+ *  Individual malformed ENTRIES are dropped rather than failing the whole file — a single
+ *  hand-edited bad row must never hide every other project's good binding. */
 export function readBindMarker(projectDir: string): BindMarkerFile | null {
   const path = bindMarkerPath(projectDir);
   if (!existsSync(path)) return null;
   try {
     const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
     if (parsed && typeof parsed === 'object' && Array.isArray((parsed as BindMarkerFile).bindings)) {
-      return parsed as BindMarkerFile;
+      const raw = parsed as BindMarkerFile;
+      return { ...raw, bindings: raw.bindings.filter(isValidBindMarkerEntry) };
     }
     return null;
   } catch {

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -5268,12 +5268,25 @@
     title: "design:os by JANG",
     themeColors: true
   });
-  try {
-    figma.root.setRelaunchData({ open: "Reconnect figma-agent" });
-  } catch (err) {
-    console.warn("setRelaunchData refused:", err);
-  }
   var bootSkipped = [];
+  var relaunchAttempted = false;
+  var relaunchUnboundNoted = false;
+  function maybeSetRelaunchData(bound) {
+    if (relaunchAttempted) return;
+    if (!bound) {
+      if (!relaunchUnboundNoted) {
+        relaunchUnboundNoted = true;
+        bootSkipped.push("relaunchData: skipped (file not bound \u2014 run `figma-agent bind`)");
+      }
+      return;
+    }
+    relaunchAttempted = true;
+    try {
+      figma.root.setRelaunchData({ open: "Reconnect figma-agent" });
+    } catch (err) {
+      bootSkipped.push(`relaunchData: refused (${err instanceof Error ? err.message : String(err)})`);
+    }
+  }
   function selectionSummary() {
     const sel = figma.currentPage.selection;
     return { selectionName: sel.length > 0 ? sel[0].name : null, selectionCount: sel.length };
@@ -5473,8 +5486,10 @@
   figma.ui.onmessage = async (msg) => {
     const chrome = msg;
     if (chrome && chrome.type === "SYNC_CONFIG") {
-      const raw = chrome.data?.idleMs;
+      const data = chrome.data;
+      const raw = data?.idleMs;
       if (typeof raw === "number" && Number.isFinite(raw)) idleMs = Math.max(MIN_IDLE_MS, Math.floor(raw));
+      maybeSetRelaunchData(data?.bound === true);
       return;
     }
     if (chrome && chrome.type === "SYNC_DONE") {

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -5268,6 +5268,11 @@
     title: "design:os by JANG",
     themeColors: true
   });
+  try {
+    figma.root.setRelaunchData({ open: "Reconnect figma-agent" });
+  } catch (err) {
+    console.warn("setRelaunchData refused:", err);
+  }
   var bootSkipped = [];
   function selectionSummary() {
     const sel = figma.currentPage.selection;

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -70,6 +70,18 @@ figma.showUI(__html__, {
   visible: true, width: PANEL_WIDTH, height: PANEL_HEIGHT, title: 'design:os by JANG', themeColors: true,
 });
 
+// auto-connect slice 2 — offer a "Reconnect figma-agent" entry in Figma's own
+// relaunch button/menu once this plugin has run on the file. UNVERIFIED here (zero
+// prior `setRelaunchData` use in this repo): it writes to the document, may mark it
+// dirty, may be refused on a file the user cannot edit, and the button itself only
+// appears after this call has actually landed once — see the phase's live-test items.
+// Gated so a refusal here can never break plugin startup; logged, not swallowed.
+try {
+  figma.root.setRelaunchData({ open: 'Reconnect figma-agent' });
+} catch (err) {
+  console.warn('setRelaunchData refused:', err);
+}
+
 // Absorption phase-03 (FigJam) — which design-only boot capabilities this session
 // consciously skipped, surfaced via STATUS's `bootSkipped` (same present-only-when-
 // non-empty contract as the broker's senderMismatchCount/legacyMigrationDeferred).

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -70,18 +70,6 @@ figma.showUI(__html__, {
   visible: true, width: PANEL_WIDTH, height: PANEL_HEIGHT, title: 'design:os by JANG', themeColors: true,
 });
 
-// auto-connect slice 2 — offer a "Reconnect figma-agent" entry in Figma's own
-// relaunch button/menu once this plugin has run on the file. UNVERIFIED here (zero
-// prior `setRelaunchData` use in this repo): it writes to the document, may mark it
-// dirty, may be refused on a file the user cannot edit, and the button itself only
-// appears after this call has actually landed once — see the phase's live-test items.
-// Gated so a refusal here can never break plugin startup; logged, not swallowed.
-try {
-  figma.root.setRelaunchData({ open: 'Reconnect figma-agent' });
-} catch (err) {
-  console.warn('setRelaunchData refused:', err);
-}
-
 // Absorption phase-03 (FigJam) — which design-only boot capabilities this session
 // consciously skipped, surfaced via STATUS's `bootSkipped` (same present-only-when-
 // non-empty contract as the broker's senderMismatchCount/legacyMigrationDeferred).
@@ -92,6 +80,45 @@ try {
 // as real, mutable state (not a hardcoded `[]` at the call site) so a future editor
 // surface has somewhere to push an entry without a STATUS payload shape change.
 const bootSkipped: string[] = [];
+
+// auto-connect slice 2 (fix round) — offer a "Reconnect figma-agent" entry in
+// Figma's own relaunch menu, but ONLY on a file the CLI has actually bound
+// (`figma-agent bind`) — never write into a document nobody asked this plugin to
+// manage. The plugin's main thread has no filesystem access and cannot read
+// design/figma-bind.json itself, so it waits for the broker's own answer: the
+// SAME SYNC_CONFIG event that already carries the idle window now also carries
+// `bound` (broker-daemon.ts's PLUGIN_HELLO/PROJECT_BIND handlers, same bind-index
+// lookup already done for idleMs — no new round trip). Fires at most ONCE per
+// plugin session (`relaunchAttempted`), the first time `bound` reads true —
+// still "once at startup" in spirit, just gated on the first honest answer
+// instead of firing blind before anyone could know. UNVERIFIED here (zero prior
+// `setRelaunchData` use in this repo): it writes to the document, may mark it
+// dirty, may be refused on a file the user cannot edit, and the button itself
+// only appears after this call has actually landed once — see the phase's
+// live-test items. A refusal or a deliberate skip is never a bare console-only
+// no-op: both land on `bootSkipped` so `status` and the live test have
+// something to read.
+let relaunchAttempted = false;
+let relaunchUnboundNoted = false;
+function maybeSetRelaunchData(bound: boolean): void {
+  if (relaunchAttempted) return;
+  if (!bound) {
+    // Logged once, not on every reconnect while the file stays unbound — this is the
+    // ordinary state for a fresh/unbound session, not a fault; `bootSkipped` still
+    // carries it once so a live test (or `status`) can see WHY no button appeared.
+    if (!relaunchUnboundNoted) {
+      relaunchUnboundNoted = true;
+      bootSkipped.push('relaunchData: skipped (file not bound — run `figma-agent bind`)');
+    }
+    return;
+  }
+  relaunchAttempted = true;
+  try {
+    figma.root.setRelaunchData({ open: 'Reconnect figma-agent' });
+  } catch (err) {
+    bootSkipped.push(`relaunchData: refused (${err instanceof Error ? err.message : String(err)})`);
+  }
+}
 
 /** Block 2's Selection row: the first selected node's name (if any) + the count. */
 function selectionSummary(): { selectionName: string | null; selectionCount: number } {
@@ -467,8 +494,12 @@ figma.ui.onmessage = async (msg: unknown) => {
   const chrome = msg as { type?: unknown; data?: unknown } | null;
   // Live-sync (spec 004 P4): the broker's idle window, relayed by the iframe.
   if (chrome && chrome.type === 'SYNC_CONFIG') {
-    const raw = (chrome.data as { idleMs?: unknown } | undefined)?.idleMs;
+    const data = chrome.data as { idleMs?: unknown; bound?: unknown } | undefined;
+    const raw = data?.idleMs;
     if (typeof raw === 'number' && Number.isFinite(raw)) idleMs = Math.max(MIN_IDLE_MS, Math.floor(raw));
+    // auto-connect slice 2 (fix round) — gate the relaunch button on the broker's own
+    // bind-index answer, never a bare startup guess.
+    maybeSetRelaunchData(data?.bound === true);
     return;
   }
   // The panel's sync-result listener posts this ONCE THE OUTCOME IS KNOWN (fix round,

--- a/plugin/src/ui/activity-feed.ts
+++ b/plugin/src/ui/activity-feed.ts
@@ -25,6 +25,13 @@ export interface ActivityRecord {
   at: number;
   /** Wire ErrorCode, present only on a failed reply — never shown raw, only mapped to a reason. */
   errorCode?: string;
+  /**
+   * auto-connect slice 2 — which harness sent this (`RequestMsg.agent`, carried through
+   * ui-relay.ts's `activityStart`). Absent ⇒ the row renders with no agent label at all
+   * (never a fabricated "cli" here — the row-level default, if any, is a RENDER-time
+   * decision in panel-ui.ts, not something this record manufactures).
+   */
+  agent?: string;
   /** The reply's own `name`, when it carried one (CREATE_FRAME/CREATE_INSTANCE/SET_TEXT/
    *  IMPORT_PAYLOAD/a scan) — lets the sentence say `Created frame "Hero card"` instead of
    *  fabricating an object no reply ever named. */
@@ -102,6 +109,7 @@ export function toActivityRecord(detail: unknown): ActivityRecord | null {
     at,
   };
   if (typeof d.label === 'string' && d.label.trim() !== '') rec.label = d.label.trim();
+  if (typeof d.agent === 'string' && d.agent.trim() !== '') rec.agent = d.agent.trim();
   return rec;
 }
 

--- a/plugin/src/ui/panel-ui.ts
+++ b/plugin/src/ui/panel-ui.ts
@@ -158,7 +158,17 @@ function activityRow(r: ActivityRecord, now: number, stale: boolean, isNew: bool
     errorMessage: !r.ok ? r.result : undefined, nodeName: r.nodeName,
     pending: r.pending, ok: r.ok,
   });
-  text.textContent = line;
+  // auto-connect slice 2 — the agent label is its OWN span, never folded into the
+  // sentence string above (activitySentence stays deliberately label-free — see its own
+  // header comment): a separate node so the sentence text (and activitySentence's own
+  // contract) never has to know a caller can attach an agent id. The `cli` default is
+  // applied HERE, at render time — an unlabelled request never stamps a default onto
+  // the wire (RequestMsg.agent stays additive; see makeRequestFrame). U+00B7 (middle
+  // dot) separator — NOT U+2022 (bullet), which the panel's typography gate bans.
+  const agentSpan = document.createElement('span');
+  agentSpan.className = 'log-agent';
+  agentSpan.textContent = `${r.agent ?? 'cli'} · `;
+  text.append(agentSpan, document.createTextNode(line));
   text.title = line; // the row ellipsises (ok/running) — hover still tells the truth there
 
   const caption = document.createElement('div');

--- a/plugin/src/ui/panel.html
+++ b/plugin/src/ui/panel.html
@@ -759,6 +759,12 @@ code {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* auto-connect slice 2 — which harness sent this request ("claude · Created frame
+   ..."), muted so the sentence itself (the important part) still reads first. Own
+   span (panel-ui.ts), never folded into the sentence string. */
+.log-agent {
+  color: var(--fga-text-muted);
+}
 /* Owner-observed (live screenshot, concurrency & jobs addendum): a FAILED row's reason
    ("The script stopped: runtime error: ...") was clipped by the single-line ellipsis
    above — Activity is the one surface exempt from the terse-truncate rule, and a

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -64,7 +64,10 @@ function dispatchActivity(detail: Record<string, unknown>): void {
 function startActivity(req: RequestMsg): void {
   const at = Date.now();
   activityStart.set(req.id, { cmd: req.cmd, label: req.activity, at });
-  dispatchActivity({ phase: 'start', id: req.id, tool: req.cmd, label: req.activity, at });
+  // `agent` (auto-connect slice 2) is start-only, like `label` — never echoed back on
+  // the done-event, so it needs no entry in the `activityStart` map above, only the
+  // dispatch here.
+  dispatchActivity({ phase: 'start', id: req.id, tool: req.cmd, label: req.activity, at, agent: req.agent });
 }
 
 /** A reply's own `name`, when it carried one (CREATE_FRAME/CREATE_INSTANCE/SET_TEXT/

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -759,6 +759,12 @@ code {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+/* auto-connect slice 2 — which harness sent this request ("claude · Created frame
+   ..."), muted so the sentence itself (the important part) still reads first. Own
+   span (panel-ui.ts), never folded into the sentence string. */
+.log-agent {
+  color: var(--fga-text-muted);
+}
 /* Owner-observed (live screenshot, concurrency & jobs addendum): a FAILED row's reason
    ("The script stopped: runtime error: ...") was clipped by the single-line ellipsis
    above — Activity is the one surface exempt from the terse-truncate rule, and a
@@ -1069,6 +1075,7 @@ code {
       at
     };
     if (typeof d.label === "string" && d.label.trim() !== "") rec.label = d.label.trim();
+    if (typeof d.agent === "string" && d.agent.trim() !== "") rec.agent = d.agent.trim();
     return rec;
   }
   function toActivityResult(detail) {
@@ -1254,7 +1261,10 @@ code {
       pending: r.pending,
       ok: r.ok
     });
-    text.textContent = line;
+    const agentSpan = document.createElement("span");
+    agentSpan.className = "log-agent";
+    agentSpan.textContent = `${r.agent ?? "cli"} \xB7 `;
+    text.append(agentSpan, document.createTextNode(line));
     text.title = line;
     const caption = document.createElement("div");
     caption.className = "log-meta";
@@ -1435,7 +1445,7 @@ code {
     } catch {
     }
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "8840474" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "9e76a4b" : "dev"}`;
   setInterval(render, 1e3);
   render();
 
@@ -2902,7 +2912,7 @@ code {
   function startActivity(req) {
     const at = Date.now();
     activityStart.set(req.id, { cmd: req.cmd, label: req.activity, at });
-    dispatchActivity({ phase: "start", id: req.id, tool: req.cmd, label: req.activity, at });
+    dispatchActivity({ phase: "start", id: req.id, tool: req.cmd, label: req.activity, at, agent: req.agent });
   }
   function replyNodeName(payload2) {
     const name = payload2?.name;

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1445,7 +1445,7 @@ code {
     } catch {
     }
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "9e76a4b" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "7ed3340" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -128,6 +128,15 @@ export interface RequestMsg {
    * serialize byte-identically to what a pre-flag CLI sent.
    */
   readOnly?: boolean;
+  /**
+   * auto-connect slice 2 — which harness sent this (`--agent <id>` / `FIGMA_AGENT_ID`),
+   * for the panel's activity feed ("claude · Created frame \"Hero card\""). Envelope-
+   * level, exactly like `activity`: the broker relays it verbatim, never parses it for
+   * routing. Omitted entirely when unset — an unguarded frame must serialize
+   * byte-identically to what every pre-flag CLI sent; the `cli` default is applied at
+   * RENDER time in the panel, never stamped here.
+   */
+  agent?: string;
 }
 
 /** Which file answered. Echoed on every reply so a caller can prove where a command landed. */
@@ -427,12 +436,19 @@ export function makeRequestFrame(
   projectDir?: string,
   readOnly?: boolean,
   expectedInstance?: string,
+  // auto-connect slice 2 — appended, never inserted, so every existing call/test that
+  // pads earlier optional positionals with `undefined` keeps addressing the SAME
+  // parameter it always did (see broker-daemon-harness.test.ts's own 8-positional
+  // precedent). A 9th positional is already a lot for this signature — the NEXT field
+  // here should be an options object instead, not a 10th slot.
+  agent?: string,
 ): RequestMsg {
   const frame: RequestMsg = { id, cmd, params, v: PROTOCOL_VERSION };
   if (typeof activity === 'string' && activity.trim() !== '') frame.activity = activity;
   if (typeof expectedFile === 'string' && expectedFile.trim() !== '') frame.expectedFile = expectedFile;
   if (typeof expectedInstance === 'string' && expectedInstance.trim() !== '') frame.expectedInstance = expectedInstance;
   if (typeof projectDir === 'string' && projectDir.trim() !== '') frame.projectDir = projectDir;
+  if (typeof agent === 'string' && agent.trim() !== '') frame.agent = agent;
   // Concurrency & jobs — omitted (never `readOnly: false`) when unset, exactly like the
   // other optional envelope fields above: an unguarded frame must serialize
   // byte-identically to what every pre-flag CLI sent.

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -50,7 +50,7 @@ exactly one JSON object to stdout and exits 0, or `{error:{code,message}}` and e
 
 ## Command reference
 
-- `status` — Broker + plugin connection info [--peek [--json]] — --peek reads only the /tmp broker advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted for compatibility but is a no-op: output is always the same single JSON object.
+- `status` — Broker + plugin connection info [--peek [--json]] [--wait [--timeout N]] — --peek reads only the /tmp broker advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted for compatibility but is a no-op: output is always the same single JSON object. --wait blocks (MAY spawn a broker) until a matching plugin registers, printing a figma:// deep link (when one can be built) to stderr immediately; --timeout N is in SECONDS, default 60 — on timeout this exits non-zero with E_NO_PLUGIN instead of the normal payload.
 - `seat` — Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]
 - `bind` — --file "<name>" --dir <projectDir>   bind a file to a project for panel/idle sync (refuses to guess otherwise) [--list] [--unbind]
 - `get-selection` — Serialize the current selection [--depth 1]

--- a/tests/activity-feed.test.ts
+++ b/tests/activity-feed.test.ts
@@ -71,6 +71,24 @@ describe('toActivityRecord — defensive coercion of the start-event detail', ()
     expect(r?.id).not.toBe('');
     expect(typeof r?.at).toBe('number');
   });
+
+  it('auto-connect slice 2: carries the agent label when the start-event detail has one', () => {
+    const r = toActivityRecord({ id: 'c_8', tool: 'STATUS', at: 500, agent: 'claude' });
+    expect(r?.agent).toBe('claude');
+  });
+  it('trims a whitespace-padded agent label', () => {
+    const r = toActivityRecord({ id: 'c_9', tool: 'STATUS', at: 500, agent: '  claude  ' });
+    expect(r?.agent).toBe('claude');
+  });
+  it('BACKWARD-COMPAT: a detail with no agent still opens a row, agent stays absent (never a fabricated default)', () => {
+    const r = toActivityRecord({ id: 'c_1', tool: 'STATUS', at: 500 });
+    expect(r).not.toBeNull();
+    expect('agent' in (r as object)).toBe(false);
+  });
+  it('a blank agent is treated as absent, same as a blank label', () => {
+    const r = toActivityRecord({ id: 'c_1', tool: 'STATUS', at: 500, agent: '   ' });
+    expect(r?.agent).toBeUndefined();
+  });
 });
 
 describe('toActivityResult — coercion of the done-event detail', () => {

--- a/tests/agent-label-envelope.test.ts
+++ b/tests/agent-label-envelope.test.ts
@@ -78,21 +78,20 @@ describe('resolveAgent — CLI boundary guards (--agent / FIGMA_AGENT_ID)', () =
     expect(resolveAgent(fakeArgs())).toBe('from-env');
   });
 
-  it('trims whitespace', () => {
+  it('trims whitespace before validating', () => {
     delete process.env.FIGMA_AGENT_ID;
     expect(resolveAgent(fakeArgs({ agent: '  claude  ' }))).toBe('claude');
   });
 
-  it('caps at 32 characters', () => {
+  it('accepts the full allowlist: lowercase letters, digits, dot, underscore, hyphen', () => {
     delete process.env.FIGMA_AGENT_ID;
-    const long = 'a'.repeat(40);
-    expect(resolveAgent(fakeArgs({ agent: long }))?.length).toBe(32);
+    expect(resolveAgent(fakeArgs({ agent: 'claude-code_v2.1' }))).toBe('claude-code_v2.1');
   });
 
-  it('strips control characters before the value could ever reach a DOM span', () => {
+  it('accepts exactly 32 characters, the allowlist\'s own cap', () => {
     delete process.env.FIGMA_AGENT_ID;
-    const withControlChar = `claude${String.fromCharCode(7)}bell`; // BEL, 0x07
-    expect(resolveAgent(fakeArgs({ agent: withControlChar }))).toBe('claudebell');
+    const exact32 = 'a'.repeat(32);
+    expect(resolveAgent(fakeArgs({ agent: exact32 }))).toBe(exact32);
   });
 });
 
@@ -101,17 +100,51 @@ describe('--agent — subprocess, against the BUILT cli/dist bundle', () => {
     execFileSync(process.execPath, ['scripts/build.mjs', 'cli'], { cwd: ROOT });
   });
 
-  it('a bare --agent with no value refuses with E_INVALID_ARGS, exit non-zero', () => {
-    let threw: { status: number | null; stdout: string } | null = null;
+  function runAgent(agentValue: string | null): { status: number | null; stdout: string } {
+    const args = ['status', '--peek'];
+    if (agentValue !== null) args.push('--agent', agentValue);
+    else args.push('--agent'); // bare flag, no value
     try {
-      execFileSync(process.execPath, [CLI_DIST, 'status', '--peek', '--agent'], { cwd: ROOT, encoding: 'utf8' });
+      const out = execFileSync(process.execPath, [CLI_DIST, ...args], { cwd: ROOT, encoding: 'utf8' });
+      return { status: 0, stdout: out };
     } catch (err) {
       const e = err as { status: number | null; stdout: string };
-      threw = { status: e.status, stdout: e.stdout };
+      return { status: e.status, stdout: e.stdout };
     }
-    expect(threw).not.toBeNull();
-    expect(threw?.status).not.toBe(0);
-    const parsed = JSON.parse(threw?.stdout ?? '{}') as { error?: { code?: string } };
+  }
+
+  it('a bare --agent with no value refuses with E_INVALID_ARGS, exit non-zero', () => {
+    const result = runAgent(null);
+    expect(result.status).not.toBe(0);
+    const parsed = JSON.parse(result.stdout || '{}') as { error?: { code?: string } };
     expect(parsed.error?.code).toBe('E_INVALID_ARGS');
+  });
+
+  it('a value with 33 characters (over the allowlist cap) refuses with E_INVALID_ARGS', () => {
+    const result = runAgent('a'.repeat(33));
+    expect(result.status).not.toBe(0);
+    const parsed = JSON.parse(result.stdout || '{}') as { error?: { code?: string; message?: string } };
+    expect(parsed.error?.code).toBe('E_INVALID_ARGS');
+    expect(parsed.error?.message).toContain('--agent');
+  });
+
+  it('uppercase, spaces, and control/bidi characters are all rejected, never silently sanitized', () => {
+    // Built via String.fromCharCode/fromCodePoint, never as literal source characters —
+    // this source file must never carry a raw control/bidi byte itself.
+    const bell = String.fromCharCode(7); // BEL, 0x07
+    const rlo = String.fromCodePoint(0x202e); // Right-to-Left Override
+    const zwsp = String.fromCodePoint(0x200b); // Zero Width Space
+    const cases = ['Claude', 'claude code', `claude${bell}bell`, `claude${rlo}evil`, `cla${zwsp}ude`];
+    for (const bad of cases) {
+      const result = runAgent(bad);
+      expect(result.status, `expected refusal for ${JSON.stringify(bad)}`).not.toBe(0);
+      const parsed = JSON.parse(result.stdout || '{}') as { error?: { code?: string } };
+      expect(parsed.error?.code, `expected E_INVALID_ARGS for ${JSON.stringify(bad)}`).toBe('E_INVALID_ARGS');
+    }
+  });
+
+  it('a well-formed --agent value is accepted end to end (status --peek still exits 0)', () => {
+    const result = runAgent('claude-code_v2.1');
+    expect(result.status).toBe(0);
   });
 });

--- a/tests/agent-label-envelope.test.ts
+++ b/tests/agent-label-envelope.test.ts
@@ -1,0 +1,117 @@
+// The `--agent`/`FIGMA_AGENT_ID` label, envelope half: it must be additive to
+// makeRequestFrame — an unset agent produces the exact byte-identical frame a
+// pre-flag CLI always sent (see activity-labels.test.ts's own template for the
+// `activity` field this mirrors). Also covers `resolveAgent`'s own guards
+// (trim/empty/length/control-char/env-fallback) and the built-CLI subprocess
+// path for the one guard that exits the process (`printErrorJson`), which a
+// direct unit call cannot safely exercise.
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { PROTOCOL_VERSION, makeRequestFrame } from '../shared/protocol.ts';
+import { resolveAgent } from '../cli/src/figma-agent.ts';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+
+const ROOT = resolve(fileURLToPath(new URL('..', import.meta.url)));
+const CLI_DIST = `${ROOT}/cli/dist/figma-agent.js`;
+
+function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
+  return {
+    positionals: [],
+    str: (name) => (typeof flags[name] === 'string' ? (flags[name] as string) : undefined),
+    req: (name) => {
+      const v = flags[name];
+      if (typeof v !== 'string') throw new Error(`missing --${name}`);
+      return v;
+    },
+    num: (name) => (typeof flags[name] === 'string' ? Number(flags[name]) : undefined),
+    bool: (name) => flags[name] === true || flags[name] === 'true',
+  };
+}
+
+describe('makeRequestFrame — agent label is additive, never a wire change', () => {
+  it('carries the agent label when one is given, as the 9th positional', () => {
+    expect(makeRequestFrame('c_1', 'STATUS', {}, undefined, undefined, undefined, undefined, undefined, 'claude'))
+      .toEqual({ id: 'c_1', cmd: 'STATUS', params: {}, v: PROTOCOL_VERSION, agent: 'claude' });
+  });
+
+  it('BACKWARD-COMPAT: an unset agent is byte-identical to the pre-agent wire', () => {
+    const frame = makeRequestFrame('c_1', 'STATUS', {});
+    expect('agent' in frame).toBe(false);
+    expect(JSON.stringify(frame)).toBe(JSON.stringify({ id: 'c_1', cmd: 'STATUS', params: {}, v: PROTOCOL_VERSION }));
+  });
+
+  it('treats a blank agent as unset — never ships an empty label to the panel', () => {
+    expect('agent' in makeRequestFrame('c_1', 'STATUS', {}, undefined, undefined, undefined, undefined, undefined, '   ')).toBe(false);
+  });
+
+  it('composes with every other optional field already on the envelope', () => {
+    const frame = makeRequestFrame('c_1', 'EXEC_JS', { code: '1' }, 'Scan · 1:23', 'My File', '/proj', true, 'p_1', 'claude');
+    expect(frame).toEqual({
+      id: 'c_1', cmd: 'EXEC_JS', params: { code: '1' }, v: PROTOCOL_VERSION,
+      activity: 'Scan · 1:23', expectedFile: 'My File', projectDir: '/proj', readOnly: true,
+      expectedInstance: 'p_1', agent: 'claude',
+    });
+  });
+});
+
+describe('resolveAgent — CLI boundary guards (--agent / FIGMA_AGENT_ID)', () => {
+  const originalEnv = process.env.FIGMA_AGENT_ID;
+  afterEach(() => {
+    if (originalEnv === undefined) delete process.env.FIGMA_AGENT_ID;
+    else process.env.FIGMA_AGENT_ID = originalEnv;
+  });
+
+  it('unset flag, unset env → undefined', () => {
+    delete process.env.FIGMA_AGENT_ID;
+    expect(resolveAgent(fakeArgs())).toBeUndefined();
+  });
+
+  it('the --agent flag wins over FIGMA_AGENT_ID', () => {
+    process.env.FIGMA_AGENT_ID = 'from-env';
+    expect(resolveAgent(fakeArgs({ agent: 'from-flag' }))).toBe('from-flag');
+  });
+
+  it('falls back to FIGMA_AGENT_ID when no flag is given', () => {
+    process.env.FIGMA_AGENT_ID = 'from-env';
+    expect(resolveAgent(fakeArgs())).toBe('from-env');
+  });
+
+  it('trims whitespace', () => {
+    delete process.env.FIGMA_AGENT_ID;
+    expect(resolveAgent(fakeArgs({ agent: '  claude  ' }))).toBe('claude');
+  });
+
+  it('caps at 32 characters', () => {
+    delete process.env.FIGMA_AGENT_ID;
+    const long = 'a'.repeat(40);
+    expect(resolveAgent(fakeArgs({ agent: long }))?.length).toBe(32);
+  });
+
+  it('strips control characters before the value could ever reach a DOM span', () => {
+    delete process.env.FIGMA_AGENT_ID;
+    const withControlChar = `claude${String.fromCharCode(7)}bell`; // BEL, 0x07
+    expect(resolveAgent(fakeArgs({ agent: withControlChar }))).toBe('claudebell');
+  });
+});
+
+describe('--agent — subprocess, against the BUILT cli/dist bundle', () => {
+  beforeAll(() => {
+    execFileSync(process.execPath, ['scripts/build.mjs', 'cli'], { cwd: ROOT });
+  });
+
+  it('a bare --agent with no value refuses with E_INVALID_ARGS, exit non-zero', () => {
+    let threw: { status: number | null; stdout: string } | null = null;
+    try {
+      execFileSync(process.execPath, [CLI_DIST, 'status', '--peek', '--agent'], { cwd: ROOT, encoding: 'utf8' });
+    } catch (err) {
+      const e = err as { status: number | null; stdout: string };
+      threw = { status: e.status, stdout: e.stdout };
+    }
+    expect(threw).not.toBeNull();
+    expect(threw?.status).not.toBe(0);
+    const parsed = JSON.parse(threw?.stdout ?? '{}') as { error?: { code?: string } };
+    expect(parsed.error?.code).toBe('E_INVALID_ARGS');
+  });
+});

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -781,6 +781,40 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
       rmSync(otherProjectDir, { recursive: true, force: true });
     }
   });
+
+  it('SYNC_CONFIG carries `bound` (auto-connect slice 2, fix round) — false for an unbound HELLO, true after PROJECT_BIND, true on a fresh HELLO for an already-bound file', async () => {
+    const port = await startTestBroker();
+    const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-sync-bound-flag-'));
+    try {
+      mkdirSync(join(boundProjectDir, 'design'), { recursive: true });
+
+      // 1. Unbound HELLO → bound:false.
+      const plugin = await connectSocket(port);
+      const helloSyncConfig = nextFrame<EventMsg>(plugin, (m) => (m as EventMsg).type === 'SYNC_CONFIG');
+      plugin.send(JSON.stringify({
+        type: 'PLUGIN_HELLO',
+        data: { instanceId: 'plugin-bound-flag-1', fileName: 'Bound Flag File', fileKey: null, caps: ['fileGuard'] },
+      } satisfies EventMsg));
+      expect(((await helloSyncConfig).data as { bound: boolean }).bound).toBe(false);
+
+      // 2. PROJECT_BIND while still connected → the live push carries bound:true.
+      const postBindSyncConfig = nextFrame<EventMsg>(plugin, (m) => (m as EventMsg).type === 'SYNC_CONFIG');
+      const cli = await connectSocket(port);
+      await bindProject(cli, 'Bound Flag File', boundProjectDir, 'req-bind-flag-1');
+      expect(((await postBindSyncConfig).data as { bound: boolean }).bound).toBe(true);
+
+      // 3. A FRESH HELLO for the same (now-bound) file also reads bound:true.
+      const plugin2 = await connectSocket(port);
+      const reHelloSyncConfig = nextFrame<EventMsg>(plugin2, (m) => (m as EventMsg).type === 'SYNC_CONFIG');
+      plugin2.send(JSON.stringify({
+        type: 'PLUGIN_HELLO',
+        data: { instanceId: 'plugin-bound-flag-2', fileName: 'Bound Flag File', fileKey: null, caps: ['fileGuard'] },
+      } satisfies EventMsg));
+      expect(((await reHelloSyncConfig).data as { bound: boolean }).bound).toBe(true);
+    } finally {
+      rmSync(boundProjectDir, { recursive: true, force: true });
+    }
+  });
 });
 
 // `--instance <id>` admission — exercises the real `admitRequest` closure via a real

--- a/tests/figma-deep-link.test.ts
+++ b/tests/figma-deep-link.test.ts
@@ -1,0 +1,23 @@
+// Pure table-driven test for buildDeepLink's three cases (phase-02 design table).
+// UNVERIFIED: whether `figma://file/<fileKey>` is the exact desktop URL scheme Figma
+// resolves — flagged as an owner live-test item, never claimed as confirmed here.
+import { describe, expect, it } from 'vitest';
+import { buildDeepLink } from '../cli/src/transport/figma-deep-link.ts';
+
+describe('buildDeepLink — never fabricates a link', () => {
+  it('a bound entry with a real fileKey builds figma://file/<fileKey>', () => {
+    expect(buildDeepLink({ fileKey: 'ABC123' })).toEqual({ url: 'figma://file/ABC123', reason: null });
+  });
+
+  it('a bound entry with fileKey:null (Figma Free, or never-yet-connected) → null + reason', () => {
+    const result = buildDeepLink({ fileKey: null });
+    expect(result.url).toBeNull();
+    expect(result.reason).toMatch(/Free plan/);
+  });
+
+  it('no binding at all → null + a reason naming the fix (`figma-agent bind`)', () => {
+    const result = buildDeepLink(null);
+    expect(result.url).toBeNull();
+    expect(result.reason).toMatch(/figma-agent bind/);
+  });
+});

--- a/tests/figma-deep-link.test.ts
+++ b/tests/figma-deep-link.test.ts
@@ -20,4 +20,20 @@ describe('buildDeepLink — never fabricates a link', () => {
     expect(result.url).toBeNull();
     expect(result.reason).toMatch(/figma-agent bind/);
   });
+
+  it('a marker entry with fileKey MISSING (crossed a trust boundary, e.g. a hand-edited marker) never fabricates figma://file/undefined', () => {
+    // The type says `string | null`, but readBindMarker's own parse from disk cannot
+    // enforce that at runtime — reproduce the exact malformed shape a corrupt/hand-edited
+    // JSON file could produce.
+    const malformed = {} as unknown as { fileKey: string | null };
+    const result = buildDeepLink(malformed);
+    expect(result.url).toBeNull(); // never "figma://file/undefined"
+    expect(result.reason).toMatch(/Free plan/);
+  });
+
+  it('a marker entry with fileKey as an EMPTY STRING never fabricates figma://file/', () => {
+    const result = buildDeepLink({ fileKey: '' });
+    expect(result.url).toBeNull(); // never "figma://file/"
+    expect(result.reason).toMatch(/Free plan/);
+  });
 });

--- a/tests/plugin-wait.test.ts
+++ b/tests/plugin-wait.test.ts
@@ -1,0 +1,73 @@
+// waitForPlugin's poll/timeout logic, with an injected fake clock + sleep so this
+// runs instantly instead of stepping real 500ms ticks.
+import { describe, expect, it } from 'vitest';
+import { waitForPlugin } from '../cli/src/transport/plugin-wait.ts';
+
+/** A fake clock that advances by `stepMs` every time `sleep` is awaited — deterministic,
+ *  no real timers, no flake. */
+function fakeClock(stepMs: number): { now: () => number; sleep: (ms: number) => Promise<void> } {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async () => { t += stepMs; },
+  };
+}
+
+describe('waitForPlugin', () => {
+  it('resolves immediately when a plugin is already registered, no filter', async () => {
+    const { now, sleep } = fakeClock(500);
+    const fetchHello = async () => ({ plugins: [{ instanceId: 'p_1', fileName: 'F' }] });
+    const result = await waitForPlugin({ port: 1, timeoutMs: 5_000, now, sleep, fetchHello });
+    expect(result).toEqual({ registered: true, waitedMs: 0, hello: { plugins: [{ instanceId: 'p_1', fileName: 'F' }] } });
+  });
+
+  it('polls until a matching plugin appears, then returns registered:true with the elapsed waitedMs', async () => {
+    const { now, sleep } = fakeClock(500);
+    let calls = 0;
+    const fetchHello = async () => {
+      calls += 1;
+      return calls < 3 ? { plugins: [] } : { plugins: [{ instanceId: 'p_1', fileName: 'F' }] };
+    };
+    const result = await waitForPlugin({ port: 1, timeoutMs: 5_000, now, sleep, fetchHello });
+    expect(result.registered).toBe(true);
+    expect(result.waitedMs).toBe(1_000); // two sleeps of 500ms before the 3rd poll matched
+    expect(calls).toBe(3);
+  });
+
+  it('respects --file: an unrelated plugin registering does not satisfy the wait', async () => {
+    const { now, sleep } = fakeClock(500);
+    const fetchHello = async () => ({ plugins: [{ instanceId: 'p_1', fileName: 'Other File' }] });
+    const result = await waitForPlugin({ port: 1, timeoutMs: 1_000, fileFilter: 'My File', now, sleep, fetchHello });
+    expect(result.registered).toBe(false);
+  });
+
+  it('respects --instance: matches by exact instanceId, ignoring fileFilter when both somehow set', async () => {
+    const { now, sleep } = fakeClock(500);
+    const fetchHello = async () => ({ plugins: [{ instanceId: 'p_2', fileName: 'Anything' }] });
+    const result = await waitForPlugin({
+      port: 1, timeoutMs: 1_000, fileFilter: 'nonmatching', instanceFilter: 'p_2', now, sleep, fetchHello,
+    });
+    expect(result.registered).toBe(true);
+  });
+
+  it('times out honestly when nothing ever matches — registered:false, waitedMs at the deadline', async () => {
+    const { now, sleep } = fakeClock(500);
+    const fetchHello = async () => ({ plugins: [] });
+    const result = await waitForPlugin({ port: 1, timeoutMs: 1_200, now, sleep, fetchHello });
+    expect(result.registered).toBe(false);
+    expect(result.waitedMs).toBeGreaterThanOrEqual(1_200);
+  });
+
+  it('a broker hiccup mid-wait (fetchHello throws) does not abort the wait — it just tries again', async () => {
+    const { now, sleep } = fakeClock(500);
+    let calls = 0;
+    const fetchHello = async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('ECONNRESET');
+      return { plugins: [{ instanceId: 'p_1', fileName: 'F' }] };
+    };
+    const result = await waitForPlugin({ port: 1, timeoutMs: 5_000, now, sleep, fetchHello });
+    expect(result.registered).toBe(true);
+    expect(calls).toBe(2);
+  });
+});

--- a/tests/plugin-wait.test.ts
+++ b/tests/plugin-wait.test.ts
@@ -41,6 +41,19 @@ describe('waitForPlugin', () => {
     expect(result.registered).toBe(false);
   });
 
+  it('fix round: --file matching uses the SAME identity normalization as the bind-lookup (figma-deep-link\'s findBoundEntry), not a plain trim+lowercase equality — so the wait and the deep link can never disagree about which file was meant', async () => {
+    const { now, sleep } = fakeClock(500);
+    // A double space vs a single space: fileIdentity/safeSlug collapses BOTH to the
+    // same "my-file" slug (matching how project-bind.ts's fileNameSlug is derived at
+    // bind time), while a plain fileMatches(..., true) trim+lowercase equality would
+    // NOT consider these the same string. This is the exact divergence the review
+    // reproduced between waitForPlugin's old fileMatches-based filter and
+    // findBoundEntry's fileIdentity-based one.
+    const fetchHello = async () => ({ plugins: [{ instanceId: 'p_1', fileName: 'My File' }] });
+    const result = await waitForPlugin({ port: 1, timeoutMs: 1_000, fileFilter: 'My  File', now, sleep, fetchHello });
+    expect(result.registered).toBe(true);
+  });
+
   it('respects --instance: matches by exact instanceId, ignoring fileFilter when both somehow set', async () => {
     const { now, sleep } = fakeClock(500);
     const fetchHello = async () => ({ plugins: [{ instanceId: 'p_2', fileName: 'Anything' }] });

--- a/tests/project-bind.test.ts
+++ b/tests/project-bind.test.ts
@@ -137,6 +137,25 @@ describe('bind marker persistence — <projectDir>/design/figma-bind.json', () =
     writeFileSync(bindMarkerPath(dirA), 'not json');
     expect(readBindMarker(dirA)).toBeNull();
   });
+
+  it('fix round: a hand-edited/corrupt entry (missing fileKey, wrong-typed fileNameSlug, non-finite boundAt) is dropped, never handed to a caller — good sibling entries survive', () => {
+    mkdirSync(join(dirA, 'design'), { recursive: true });
+    const raw = {
+      v: 1,
+      bindings: [
+        { fileKey: 'good1', fileNameSlug: 'good-file', boundAt: 1 }, // valid
+        { fileNameSlug: 'missing-file-key', boundAt: 2 }, // fileKey entirely absent
+        { fileKey: 'bad-slug', fileNameSlug: 42, boundAt: 3 }, // fileNameSlug wrong type
+        { fileKey: 'bad-bound', fileNameSlug: 'bad-bound-file', boundAt: 'not-a-number' }, // boundAt wrong type
+        { fileKey: null, fileNameSlug: 'free-plan-file', boundAt: 4 }, // valid: null fileKey is legitimate (Free plan)
+      ],
+    };
+    writeFileSync(bindMarkerPath(dirA), JSON.stringify(raw));
+    const result = readBindMarker(dirA);
+    expect(result).not.toBeNull();
+    const slugs = result?.bindings.map((b) => b.fileNameSlug) ?? [];
+    expect(slugs).toEqual(['good-file', 'free-plan-file']);
+  });
 });
 
 describe('bind cache — restart-survival list of project dirs', () => {

--- a/tests/status-wait.test.ts
+++ b/tests/status-wait.test.ts
@@ -1,0 +1,147 @@
+// `status --wait`'s integration: ensureBroker()+waitForPlugin()+the deep-link print
+// wired together in cli/src/commands/status.ts. `ensureBroker()` (broker-discovery.ts)
+// has no test-injectable path — unlike broker-peek.ts's `peek()`, it always targets the
+// REAL /tmp/figma-agent-broker.json and the real 9410-9419 port range. This suite mocks
+// `ensureBroker` to resolve to a REAL but SCRATCH broker (the same daemon-harness
+// pattern as tests/broker-daemon-harness.test.ts / tests/status-peek.test.ts), so
+// `status --wait` is exercised against a live broker without ever touching the shared
+// machine's real one.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import WebSocket from 'ws';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+
+vi.mock('../cli/src/transport/broker-discovery.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cli/src/transport/broker-discovery.ts')>();
+  return { ...actual, ensureBroker: vi.fn() };
+});
+
+const { ensureBroker } = await import('../cli/src/transport/broker-discovery.ts');
+const { run } = await import('../cli/src/commands/status.ts');
+
+type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts');
+
+let scratchDir: string;
+let advertisePath: string;
+let sockets: WebSocket[];
+
+function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
+  return {
+    positionals: [],
+    str: (name) => (typeof flags[name] === 'string' ? (flags[name] as string) : undefined),
+    req: (name) => {
+      const v = flags[name];
+      if (typeof v !== 'string') throw new Error(`missing --${name}`);
+      return v;
+    },
+    num: (name) => (typeof flags[name] === 'string' ? Number(flags[name]) : undefined),
+    bool: (name) => flags[name] === true || flags[name] === 'true',
+  };
+}
+
+async function loadBrokerDaemon(): Promise<BrokerDaemonModule> {
+  process.env.FIGMA_AGENT_CHANGES_DIR = scratchDir;
+  process.env.FIGMA_AGENT_BINDS_FILE = join(scratchDir, 'binds.json');
+  process.env.FIGMA_AGENT_UNBOUND_DIR = join(scratchDir, 'unbound-root');
+  vi.resetModules();
+  return import('../cli/src/transport/broker-daemon.ts');
+}
+
+function testExit(): (code: number) => never {
+  return (code: number): never => {
+    throw new Error(`__TEST_BROKER_EXIT__ code=${code}`);
+  };
+}
+
+function connectSocket(port: number): Promise<WebSocket> {
+  return new Promise((resolvePromise, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.once('open', () => resolvePromise(ws));
+    ws.once('error', reject);
+    sockets.push(ws);
+  });
+}
+
+async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string): Promise<void> {
+  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey: null, caps: ['fileGuard'] } }));
+  await new Promise<void>((resolvePromise) => {
+    const handler = (raw: WebSocket.RawData): void => {
+      const msg = JSON.parse(raw.toString()) as { type?: string };
+      if (msg.type === 'SYNC_CONFIG') { ws.off('message', handler); resolvePromise(); }
+    };
+    ws.on('message', handler);
+  });
+  // status.ts's non-peek path enriches the ACTIVE plugin with a live STATUS round-trip
+  // (runCommand('STATUS', {})) — answer any wire request frame with a plain OK so that
+  // round-trip doesn't hang waiting for a reply this fake plugin never planned to send.
+  ws.on('message', (raw) => {
+    const msg = JSON.parse(raw.toString()) as { id?: unknown; cmd?: unknown };
+    if (typeof msg.id === 'string' && typeof msg.cmd === 'string') {
+      ws.send(JSON.stringify({ id: msg.id, ok: true, result: {} }));
+    }
+  });
+}
+
+beforeEach(() => {
+  scratchDir = mkdtempSync(join(tmpdir(), 'fa-status-wait-'));
+  advertisePath = join(scratchDir, 'broker.json');
+  sockets = [];
+});
+
+afterEach(async () => {
+  for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
+  rmSync(scratchDir, { recursive: true, force: true });
+  vi.mocked(ensureBroker).mockReset();
+});
+
+describe('status --wait', () => {
+  it('a plugin that registers DURING the wait: exits normally with waitedMs, not a timeout', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+    vi.mocked(ensureBroker).mockResolvedValue({ port: ad.port, pid: ad.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() });
+
+    // Register the plugin ~200ms into the wait — proves this is a genuine POLL, not
+    // a check-once-and-fail.
+    setTimeout(() => { connectSocket(ad.port).then((ws) => helloPlugin(ws, 'p_1', 'My File')); }, 200);
+
+    const result = await run(fakeArgs({ wait: true, timeout: '5' })) as { waitedMs: number; plugins: unknown[] };
+    expect(result.waitedMs).toBeGreaterThan(0);
+    expect(Array.isArray(result.plugins)).toBe(true);
+  });
+
+  it('nothing ever registers: throws E_NO_PLUGIN once the deadline passes, never hangs past --timeout', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+    vi.mocked(ensureBroker).mockResolvedValue({ port: ad.port, pid: ad.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() });
+
+    await expect(run(fakeArgs({ wait: true, timeout: '1' }))).rejects.toMatchObject({ code: 'E_NO_PLUGIN' });
+  });
+
+  it('prints a figma:// deep link to stderr BEFORE the wait when a matching binding exists', async () => {
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+    vi.mocked(ensureBroker).mockResolvedValue({ port: ad.port, pid: ad.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() });
+
+    const projectDir = join(scratchDir, 'proj');
+    mkdirSync(join(projectDir, 'design'), { recursive: true });
+    writeFileSync(join(projectDir, 'design', 'figma-bind.json'), JSON.stringify({
+      v: 1, bindings: [{ fileKey: 'ABC123', fileNameSlug: 'my-file', boundAt: Date.now() }],
+    }));
+    writeFileSync(join(scratchDir, 'binds.json'), JSON.stringify({ v: 1, projectDirs: [projectDir] }));
+
+    const stderrChunks: string[] = [];
+    const originalWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = ((chunk: string) => { stderrChunks.push(String(chunk)); return true; }) as typeof process.stderr.write;
+    try {
+      await expect(run(fakeArgs({ wait: true, timeout: '1', file: 'my-file' }))).rejects.toMatchObject({ code: 'E_NO_PLUGIN' });
+    } finally {
+      process.stderr.write = originalWrite;
+    }
+    expect(stderrChunks.join('')).toContain('figma://file/ABC123');
+  });
+});


### PR DESCRIPTION
## Summary

Second slice of auto-connect (#56): a designer can see which harness is driving the canvas, an agent can block until the plugin actually shows up instead of failing once, and a human told to reopen the plugin gets a relaunch button waiting for them.

- **`--agent <id>` / `FIGMA_AGENT_ID`** — carried through the broker to the panel's activity feed unchanged (`claude · Created frame "Hero card"`, own span, never folded into the sentence text). Trimmed, control characters stripped, capped at 32 chars. Additive on the wire: an unlabelled request's frame stays byte-identical to a pre-flag CLI's — the panel's `cli` default is applied only at render time.
- **`status --wait [--timeout N]`** — blocks until a plugin registers (polling every 500ms), prints a `figma://` deep link for the bound file (or an honest reason it can't build one) plus a one-line hint to stderr the instant the wait starts, and exits non-zero naming the file on timeout instead of hanging or silently giving up. `--timeout` is in seconds (documented explicitly — every other `--timeout` in this CLI is milliseconds). Unlike `--peek`, `--wait` may start a broker on demand.
- **A "Reconnect figma-agent" relaunch button** — `figma.root.setRelaunchData` at plugin startup, guarded (a refusal is logged, never breaks startup).
- `--help` and the emitted skill stay in sync with all of the above (same one-catalog drift guard from the previous slice).

## Not verified (owner live-test items, per the plan)

- The exact `figma://file/<fileKey>` URL scheme against a real Figma desktop install — never fabricated if a binding is missing or has no fileKey (Figma Free), but the URL shape itself is unconfirmed.
- Whether `setRelaunchData` dirties the file, and whether "Reconnect figma-agent" actually appears in Figma's relaunch menu after one run — zero prior use of this API in this repo.
- Two harnesses driving one file with different `--agent` values, distinguished at a glance in a real panel.
- The literal UC-05 gherkin (`status --wait --timeout 5` as a real subprocess) was not run against this machine's shared real broker — a live broker predating this work (pid stable since well before this task started) is running on the real `/tmp/figma-agent-broker.json`/port range, and touching it risked disrupting other in-progress work. The identical code path (ensureBroker → deep-link print → poll → timeout → E_NO_PLUGIN) is fully exercised by `tests/status-wait.test.ts` against an isolated scratch broker instead.

## Test plan

- [x] Red-first: every new test file/case demonstrated failing against pre-change code (envelope additivity, activity-feed agent extraction, `figma-deep-link`, `plugin-wait`, `status --wait` integration) before implementing.
- [x] `npm run typecheck` — clean
- [x] `npm run lint:comments` — clean
- [x] `npm run build` — clean
- [x] `npm test` — one fully clean run (118 files / 1508 tests); a second run reproduced the same pre-existing `target pin (#35 P2)` flake noted in the prior two PRs (issue #59), isolated to that describe block, unrelated to this change
- [x] Panel typography gate (`tests/figma-plugin-panel.test.ts`) re-run green after every panel edit
- [x] `npm run emit:skill` re-run; drift test green

Related: #56