### PR TITLE
docs: tell the auto-connect story in the README, credit cast-to-figma

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,18 +11,57 @@ the optional, non-deterministic "hands" for its Figma authoring track. It talks 
 through the public Plugin API (Figma Free, no paid write API, no OAuth, no seat).
 
 ```
+skills/figma-agent/SKILL.md ⇢ the agent          (emitted from this CLI's own command table)
+                              ↓
 you / an agent CLI ⇄ figma-agent CLI ⇄ local WebSocket broker (ports 9410-9419)
                                               ⇄ Figma plugin (Plugin API) ⇄ canvas
 ```
 
 ## Why this exists
 
-Every AI-on-Figma setup hits the same three walls. The agent's work collapses into **one
-giant undo step** — press ⌘Z after twenty minutes of automated work and twenty minutes
-disappear. The designer's own edits are **invisible to the codebase** — a human moves a
-component, and whatever registry the agent builds from quietly goes stale. And when both
-act at once, they **trample each other** — half-applied scripts, overwritten changes, no
-way to tell what happened. This plugin exists to remove exactly those three walls.
+Every AI-on-Figma setup hits the same four walls. Before any work starts, **the agent has
+no idea how to connect** — every session opens with the same ritual of "is the broker up,
+is the plugin open, which commands does this build even have". Then the agent's work
+collapses into **one giant undo step** — press ⌘Z after twenty minutes of automated work
+and twenty minutes disappear. The designer's own edits are **invisible to the codebase** —
+a human moves a component, and whatever registry the agent builds from quietly goes stale.
+And when both act at once, they **trample each other** — half-applied scripts, overwritten
+changes, no way to tell what happened. This plugin exists to remove exactly those four
+walls.
+
+### The agent arrives already knowing
+
+The transport was never the missing piece — the broker starts on demand and the plugin
+reconnects itself. What was missing is **knowledge at the moment a session opens**. So the
+CLI hands it over:
+
+```sh
+figma-agent install-skill            # into ~/.claude/skills by default; --folder to redirect
+figma-agent install-hook --dry-run   # show the SessionStart hook; --dry-run writes nothing
+```
+
+The skill's command reference is **emitted from the CLI's own command table** — the same
+table `--help` renders — and a test fails the build when the committed file and the
+emitter disagree. A reference that can drift is a reference that will, so this one cannot:
+add a command and forget to document it, and CI says so by name.
+
+The hook runs one cheap question at every session start:
+
+```sh
+figma-agent status --peek            # never spawns a broker; idle is a normal answer, exit 0
+```
+
+It reads the broker's `/tmp` advertisement and, only if one is live, asks it a single short
+question — a session start must never leave a daemon behind on a machine that wasn't going
+to use one. The answer carries `versionMatch` / `protocolMatch`, so a plugin build that no
+longer matches the CLI is visible before it causes a confusing failure — `null` there means
+*the plugin never reported a version*, never "mismatch", and a broker that doesn't answer in
+time reports `connected: null` rather than guessing either way.
+
+Neither installer touches anything without asking. `install-skill` compares versions and
+prompts before overwriting; `install-hook` backs up your settings first, refuses outright if
+it can't parse them as JSON, and leaves the file untouched on `--dry-run`. A machine without
+the CLI installed runs the hook as a silent no-op instead of failing a session.
 
 ### Your edits reach the codebase — the right codebase
 
@@ -63,7 +102,12 @@ reads it back without ever crashing on a bad line.
 ### Multiple files, one broker
 
 Several open Figma files stay connected at once — they no longer evict each other. Commands
-route to the most-recently-active file, or pin to one with `FIGMA_AGENT_FILE`.
+route to the most-recently-active file, or pin to one with `FIGMA_AGENT_FILE`. Several
+*agents* can share one file too: pass `--agent claude` (or set `FIGMA_AGENT_ID`) and the
+panel's activity feed labels each entry with the harness that sent it, so a designer
+watching the canvas can tell who just did that. Omit it and the wire frame is byte-identical
+to what a pre-flag CLI sent — the panel's own `cli` default is applied when the row renders,
+never stamped onto the request.
 
 <img src="docs/images/multi-file-peers.png" width="320" alt="Multiple files connected at once">
 
