### PR TITLE
docs: attribute a missing fileKey to the plugin manifest, not the Figma plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,8 @@ $FA status --wait --timeout 60    # blocks until a plugin registers; prints the 
 ```
 
 The link comes from the file's bind record. When one can't be built — an unbound file, or a
-Figma Free file that has no `fileKey` — it says which of the two it is instead of printing a
+plugin build that never reported a `fileKey` (reading it needs `enablePrivatePluginApi` in the
+manifest, which this repo now ships) — it says which of the two it is instead of printing a
 URL that opens nothing. On timeout it exits non-zero with `E_NO_PLUGIN`.
 
 ## The deterministic kernel (reconcile)

--- a/cli/src/transport/figma-deep-link.ts
+++ b/cli/src/transport/figma-deep-link.ts
@@ -22,7 +22,7 @@ const NO_FILE_KEY_REASON = 'file has no fileKey (Free plan) — open the file ma
 /**
  * `entry === null` → no binding at all was found for the file in question.
  * `entry.fileKey === null` → bound, but the file has never carried an org fileKey
- * (a Figma Free file, or one bound before its first connect) — a deep link cannot be
+ * (a plugin running without enablePrivatePluginApi, or a file bound before its first connect) — a deep link cannot be
  * built for it. `entry.fileKey` a string → `figma://file/<fileKey>`.
  */
 export function buildDeepLink(entry: DeepLinkEntry | null): DeepLinkResult {

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -5455,9 +5455,9 @@
     const changes = coalesceChanges(raw);
     if (changes.length > 0) {
       figma.ui.postMessage({
-        // fileName rides alongside fileKey (registry-integrity phase 03, §1) — a Figma-Free
-        // file's fileKey is null, so without a name the slug chain collapses every such
-        // file to 'unknown' and keeps coalescing them together.
+        // fileName rides alongside fileKey (registry-integrity phase 03, §1) — fileKey is
+        // null whenever the manifest lacks enablePrivatePluginApi, so without a name the
+        // slug chain collapses every such file to 'unknown' and keeps coalescing them.
         type: "DOC_CHANGE",
         data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null, fileName: figma.root.name }
       });

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -396,9 +396,9 @@ function onDocumentChange(event: DocumentChangeEvent): void {
   const changes = coalesceChanges(raw);
   if (changes.length > 0) {
     figma.ui.postMessage({
-      // fileName rides alongside fileKey (registry-integrity phase 03, §1) — a Figma-Free
-      // file's fileKey is null, so without a name the slug chain collapses every such
-      // file to 'unknown' and keeps coalescing them together.
+      // fileName rides alongside fileKey (registry-integrity phase 03, §1) — fileKey is
+      // null whenever the manifest lacks enablePrivatePluginApi, so without a name the
+      // slug chain collapses every such file to 'unknown' and keeps coalescing them.
       type: 'DOC_CHANGE',
       data: { changes, page: figma.currentPage.name, fileKey: figma.fileKey ?? null, fileName: figma.root.name },
     });

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1460,7 +1460,7 @@ code {
     } catch {
     }
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "b6681f7" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "1564326" : "dev"}`;
   setInterval(render, 1e3);
   render();
 


### PR DESCRIPTION
Three sites blamed "Figma Free" for a null `fileKey`. Live check on a Pro seat proved the real gate is `enablePrivatePluginApi` in the manifest (now shipped): with the flag, the same file reports a real key and the `figma://` deep link builds. Reworded README, the deep-link module header, and the DOC_CHANGE comment to name the actual cause. Prose/comments only, no behavior.