### PR TITLE
fix(cli): disclose capped cowork timeout

### DIFF
--- a/cli/src/commands/cowork.ts
+++ b/cli/src/commands/cowork.ts
@@ -19,6 +19,7 @@ interface CoworkWireResult {
   file: string | null;
   edits: EditInput[];
   ambiguousCount?: number;
+  timeoutCappedMs?: number;
 }
 
 interface CoworkEditOutput {
@@ -75,6 +76,7 @@ export async function run(args: CommandArgs): Promise<unknown> {
   const base = {
     cycles: wire.cycles, quietMs: wire.quietMs, waitedMs: wire.waitedMs, file: wire.file, edits,
     ...(wire.ambiguousCount !== undefined && { ambiguousCount: wire.ambiguousCount }),
+    ...(wire.timeoutCappedMs !== undefined && { timeoutCappedMs: wire.timeoutCappedMs }),
   };
 
   // Read-only ledger round trip — never SET_CORRECTION_MEMORY, never a jsonl write.

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -162,6 +162,9 @@ interface CoworkWaiterEntry {
   targetInstanceId: string;
   startedAt: number;
   state: CoworkWaiterState;
+  /** Set only when the caller's requested `timeoutMs` exceeded COWORK_MAX_TIMEOUT_MS —
+   *  same "nothing vanishes silently" disclosure contract as `ambiguousCount`. */
+  timeoutCappedMs?: number;
 }
 
 interface BrokerState {
@@ -1369,6 +1372,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       reqId: msg.id, from: ws, fileIdentity: fileIdentity(fileKey, fileName), fileName,
       targetInstanceId: target.instanceId, startedAt: now,
       state: createCoworkWaiter(waitMs, now + timeoutMs),
+      ...(requestedTimeoutMs > COWORK_MAX_TIMEOUT_MS && { timeoutCappedMs: COWORK_MAX_TIMEOUT_MS }),
     };
     st.coworkWaiters.push(entry);
     log(`cowork armed for "${fileName ?? '?'}" [${target.instanceId}] — quiet ${waitMs}ms, timeout ${timeoutMs}ms`);
@@ -1385,6 +1389,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // Nothing vanishes silently — present only once non-zero, same contract as the
     // broker's other diagnostic counters (senderMismatchCount, reHelloCount, ...).
     ...(entry.state.ambiguousCount > 0 && { ambiguousCount: entry.state.ambiguousCount }),
+    ...(entry.timeoutCappedMs !== undefined && { timeoutCappedMs: entry.timeoutCappedMs }),
   });
 
   const handleClose = (ws: WebSocket): void => {

--- a/tests/cowork-command.test.ts
+++ b/tests/cowork-command.test.ts
@@ -1,0 +1,37 @@
+// `figma-agent cowork`'s CLI boundary — `run()`'s own passthrough of the broker's
+// COWORK reply into the CLI's JSON output. `runCommand` (the broker round trip) is
+// mocked so this never needs a live broker/plugin; the harness-level proof that the
+// broker itself computes `timeoutCappedMs` correctly lives in cowork-harness.test.ts.
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../cli/src/transport/broker-client.ts', () => ({ runCommand: vi.fn() }));
+
+import { run } from '../cli/src/commands/cowork.ts';
+import { runCommand } from '../cli/src/transport/broker-client.ts';
+import { parseArgs } from '../cli/src/arg-parse.ts';
+
+function mockCoworkWire(coworkResult: Record<string, unknown>): void {
+  const mocked = vi.mocked(runCommand);
+  mocked.mockClear();
+  mocked.mockImplementation(async (cmd: string) => {
+    if (cmd === 'COWORK') {
+      return { cycles: 1, quietMs: 100, waitedMs: 100, file: 'F', edits: [], ...coworkResult };
+    }
+    if (cmd === 'GET_CORRECTION_MEMORY') return { events: [] };
+    throw new Error(`unexpected cmd ${cmd}`);
+  });
+}
+
+describe('cowork run() — timeoutCappedMs passthrough from the broker reply', () => {
+  it('the broker reply carrying timeoutCappedMs → the CLI output carries it too', async () => {
+    mockCoworkWire({ timeoutCappedMs: 1_800_000 });
+    const out = await run(parseArgs([])) as { timeoutCappedMs?: number };
+    expect(out.timeoutCappedMs).toBe(1_800_000);
+  });
+
+  it('the broker reply omitting timeoutCappedMs → the CLI output omits it entirely, never a stray key', async () => {
+    mockCoworkWire({});
+    const out = await run(parseArgs([]));
+    expect('timeoutCappedMs' in (out as object)).toBe(false);
+  });
+});

--- a/tests/cowork-harness.test.ts
+++ b/tests/cowork-harness.test.ts
@@ -9,7 +9,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
-import { makeRequestFrame } from '../shared/protocol.ts';
+import { COWORK_MAX_TIMEOUT_MS, makeRequestFrame } from '../shared/protocol.ts';
 import type { EventMsg, ReplyErr, ReplyOk, WireMsg } from '../shared/protocol.ts';
 
 type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts');
@@ -234,6 +234,42 @@ describe('cowork — the plugin disconnecting mid-wait refuses with a reconnect 
     expect((reply as ReplyErr).error.code).toBe('E_NO_PLUGIN');
     expect((reply as ReplyErr).error.message).toMatch(/reopen|reconnect/i);
     expect(elapsed).toBeLessThan(2_000); // reacted to the disconnect, did not wait out the deadline
+  });
+});
+
+describe('cowork — a requested --timeout past COWORK_MAX_TIMEOUT_MS discloses the cap, never silently', () => {
+  it('requested timeoutMs > cap → the fired reply carries timeoutCappedMs: COWORK_MAX_TIMEOUT_MS', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-cw-8', 'Cowork File G');
+    const cli = await connectSocket(port);
+
+    const replyPromise = nextFrame<ReplyOk | ReplyErr>(cli, (m) => (m as ReplyOk).id === 'req-cw-8');
+    sendCowork(cli, 'req-cw-8', { waitMs: 100, timeoutMs: COWORK_MAX_TIMEOUT_MS + 3_600_000 });
+    sendEditFeed(plugin, [ownerEdit('1:1')], { fileKey: null, fileName: 'Cowork File G' });
+
+    const reply = await replyPromise;
+    expect(reply.ok).toBe(true);
+    const result = (reply as ReplyOk).result as { cycles: number; timeoutCappedMs?: number };
+    expect(result.cycles).toBe(1);
+    expect(result.timeoutCappedMs).toBe(COWORK_MAX_TIMEOUT_MS);
+  });
+
+  it('requested timeoutMs at or below the cap → timeoutCappedMs is absent entirely', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-cw-9', 'Cowork File H');
+    const cli = await connectSocket(port);
+
+    const replyPromise = nextFrame<ReplyOk | ReplyErr>(cli, (m) => (m as ReplyOk).id === 'req-cw-9');
+    sendCowork(cli, 'req-cw-9', { waitMs: 100, timeoutMs: 5_000 });
+    sendEditFeed(plugin, [ownerEdit('1:1')], { fileKey: null, fileName: 'Cowork File H' });
+
+    const reply = await replyPromise;
+    expect(reply.ok).toBe(true);
+    const result = (reply as ReplyOk).result as { cycles: number; timeoutCappedMs?: number };
+    expect(result.cycles).toBe(1);
+    expect('timeoutCappedMs' in result).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- disclose `timeoutCappedMs: 1800000` when the broker clamps an oversized cowork timeout
- omit the field when the requested timeout is at or below the cap
- preserve the disclosure through the final CLI JSON output

## Verification

- `npx vitest run --config vitest.config.ts tests/cowork-command.test.ts tests/cowork-harness.test.ts tests/cowork-waiter.test.ts` — 24 passed
- `npm run typecheck` — passed
- `npm run build` — passed
- `npm test` — 123 files, 1547 tests passed
- `npm run lint:comments` — passed, 0 new citations

Tracks #64. Issue closure remains gated on the final auto-connect live audit.