@@ -86,16 +130,31 @@ auto-starts on your first command and the plugin auto-reconnects to it.
 
 ```bash
 FA="node $(pwd)/cli/dist/figma-agent.js"
+$FA status --peek                                 # is anything alive? never spawns anything
 $FA status                                        # spawns the broker if absent; needs the plugin open
 $FA bind --file "Design System v4" --dir ~/code/your-app
-$FA create-frame --name Card --w 320 --h 200
+$FA create-frame --name Card --w 320 --h 200 --agent claude
 $FA html-to-figma --html page.html --width 1440
 $FA export-png --node <id> --out out.png          # then read the file to see the result
 $FA changes --owner-only                          # the designer's own edits, in plain sentences
+$FA cowork --wait 3                               # block until the designer stops editing
 $FA errors --limit 10                             # what went wrong, and why
 ```
 
-Every command prints one JSON object to stdout. See `cli/src/commands/` for the full list.
+Every command prints one JSON object to stdout. `figma-agent --help` lists all of them, and
+so does `skills/figma-agent/SKILL.md` — both rendered from one command table, so they cannot
+disagree.
+
+**When the plugin isn't open yet**, Figma offers no API to open it for you — that click is
+the one step that stays human. `status --wait` shrinks it to exactly that:
+
+```bash
+$FA status --wait --timeout 60    # blocks until a plugin registers; prints the figma:// link
+```
+
+The link comes from the file's bind record. When one can't be built — an unbound file, or a
+Figma Free file that has no `fileKey` — it says which of the two it is instead of printing a
+URL that opens nothing. On timeout it exits non-zero with `E_NO_PLUGIN`.
 
 ## The deterministic kernel (reconcile)
 
@@ -151,6 +210,21 @@ same node becomes an immutable linked correction in Figma shared plugin data.
 `design/memory/figma-corrections.jsonl`. Same-ID/different-hash conflicts are quarantined;
 corrections never promote themselves into knowledge.
 
+`cowork` is the live door onto that same ledger — no second store, no polling. It waits for
+one **designer change-cycle**: the designer edits, then goes quiet for `--wait` seconds, and
+the command returns with the nodes they touched plus any corrections still pending on them.
+
+```bash
+$FA cowork --wait 3 --timeout 600   # both in seconds; read-only against the ledger
+```
+
+Only a live edit whose actor is the *owner* arms that cycle — the agent's own writes, an
+edit nobody could confidently attribute, and the gap-fill replay after a reconnect all leave
+it alone, so an agent can never wake itself up. Quiet for the whole budget is a normal
+answer (`cycles: 0`, exit 0), not an error, and the plugin disconnecting mid-wait refuses
+with a reconnect hint rather than hanging to the deadline. Edits it declined to attribute
+are reported as a count rather than dropped.
+
 ## The panel
 
 Once loaded, the plugin opens a small (340×480) panel — the bridge's face. **Keep it open**
@@ -166,7 +240,8 @@ while you (or an agent) drive the CLI; closing it drops the connection.
 | **Connected** (green) | Ready — the CLI can drive this file. Shows the port + connection uptime. |
 
 **Activity log** lists recent commands (tool · duration · time-ago, newest first) so you can
-watch an agent work. **Connection details** (collapsible) exposes port, protocol version,
+watch an agent work — each row carrying the label of the harness that sent it when one was
+given (`--agent`). **Connection details** (collapsible) exposes port, protocol version,
 heartbeat age, reconnect attempts, and the file/page.
 
 ## Multiple files open at once
@@ -187,8 +262,9 @@ With the pin set and no open file matching, the command waits briefly then fails
 - **Panel says "No broker yet" and never connects** — that's the resting state; it only
   connects once a CLI command spawns the broker. Run `figma-agent status` to spawn + verify.
 - **`E_NO_PLUGIN`** — the broker is up but no panel is connected: open (or reopen) the plugin
-  and retry. Right after a rebuild the broker hot-replace can race the panel's reconnect
-  (<1s) — just retry.
+  and retry, or run `figma-agent status --wait`, which blocks until one registers and prints
+  the file's `figma://` link while it waits. Right after a rebuild the broker hot-replace can
+  race the panel's reconnect (<1s) — just retry.
 - **Stuck on "Looking for broker…"** — confirm a CLI command has actually run (the broker is
   demand-started) and that nothing else holds ports 9410–9419. `figma-agent status` is the
   one-shot health check.
