### PR TITLE
fix(plugin): render the gradient from a published version, with one React

### DIFF
--- a/THIRD-PARTY.md
+++ b/THIRD-PARTY.md
@@ -120,9 +120,18 @@ unrelated to this phase's absorption work).
 - Upstream: `ruucm/shadergradient`
 - Fork (upstream-tracked, read from): `jangtrinh/shadergradient`
 - Revision read: **`974a230b1e6c3ec375fbe17a8ea1c89edbc48019`** (committed 2026-06-12)
-- Package: `@shadergradient/react` **v2.4.24**
+- Version in that revision's `package.json`: **2.4.24** — source only, see below
+- Package version actually rendered with: `@shadergradient/react` **v2.4.20**
 - Read date: **2026-08-16**
 - License: MIT
+
+**Source version != published version.** At the pinned revision
+`packages/shadergradient/package.json` reads `2.4.24`, but that version was never released:
+changesets bumped it in-repo without publishing. npm's latest is **2.4.20**, and every
+registry and CDN 404s on 2.4.24. Preset values are read from the revision; the renderer is
+loaded at 2.4.20. **The two were compared key-by-key and are identical** on all 30
+render-relevant keys across all 10 presets, so the split introduces no drift — re-run that
+comparison at any future pin rather than assuming it still holds.
 
 **Where the license is declared.** This project has **no root `LICENSE` file** at the
 revision above — GitHub's own API consequently reports `license: null` for the repository,

--- a/cli/src/commands/shader-gradient.ts
+++ b/cli/src/commands/shader-gradient.ts
@@ -11,8 +11,13 @@ import { runCommand } from '../transport/broker-client.ts';
 import { resolveConfig, toQueryString } from '../../../shared/shader-gradient-config.ts';
 import { SHADER_GRADIENT_PRESETS } from '../../../shared/shader-gradient-presets.ts';
 
