### PR TITLE
fix(cli): route fresh Figma sessions to local skill

### DIFF
--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -117,9 +117,19 @@ export async function run(args: CommandArgs): Promise<InstallSkillResult> {
       skipped.push({ path: skillPath, reason: `unchanged (already v${CLI_VERSION})` });
     } else if (!yes) {
       const label = frontmatterVersion(existingContent) ?? 'unknown';
-      const ok = await confirm(`overwrite v${label} with v${CLI_VERSION}?`);
+      // Same version label but different bytes (e.g. a description update under an
+      // unchanged version number) — "overwrite vX with vX" would misreport this as a
+      // version bump when nothing about the version changed.
+      const sameVersion = label === CLI_VERSION;
+      const prompt = sameVersion
+        ? `local copy of v${label} differs from the emitted skill — overwrite?`
+        : `overwrite v${label} with v${CLI_VERSION}?`;
+      const declineReason = sameVersion
+        ? `declined overwrite: local copy differs from emitted skill (both v${label})`
+        : `declined overwrite of v${label}`;
+      const ok = await confirm(prompt);
       writeSkill = ok;
-      if (!ok) skipped.push({ path: skillPath, reason: `declined overwrite of v${label}` });
+      if (!ok) skipped.push({ path: skillPath, reason: declineReason });
     }
   }
   if (writeSkill) {

--- a/cli/src/commands/install-skill.ts
+++ b/cli/src/commands/install-skill.ts
@@ -104,14 +104,19 @@ export async function run(args: CommandArgs): Promise<InstallSkillResult> {
   const skipped: { path: string; reason: string }[] = [];
 
   const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+  const freshSkill = renderSkill();
   let writeSkill = true;
   if (existsSync(skillPath)) {
-    const existingVersion = frontmatterVersion(readFileSync(skillPath, 'utf8'));
-    if (existingVersion === CLI_VERSION) {
+    const existingContent = readFileSync(skillPath, 'utf8');
+    if (existingContent === freshSkill) {
+      // Exact-content match wins over any version check — a same-version file
+      // whose bytes differ (e.g. installed before an emitter description update
+      // shipped under an unchanged version number) must still be offered a
+      // reinstall, not silently declared unchanged.
       writeSkill = false;
       skipped.push({ path: skillPath, reason: `unchanged (already v${CLI_VERSION})` });
     } else if (!yes) {
-      const label = existingVersion ?? 'unknown';
+      const label = frontmatterVersion(existingContent) ?? 'unknown';
       const ok = await confirm(`overwrite v${label} with v${CLI_VERSION}?`);
       writeSkill = ok;
       if (!ok) skipped.push({ path: skillPath, reason: `declined overwrite of v${label}` });
@@ -119,7 +124,7 @@ export async function run(args: CommandArgs): Promise<InstallSkillResult> {
   }
   if (writeSkill) {
     mkdirSync(join(folder, 'figma-agent'), { recursive: true });
-    writeFileSync(skillPath, renderSkill());
+    writeFileSync(skillPath, freshSkill);
     installed.push(skillPath);
   }
 

--- a/cli/src/skill-template.ts
+++ b/cli/src/skill-template.ts
@@ -4,12 +4,14 @@
 
 export const SKILL_DESCRIPTION =
   'figma-agent — the CLI bridge to the Figma file already open in the designer\'s Figma '
-  + 'desktop app, over a local WebSocket broker. SessionStart already ran figma-agent '
-  + 'status --peek; when it reports a live connection, use THIS skill — not the DesignAgent '
-  + 'MCP or any other Figma bridge — for every request to inspect, read, edit, or check the '
-  + 'status of that open file: selection, nodes, layers, styles, components, variables, '
-  + 'frames, screenshots, or making changes to the canvas. Read connection state, then '
-  + 'read/write the open Figma document without the paid official write MCP.';
+  + 'desktop app, over a local WebSocket broker. SessionStart MAY have already run figma-agent '
+  + 'status --peek and left its result in context (only if the optional install-hook was set '
+  + 'up) — if no peek result is visible, run figma-agent status --peek first. When it reports '
+  + 'a live connection, use THIS skill — not the DesignAgent MCP or any other Figma bridge — '
+  + 'for every request to inspect, read, edit, or check the status of that open file: '
+  + 'selection, nodes, layers, styles, components, variables, frames, screenshots, or making '
+  + 'changes to the canvas. Read connection state, then read/write the open Figma document '
+  + 'without the paid official write MCP.';
 
 export const SKILL_INTRO = `# figma-agent
 

--- a/cli/src/skill-template.ts
+++ b/cli/src/skill-template.ts
@@ -3,9 +3,13 @@
 // command-catalog.ts by skill-emitter.ts). Pure data, no fs, no catalog import.
 
 export const SKILL_DESCRIPTION =
-  'figma-agent — the CLI bridge between an agent and a live Figma file, over a local '
-  + 'WebSocket broker. Use it to read connection state at session start, then read/write '
-  + 'the open Figma document without the paid official write MCP.';
+  'figma-agent — the CLI bridge to the Figma file already open in the designer\'s Figma '
+  + 'desktop app, over a local WebSocket broker. SessionStart already ran figma-agent '
+  + 'status --peek; when it reports a live connection, use THIS skill — not the DesignAgent '
+  + 'MCP or any other Figma bridge — for every request to inspect, read, edit, or check the '
+  + 'status of that open file: selection, nodes, layers, styles, components, variables, '
+  + 'frames, screenshots, or making changes to the canvas. Read connection state, then '
+  + 'read/write the open Figma document without the paid official write MCP.';
 
 export const SKILL_INTRO = `# figma-agent
 

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-agent
-description: "figma-agent — the CLI bridge to the Figma file already open in the designer's Figma desktop app, over a local WebSocket broker. SessionStart already ran figma-agent status --peek; when it reports a live connection, use THIS skill — not the DesignAgent MCP or any other Figma bridge — for every request to inspect, read, edit, or check the status of that open file: selection, nodes, layers, styles, components, variables, frames, screenshots, or making changes to the canvas. Read connection state, then read/write the open Figma document without the paid official write MCP."
+description: "figma-agent — the CLI bridge to the Figma file already open in the designer's Figma desktop app, over a local WebSocket broker. SessionStart MAY have already run figma-agent status --peek and left its result in context (only if the optional install-hook was set up) — if no peek result is visible, run figma-agent status --peek first. When it reports a live connection, use THIS skill — not the DesignAgent MCP or any other Figma bridge — for every request to inspect, read, edit, or check the status of that open file: selection, nodes, layers, styles, components, variables, frames, screenshots, or making changes to the canvas. Read connection state, then read/write the open Figma document without the paid official write MCP."
 version: 0.1.0
 requiresCli: ">=0.1.0"
 cliBinary: figma-agent

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: figma-agent
-description: "figma-agent — the CLI bridge between an agent and a live Figma file, over a local WebSocket broker. Use it to read connection state at session start, then read/write the open Figma document without the paid official write MCP."
+description: "figma-agent — the CLI bridge to the Figma file already open in the designer's Figma desktop app, over a local WebSocket broker. SessionStart already ran figma-agent status --peek; when it reports a live connection, use THIS skill — not the DesignAgent MCP or any other Figma bridge — for every request to inspect, read, edit, or check the status of that open file: selection, nodes, layers, styles, components, variables, frames, screenshots, or making changes to the canvas. Read connection state, then read/write the open Figma document without the paid official write MCP."
 version: 0.1.0
 requiresCli: ">=0.1.0"
 cliBinary: figma-agent

--- a/tests/install-skill.test.ts
+++ b/tests/install-skill.test.ts
@@ -63,6 +63,26 @@ describe('install-skill — writes the emitted SKILL.md, never a stale copy', ()
     expect(result.skipped.some((s) => s.path === skillPath && s.reason.includes('unchanged'))).toBe(true);
   });
 
+  it('same version, byte-different (stale description installed before an emitter update): --yes replaces it, no --yes preserves it and reports declined', async () => {
+    const folder = join(scratchDir, 'skills');
+    mkdirSync(join(folder, 'figma-agent'), { recursive: true });
+    const skillPath = join(folder, 'figma-agent', 'SKILL.md');
+    // Same version as CLI_VERSION, but the body differs from what renderSkill()
+    // produces now — e.g. installed before an emitter description update shipped
+    // under an unchanged version number.
+    const staleSameVersion = `---\nname: figma-agent\nversion: ${CLI_VERSION}\n---\nold description body`;
+    writeFileSync(skillPath, staleSameVersion);
+
+    const declined = await run(fakeArgs({ folder, 'no-craft': true }));
+    expect(readFileSync(skillPath, 'utf8')).toBe(staleSameVersion);
+    expect(declined.installed).not.toContain(skillPath);
+    expect(declined.skipped.some((s) => s.path === skillPath && s.reason.includes('declined'))).toBe(true);
+
+    const replaced = await run(fakeArgs({ folder, 'no-craft': true, yes: true }));
+    expect(readFileSync(skillPath, 'utf8')).toBe(renderSkill());
+    expect(replaced.installed).toContain(skillPath);
+  });
+
   it('older version present, --yes → overwrites without prompting', async () => {
     const folder = join(scratchDir, 'skills');
     mkdirSync(join(folder, 'figma-agent'), { recursive: true });


### PR DESCRIPTION
## Summary

- make the emitted skill explicitly win for the already-connected local Figma file
- preserve user edits while allowing `install-skill --yes` to refresh byte-different same-version skill content
- regenerate the committed skill artifact from its source

## Red / green

- pre-fix regression: same-version stale skill was silently marked unchanged
- post-fix: exact bytes are the no-op condition; stale bytes require consent or `--yes`
- focused: 2 files / 16 tests passed
- typecheck/build passed
- live fresh-session rerun automatically selected `Skill(figma-agent)`, then `status --peek` + `get-selection`; versionMatch=true

Tracks #56. Closure remains gated on the remaining live acceptance and Fable audit.