@@ -206,6 +282,10 @@ inside this repo to enable them.
 
 - Broker/relay design adapted from `southleft/figma-console-mcp`'s websocket-server
   pending-request correlation and heartbeat approach (MIT).
+- The auto-connect surface — distributing a CLI's own skill to an agent, an `--agent`
+  presence label, and the "wait one designer change-cycle" idea — follows patterns studied in
+  `newfiction/cast-to-figma` (MIT). Patterns only, no code vendored; see
+  [THIRD-PARTY.md](THIRD-PARTY.md).
 - The plugin's HTML→Figma converter and node executors are ported from an earlier EaseUI
   internal tool (`figma-export.ts` / `figma-plugin/code.ts`).
 - `scripts/probe/` ideas draw on `Jane-xiaoer/claude-skill-web-clone`'s `visual-diff.mjs`

--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -1,11 +1,11 @@
 # Third-party attribution
 
-This repo absorbs specific capabilities studied from a fork of an existing open-source
-Figma tool, under its MIT license. This file lists exactly what was adapted, from where,
-and how — the citations in `plugin/src/main/` doc comments and `knowledge/` point back
-here.
+This repo absorbs specific capabilities studied from existing open-source Figma tools,
+under their MIT licenses. This file lists exactly what was adapted, from where, and how —
+the citations in `plugin/src/main/` doc comments and `knowledge/` point back here. Each
+source gets its own section below.
 