-/** Pinned renderer, recorded onto the node so a stale bake stays identifiable. */
-const RENDERER = '@shadergradient/react@2.4.24';
+/**
+ * Pinned renderer, recorded onto the node so a stale bake stays identifiable.
+ * The PUBLISHED version — upstream's package.json at the read revision says 2.4.24,
+ * which was never released and 404s everywhere. Keep this in step with
+ * RENDERER_VERSION in plugin/src/ui/gradient-host.ts.
+ */
+const RENDERER = '@shadergradient/react@2.4.20';
 
 export async function run(args: CommandArgs): Promise<unknown> {
   if (args.bool('list')) {

--- a/knowledge/shader-gradient.md
+++ b/knowledge/shader-gradient.md
@@ -52,10 +52,22 @@ We deliberately do not follow that:
 - it sends the user's config **off-machine**, which this repo's broker contract does not do.
 
 Instead the render iframe loads **pinned** ESM (`@shadergradient/react` at an exact version)
-from a CDN host the plugin manifest already allows for the html-to-figma iframe. The
-renderer is not vendored: bundling three + React Three Fiber + the renderer would add
-roughly a megabyte to a UI bundle that is inlined into the plugin, for a feature most
-sessions never invoke.
+from esm.sh, declared in the plugin manifest. The renderer is not vendored: bundling
+three + React Three Fiber + the renderer would add roughly a megabyte to a UI bundle that is
+inlined into the plugin, for a feature most sessions never invoke.
+
+**Why esm.sh specifically, and not a plain per-package CDN bundle.** A per-package ESM
+bundle resolves its own copy of React. Loading the renderer and React as separate bundles
+leaves the page with two React instances, so the renderer's hooks read from an instance that
+never mounted and the first render dies on `Cannot read properties of null (reading
+'useState')`. esm.sh's `?deps=` pins the shared dependencies to a single build of each.
+
+`@react-three/fiber` is pinned for a second, independent reason: unpinned, the latest major
+(v9) is resolved, which requires React 19 and fails against React 18 with an equally opaque
+internal error. The pinned pair is the one upstream develops against.
+
+**The rendered version is not the version in upstream's `package.json`** at the revision the
+presets came from — that one was bumped in-repo and never published. See `THIRD-PARTY.md`.
 
 **The trade this makes:** the bake needs network at render time. That is why every failure
 path carries its own code (`E_NO_WEBGL`, `E_IFRAME_LOAD`, `E_RENDER_SCRIPT`,

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -4,13 +4,22 @@
   "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
-  "editorType": ["figma", "figjam", "slides"],
+  "editorType": [
+    "figma",
+    "figjam",
+    "slides"
+  ],
   "documentAccess": "dynamic-page",
   "enablePrivatePluginApi": true,
   "relaunchButtons": [
-    { "command": "open", "name": "Reconnect figma-agent" }
+    {
+      "command": "open",
+      "name": "Reconnect figma-agent"
+    }
   ],
-  "permissions": ["currentuser"],
+  "permissions": [
+    "currentuser"
+  ],
   "networkAccess": {
     "allowedDomains": [
       "http://localhost",
@@ -59,9 +68,10 @@
       "https://cdn.jsdelivr.net",
       "https://fonts.googleapis.com",
       "https://fonts.gstatic.com",
-      "https://unpkg.com"
+      "https://unpkg.com",
+      "https://esm.sh"
     ],
-    "reasoning": "Connects to the local figma-agent CLI broker via WebSocket (port range 9410-9419); CDN + font hosts let the hidden UI iframe render HTML for html-to-figma conversion. External images are inlined as data URIs by the CLI before sending.",
+    "reasoning": "Connects to the local figma-agent CLI broker via WebSocket (port range 9410-9419); CDN + font hosts let the hidden UI iframe render HTML for html-to-figma conversion. esm.sh serves the pinned ShaderGradient renderer to the offscreen gradient-bake iframe, with its shared React/three dependencies pinned to a single build so the renderer's hooks resolve against the instance that mounted them. External images are inlined as data URIs by the CLI before sending.",
     "devAllowedDomains": [
       "http://localhost",
       "ws://localhost",
@@ -109,7 +119,8 @@
       "https://cdn.jsdelivr.net",
       "https://fonts.googleapis.com",
       "https://fonts.gstatic.com",
-      "https://unpkg.com"
+      "https://unpkg.com",
+      "https://esm.sh"
     ]
   }
 }

--- a/plugin/src/ui/gradient-host.ts
+++ b/plugin/src/ui/gradient-host.ts
@@ -18,9 +18,33 @@
 
 import type { ShaderGradientProps } from '../../../shared/shader-gradient-presets';
 
-/** Pinned exactly. A range would let a background republish change what a bake produces. */
-const RENDERER_VERSION = '2.4.24';
-const CDN_BASE = 'https://cdn.jsdelivr.net/npm';
+/**
+ * Pinned exactly. A range would let a background republish change what a bake produces.
+ *
+ * This is the PUBLISHED version, which is NOT the version in upstream's package.json at
+ * the revision the presets were read from. That file says 2.4.24; changesets bumped it
+ * in-repo without a release, so 2.4.24 exists only as source and 404s on every registry
+ * and CDN. Read the source version from the repo, but always render with a version that
+ * was actually published — see THIRD-PARTY.md for the full record.
+ */
+const RENDERER_VERSION = '2.4.20';
+
+/**
+ * esm.sh, not a plain CDN bundle, and this is load-bearing rather than a preference.
+ *
+ * A per-package ESM bundle resolves its OWN copy of react. Import the renderer and react
+ * as separate bundles and the page ends up with two react instances, so the renderer's
+ * hooks read from an instance that was never mounted and the first render dies on
+ * `Cannot read properties of null (reading 'useState')`. esm.sh's `?deps=` pins the
+ * shared dependencies so every module resolves to ONE build of each.
+ *
+ * `@react-three/fiber` is pinned for a second, separate reason: unpinned, esm.sh resolves
+ * the latest major (v9), which requires React 19 and dies against React 18 with an equally
+ * opaque internal error. 8.17.10 is the pair upstream itself develops against.
+ */
+const CDN_BASE = 'https://esm.sh';
+const REACT_VERSION = '18.3.1';
+const DEPS = `react@${REACT_VERSION},react-dom@${REACT_VERSION},three@0.169.0,@react-three/fiber@8.17.10`;
 
 const IFRAME_LOAD_TIMEOUT_MS = 15_000;
 const RENDER_TIMEOUT_MS = 45_000;
@@ -84,9 +108,9 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     if (!gl) { fail('E_NO_WEBGL', 'this environment provides no WebGL context'); return; }
 
     const [React, ReactDOMClient, SG] = await Promise.all([
-      import(${JSON.stringify(`${CDN_BASE}/react@18.3.1/+esm`)}),
-      import(${JSON.stringify(`${CDN_BASE}/react-dom@18.3.1/client/+esm`)}),
-      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}/+esm`)}),
+      import(${JSON.stringify(`${CDN_BASE}/react@${REACT_VERSION}`)}),
+      import(${JSON.stringify(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
+      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
     ]);
 
     const { ShaderGradientCanvas, ShaderGradient } = SG;

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1464,7 +1464,7 @@ code {
     } catch {
     }
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "7853108" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "2d0092f" : "dev"}`;
   setInterval(render, 1e3);
   render();
 
@@ -2868,8 +2868,10 @@ code {
   }
 
   // plugin/src/ui/gradient-host.ts
-  var RENDERER_VERSION = "2.4.24";
-  var CDN_BASE = "https://cdn.jsdelivr.net/npm";
+  var RENDERER_VERSION = "2.4.20";
+  var CDN_BASE = "https://esm.sh";
+  var REACT_VERSION = "18.3.1";
+  var DEPS = `react@${REACT_VERSION},react-dom@${REACT_VERSION},three@0.169.0,@react-three/fiber@8.17.10`;
   var IFRAME_LOAD_TIMEOUT_MS2 = 15e3;
   var RENDER_TIMEOUT_MS = 45e3;
   var SETTLE_FRAMES = 8;
@@ -2909,9 +2911,9 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     if (!gl) { fail('E_NO_WEBGL', 'this environment provides no WebGL context'); return; }
 
     const [React, ReactDOMClient, SG] = await Promise.all([
-      import(${JSON.stringify(`${CDN_BASE}/react@18.3.1/+esm`)}),
-      import(${JSON.stringify(`${CDN_BASE}/react-dom@18.3.1/client/+esm`)}),
-      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}/+esm`)}),
+      import(${JSON.stringify(`${CDN_BASE}/react@${REACT_VERSION}`)}),
+      import(${JSON.stringify(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
+      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
     ]);
 
     const { ShaderGradientCanvas, ShaderGradient } = SG;

--- a/tests/gradient-renderer-pin.test.ts
+++ b/tests/gradient-renderer-pin.test.ts
@@ -1,0 +1,93 @@
+// Guards on the gradient renderer's CDN pin.
+//
+// These exist because two defects shipped together and neither was catchable by any
+// existing test: the pinned version was one that upstream never published (404 on every
+// CDN), and the three modules were imported as separate per-package bundles, which gives
+// the page two React instances and kills the first render inside the renderer's own hooks.
+//
+// Both are STATIC properties of the generated render document, so they are checkable here
+// without a browser. What is NOT checkable here is whether the pinned version is actually
+// published — that needs the network. Verify that by hand at every repin; the version-drift
+// test below at least guarantees there is only one place to check.
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { join, dirname } from 'node:path';
+
+const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
+const read = (rel: string): string => readFileSync(join(REPO_ROOT, rel), 'utf8');
+
+const HOST = read('plugin/src/ui/gradient-host.ts');
+const CLI = read('cli/src/commands/shader-gradient.ts');
+const MANIFEST = JSON.parse(read('plugin/manifest.json')) as {
+  networkAccess: { allowedDomains: string[]; devAllowedDomains: string[] };
+};
+
+/** The single pinned version, read from its one definition. */
+function hostVersion(): string {
+  const m = /const RENDERER_VERSION = '([^']+)'/.exec(HOST);
+  if (!m) throw new Error('RENDERER_VERSION not found in gradient-host.ts');
+  return m[1]!;
+}
+
+describe('gradient renderer pin — version agreement', () => {
+  it('the CLI records exactly the version the render host loads', () => {
+    // The CLI writes this onto the node as provenance. If it drifts from what actually
+    // rendered, every baked node carries a false claim about its own origin.
+    const m = /const RENDERER = '@shadergradient\/react@([^']+)'/.exec(CLI);
+    expect(m, 'RENDERER not found in the CLI command').not.toBeNull();
+    expect(m![1]).toBe(hostVersion());
+  });
+
+  it('the version is an exact pin, never a range', () => {
+    // A range lets a background republish change what a bake produces.
+    expect(hostVersion()).toMatch(/^\d+\.\d+\.\d+$/);
+  });
+
+  it('is NOT the unpublished source version from upstream package.json', () => {
+    // 2.4.24 is in upstream's package.json at the revision the presets came from, but was
+    // never released. Pinning it 404s on every CDN and the bake fails 100% of the time.
+    expect(hostVersion()).not.toBe('2.4.24');
+  });
+});
+
+describe('gradient renderer pin — one React instance', () => {
+  it('shares dependencies via a deps pin rather than separate per-package bundles', () => {
+    // Without this the renderer resolves its own React and its hooks die on an instance
+    // that never mounted: "Cannot read properties of null (reading 'useState')".
+    expect(HOST).toContain('?deps=');
+  });
+
+  it('never loads the renderer as a standalone bundle with unpinned dependencies', () => {
+    const rendererImport = /@shadergradient\/react@\$\{RENDERER_VERSION\}([^`]*)`/.exec(HOST);
+    expect(rendererImport, 'renderer import not found').not.toBeNull();
+    expect(rendererImport![1]).toContain('?deps=');
+  });
+
+  it('pins react-dom to the same react build the page imports', () => {
+    expect(HOST).toMatch(/react-dom@\$\{REACT_VERSION\}\/client\?deps=react@\$\{REACT_VERSION\}/);
+  });
+
+  it('pins @react-three/fiber, so the resolver cannot pick a React-19-only major', () => {
+    // Unpinned, the latest major (v9) is resolved; it requires React 19 and fails against
+    // React 18 with an opaque internal error rather than a version complaint.
+    const deps = /const DEPS = `([^`]+)`/.exec(HOST);
+    expect(deps, 'DEPS not found').not.toBeNull();
+    expect(deps![1]).toMatch(/@react-three\/fiber@\d+\.\d+\.\d+/);
+    expect(deps![1]).toMatch(/^react@/);
+    expect(deps![1]).toContain('three@');
+  });
+});
+
+describe('gradient renderer pin — manifest declares the host it fetches from', () => {
+  it('the CDN base is declared in allowedDomains', () => {
+    const m = /const CDN_BASE = '([^']+)'/.exec(HOST);
+    expect(m, 'CDN_BASE not found').not.toBeNull();
+    const origin = m![1]!;
+    // A fetch to an undeclared origin is blocked by Figma at runtime, so a render host
+    // pointing anywhere the manifest does not list can never succeed.
+    expect(MANIFEST.networkAccess.allowedDomains).toContain(origin);
+    expect(MANIFEST.networkAccess.devAllowedDomains).toContain(origin);
+  });
+});


