### PR TITLE
fix(cli): dispatch commands through executable symlinks

### DIFF
--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -8,7 +8,8 @@
 // this module (e.g. for COMMAND_MODULES) without accidentally dispatching a
 // command from the TEST RUNNER's own argv.
 import { resolve } from 'node:path';
-import { pathToFileURL } from 'node:url';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { runBrokerDaemon } from './transport/broker-daemon.ts';
 import { parseArgs, type CommandArgs } from './arg-parse.ts';
 import { CliError } from './transport/protocol-helpers.ts';
@@ -197,7 +198,16 @@ async function main(): Promise<void> {
 // <args>`), never on a plain `import` — the guard is what lets
 // tests/skill-emitter-drift.test.ts import COMMAND_MODULES from this module without
 // dispatching a command from the TEST RUNNER's own argv.
-const isEntrypoint = process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href;
+function isProcessEntrypoint(argvPath: string | undefined): boolean {
+  if (argvPath === undefined) return false;
+  try {
+    return realpathSync(fileURLToPath(import.meta.url)) === realpathSync(argvPath);
+  } catch {
+    return false;
+  }
+}
+
+const isEntrypoint = isProcessEntrypoint(process.argv[1]);
 if (isEntrypoint) {
   main().catch((err) => printErrorJson(err));
 }

--- a/tests/cli-symlink-entrypoint.test.ts
+++ b/tests/cli-symlink-entrypoint.test.ts
@@ -1,0 +1,67 @@
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, symlinkSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CLI_DIST = fileURLToPath(new URL('../cli/dist/figma-agent.js', import.meta.url));
+
+describe('CLI symlink entrypoint', () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'figma-agent-entrypoint-'));
+  const symlinkPath = join(tempDir, 'figma-agent');
+  const preservedTempDir = mkdtempSync(join(ROOT, '.figma-agent-entrypoint-'));
+  const preservedSymlinkPath = join(preservedTempDir, 'figma-agent');
+
+  beforeAll(() => {
+    const build = spawnSync(process.execPath, ['scripts/build.mjs', 'cli'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    });
+    expect(build.status, build.stderr).toBe(0);
+    symlinkSync(CLI_DIST, symlinkPath, 'file');
+    symlinkSync(CLI_DIST, preservedSymlinkPath, 'file');
+  });
+
+  afterAll(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+    rmSync(preservedTempDir, { recursive: true, force: true });
+  });
+
+  it('dispatches help identically through the real path and a filesystem symlink', () => {
+    const direct = spawnSync(process.execPath, [CLI_DIST, '--help'], { encoding: 'utf8' });
+    const linked = spawnSync(process.execPath, [symlinkPath, '--help'], { encoding: 'utf8' });
+
+    expect(direct.status, direct.stderr).toBe(0);
+    expect(linked.status, linked.stderr).toBe(direct.status);
+    expect(linked.stdout).toBe(direct.stdout);
+    expect(linked.stdout).not.toBe('');
+  });
+
+  it('dispatches through a symlink when Node preserves the main module path', () => {
+    const direct = spawnSync(process.execPath, [CLI_DIST, '--help'], { encoding: 'utf8' });
+    const linked = spawnSync(process.execPath, ['--preserve-symlinks-main', preservedSymlinkPath, '--help'], {
+      encoding: 'utf8',
+    });
+
+    expect(linked.status, linked.stderr).toBe(direct.status);
+    expect(linked.stdout).toBe(direct.stdout);
+    expect(linked.stdout).not.toBe('');
+  });
+
+  it('does not dispatch or throw when imported with a missing process entry path', () => {
+    const importScript = [
+      "import { pathToFileURL } from 'node:url';",
+      `process.argv[1] = ${JSON.stringify(join(tempDir, 'missing-entrypoint.js'))};`,
+      `await import(pathToFileURL(${JSON.stringify(CLI_DIST)}).href);`,
+      "process.stdout.write('imported');",
+    ].join('\n');
+    const imported = spawnSync(process.execPath, ['--input-type=module', '--eval', importScript], {
+      encoding: 'utf8',
+    });
+
+    expect(imported.status, imported.stderr).toBe(0);
+    expect(imported.stdout).toBe('imported');
+  });
+});


### PR DESCRIPTION
## End-to-end work summary

The bundled CLI now recognizes its process entrypoint through a real filesystem symlink. The guard compares canonical paths on both sides and treats an unresolvable process entry path as a plain import, preserving import-without-dispatch behavior.

## Subagent delegation

- Implementation worker added the failing regression and initial minimal fix.
- Debug review identified `--preserve-symlinks-main` and missing `argv[1]` path edges.
- Production review verified the hardened implementation and regression coverage.
- Git manager committed and pushed the reviewed two-file scope.

## Technical decisions

- Canonicalize both `import.meta.url` and `process.argv[1]` with `realpathSync`.
- Keep canonicalization inside a non-throwing entrypoint predicate so programmatic imports remain safe.
- Exercise a real filesystem symlink, Node preserved-main-symlink mode, and a missing process entry path.

## Deviations from plan

The initial one-sided canonicalization was expanded after review showed it could throw during a plain import and could still skip dispatch with `--preserve-symlinks-main`. The accepted outcome and external contracts are unchanged.

## Completion evidence

- Test-first proof: the original regression failed on unmodified `main` with exit 0 and empty stdout through the symlink.
- Focused tests: 2 files, 7 tests passed.
- Full suite: 126 files, 1,619 tests passed.
- Typecheck: passed.
- Comment hygiene: clean, zero new findings.
- Build: passed.
- `git diff --check`: passed.
- Independent spec and production re-review: PASS, no findings.

## Checklist

- [x] Change is scoped to CLI entrypoint identity.
- [x] Direct invocation behavior is preserved.
- [x] Import-without-dispatch behavior is preserved.
- [x] No command, broker, transport, wire, or Figma plugin contract changed.
- [x] No installer, publication, or version changes.
- [x] Tests and build pass locally.

## Human actions required

None.

## Linked Issues

Closes #71

## Ship Mode

English fallback.