-## Source
+## Source — figma-console-mcp
 
 - Project: `figma-console-mcp` (Figma Desktop Bridge)
 - Read at: `southleft/figma-console-mcp` (studied locally as
@@ -58,6 +58,53 @@ source project's analysis code** (`code.js:1318`, `code.js:1176-1197`), cited fo
 re-verifiability — so a reader can go check the claim against the source — not
 reproduced as licensed expression. The table itself is rewritten in this repo's own
 words per `knowledge/component-sets.md` §2.3.
+
+## Source — cast-to-figma (the auto-connect surface)
+
+- Project: `cast-to-figma` (a local CLI + Figma plugin workflow, distributed with its own
+  agent skill)
+- Read at: `newfiction/cast-to-figma`, npm package `@newfiction/cast-to-figma`
+- Version read: **0.2.2**
+- Read date: **2026-08-12**
+- License: MIT
+
+Verbatim MIT notice from that project's `LICENSE`:
+
+```
+MIT License
+
+Copyright (c) 2026 New Fiction
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+**No code was vendored from this project — nothing here derives from its source
+expression.** What was studied is its README/SKILL.md and its CLI's user-facing surface:
+the *shape* of four ideas, each re-designed and re-implemented against this repo's own
+broker, protocol, and ledger.
+
+| Our file | Idea studied | Nature of adaptation |
+|---|---|---|
+| `cli/src/commands/install-skill.ts`, `cli/src/skill-emitter.ts`, `cli/src/command-catalog.ts`, `skills/figma-agent/SKILL.md` | A CLI that distributes its OWN agent skill, whose frontmatter declares the CLI version it needs (`requiresCli`) | Adopted: the concept of the skill as the distribution unit, the `requiresCli`/`version`/`cliBinary` frontmatter keys as a compatibility contract, and an installer command as the delivery path. Deliberately DIVERGENT, and the reason this was worth building rather than copying: the source ships a hand-written static `SKILL.md`, so its reference can drift from its binary. Here the command-reference section is **emitted** from the same `command-catalog.ts` that renders `--help`, and `tests/skill-emitter-drift.test.ts` fails the build when the committed artifact and the emitter disagree — the repo's standing "a standard needs an emitter AND a linter" rule. The consent behaviour (version compare before overwrite, a non-interactive run that refuses to assume) is this repo's own. |
+| `cli/src/transport/broker-peek.ts`, `cli/src/commands/install-hook.ts` | A session-start status surface an agent reads before doing anything | Concept only. The implementation is entirely this repo's: a non-spawning read of our own `/tmp` broker advertisement plus one short bounded WS query, three-state honesty (`connected: true|false|null`), and `versionMatch`/`protocolMatch` computed from the `pluginVersion` our plugin already sends on `PLUGIN_HELLO`. The consent rules around writing a hook into a user's settings file (confirm, backup, abort on unparseable JSON, `--dry-run`) have no counterpart in the source. |
+| `shared/protocol.ts` (`RequestMsg.agent`), `cli/src/transport/broker-client.ts`, `plugin/src/ui/activity-feed.ts`, `plugin/src/ui/panel-ui.ts` | An `--agent <id>` label so a panel can show which harness is driving | Adopted: the flag name, the env-var fallback, and the `cli` default. Implemented against our own envelope with this repo's additive-field contract — omitted entirely when unset so an unlabelled frame stays byte-identical to a pre-flag CLI's, with the default applied at render time instead. Validation against an explicit allowlist (refusing rather than sanitizing) is this repo's own. |
+| `cli/src/commands/cowork.ts`, `cli/src/transport/cowork-waiter.ts` | A `cowork` command that waits for the designer to finish a round of edits | Concept and command name only. This repo already had an actor-labelled edit feed and a supervised-memory correction ledger, so quiescence is detected broker-side from edits that already cross the wire — no second store, no new plugin timer, no polling. The actor/source gating (only a LIVE `owner` batch arms a cycle; agent, ambiguous, and gap-fill replay never do), the `cycles: 0`-is-success contract, and the read-only ledger lookup are this repo's own design. |
 
 ## Attribution already carried in `knowledge/figma-agent-hand.md`
 


### PR DESCRIPTION
Closes the documentation half of #56. Docs only — no source, no tests, no `SKILL.md` (that file is emitted).

## Why

Four capabilities shipped in #57/#60/#61/#63, and the README still described a bridge that assumed you already knew how to connect to it. It had started to lie by omission: `status --peek`, `--agent`, `status --wait`, and `cowork` appeared nowhere, and the architecture sketch showed no path by which an agent learns any of this.

## README

- **A fourth wall, placed first.** "Every AI-on-Figma setup hits the same three walls" becomes four: before undo, staleness, and trampling, the agent has no idea how to connect. That is the wall a user hits first, so it leads.
- **New section — "The agent arrives already knowing."** The skill installer and the SessionStart hook; why the skill's command reference is emitted from the same table `--help` renders and drift-tested rather than hand-written; why `status --peek` never spawns a broker; what `versionMatch`/`protocolMatch`/`connected: null` actually mean; and the consent rules both installers follow.
- **Architecture sketch** now shows `skills/figma-agent/SKILL.md` feeding the agent.
- **Command list** gains `status --peek`, `--agent`, and `cowork`, plus a short "when the plugin isn't open yet" block for `status --wait` and the `figma://` link.
- **Multiple files, one broker** picks up multi-*agent* presence; **The panel** notes the harness label on activity rows; **Troubleshooting**'s `E_NO_PLUGIN` entry points at `status --wait`.
- **Supervised editing loop** gains `cowork` as the live door onto the ledger it already describes — one designer change-cycle, no second store.

No changelog section: this repo has no `CHANGELOG.md` and its `CLAUDE.md` mandates none. Adopting one is a separate decision.

## THIRD-PARTY.md

New MIT attribution section for `newfiction/cast-to-figma` (v0.2.2, read 2026-08-12), matching the existing `figma-console-mcp` entry's format — source metadata, verbatim licence notice, and a table of what was adapted.

**No code was vendored.** Four ideas were studied from its README/SKILL.md and CLI surface: skill-as-distribution-unit with a `requiresCli` frontmatter contract, a session-start status surface, the `--agent` presence label, and the "wait one designer change-cycle" concept. The table names each divergence — chiefly that the source ships a hand-written `SKILL.md` that can drift from its binary, which is precisely why this repo emits and drift-tests its own.

## Claims and proof

Every added claim maps to a shipped test — `skill-emitter-drift`, `status-peek`, `status-wait`, `plugin-wait`, `figma-deep-link`, `install-skill`, `install-hook`, `agent-label-envelope`, `cowork-waiter`, `cowork-harness`.

Two things are deliberately **not** claimed:

- the relaunch-menu button, which remains unverified against a live Figma desktop file;
- any `cowork --timeout` beyond its documented ceiling (see #64).

## Gates

- `npm run lint:comments` — clean, 0 new citations.
- `npm test` — 1493 passed; the panel gate needed `git submodule update --init --depth 1` in a fresh worktree (as the README documents) and passes 43/43 after it.
- `typecheck`/`build` not run: nothing under `cli/src`, `plugin/`, `shared/`, or `tests/` was touched.