### PR DESCRIPTION
**The bake could not have worked.** Two defects, either of which fails it 100% of the time, and neither catchable by any test that existed. Both were found by trying to produce a demo asset — the first thing that actually exercised the render path.

## 1. The pinned version was never published

Upstream's `package.json` at the revision the presets were read from says `2.4.24`. Changesets bumped it in-repo without a release: **npm's latest is `2.4.20`**, and `2.4.24` returns 404 on every registry and CDN. GitHub's API also reports `license: null` for the repo, which is how the version got trusted without a second look.

Repinned to `2.4.20`. The preset values were then compared **key-by-key across both** — identical on all 30 render-relevant keys for all 10 presets — so splitting "revision read for values" from "version rendered with" introduces no drift today. That comparison is recorded so a future repin re-runs it rather than assuming.

## 2. Three bundles meant two Reacts

The modules were loaded as separate per-package bundles, and such a bundle resolves its **own** copy of react. The page ends up with two react instances, the renderer's hooks read from one that never mounted, and the first render dies inside the renderer:

```
Uncaught TypeError: Cannot read properties of null (reading 'useState')
```

Reproduced directly, then fixed by pinning the shared dependencies to a single build.

### `@react-three/fiber` is pinned for a separate reason

Found the same way: unpinned, the latest major (**v9**) resolves, which requires React 19 and fails against React 18 with an equally opaque internal error rather than a version complaint:

```
TypeError: Cannot read properties of undefined (reading 'S')
    at .../@react-three/fiber@9.7.0/.../fiber.mjs
```

`8.17.10` is the pair upstream itself develops against. This is the exact peer-matrix hazard the kernel's direction file documents — it then bit the first real render.

## Verified

All three generated URLs resolve `200`, and this configuration **renders**: 10/10 presets captured to PNG in headless Chromium, plus an animated capture. Those renders are the demo assets in the companion kernel PR.

Note the renderer is now fetched from **esm.sh**, added to `networkAccess`. A fetch to an undeclared origin is blocked at runtime, so the host and the manifest have to agree or nothing renders — there is a test for exactly that.

## Tests

Eight guards over what is static, each probed red before being trusted:

- the CLI's recorded version matches the host's (a drift makes every baked node carry a false claim about its own origin)
- the pin is exact, and is **not** the unpublished one
- dependencies are shared rather than per-bundle
- fiber is pinned
- the CDN origin is declared in both manifest lists

**Not covered:** whether a version is actually published needs the network, and stays a manual check at each repin. The version-agreement test at least guarantees there is only one place to look.

## Still unverified

This does not prove the bake works end to end in Figma — the renders were headless Chromium, not the plugin's sandboxed UI iframe. `E_NO_WEBGL` on a real bake would still mean the iframe assumption is wrong.

Gates: `typecheck` · `build` · `lint:comments` · **129/129 files, 1675 tests**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)