### PR TITLE
fix(plugin): boot gap-fill walks each page once and yields between pages

### DIFF
--- a/plugin/code.js
+++ b/plugin/code.js
@@ -132,6 +132,12 @@
     if (current.length > 0) chunks.push(JSON.stringify(current));
     return chunks;
   }
+  function snapshotProviderFrom(precomputed, fallback) {
+    return (page) => precomputed.get(page.id) ?? fallback(page);
+  }
+  function yieldToHost() {
+    return new Promise((resolve) => setTimeout(resolve, 0));
+  }
   var MOVE_EPSILON = 0.5;
   function diffSnapshots(prev, next) {
     const prevById = new Map(prev.map((n) => [n.id, n]));
@@ -252,13 +258,13 @@
       return prevEntry ? { entry: prevEntry, chunksToWrite: null } : null;
     }
   }
-  function writeSnapshot(pages) {
+  function writeSnapshot(pages, snapshotFor = snapshotPage) {
     const prevManifest = readManifest();
     const manifest = { v: 1, pages: [] };
     const currentPageIds = new Set(pages.map((p) => p.id));
     for (const page of pages) {
       const prevEntry = prevManifest?.pages.find((p) => p.pageId === page.id);
-      const result = resolvePageWrite(page, prevEntry, () => snapshotPage(page));
+      const result = resolvePageWrite(page, prevEntry, () => snapshotFor(page));
       if (!result) continue;
       if (result.chunksToWrite === null) {
         manifest.pages.push(result.entry);
@@ -289,13 +295,22 @@
     } catch {
     }
   }
-  function runGapfillDiff(pages) {
+  async function runGapfillDiff(pages) {
     const prev = readManifest();
     if (!prev) {
-      writeSnapshot(pages);
+      const firstRun = /* @__PURE__ */ new Map();
+      for (const page of pages) {
+        await yieldToHost();
+        try {
+          firstRun.set(page.id, snapshotPage(page));
+        } catch {
+        }
+      }
+      writeSnapshot(pages, snapshotProviderFrom(firstRun, snapshotPage));
       return [];
     }
     const edits = [];
+    const walked = /* @__PURE__ */ new Map();
     const currentPageIds = new Set(pages.map((p) => p.id));
     for (const deletedId of deletedPageIds(prev.pages.map((p) => p.pageId), currentPageIds)) {
       const prevEntry = prev.pages.find((p) => p.pageId === deletedId);
@@ -308,9 +323,11 @@
       ));
     }
     for (const page of pages) {
+      await yieldToHost();
       const prevEntry = prev.pages.find((p) => p.pageId === page.id);
       const prevRecords = prevEntry ? readPageChunks(prevEntry) : [];
       const { records: nextRecords, truncated: nextTruncated } = snapshotPage(page);
+      walked.set(page.id, { records: nextRecords, truncated: nextTruncated });
       if (pageWasTruncated(prevEntry?.truncated, nextTruncated)) {
         edits.push(toGapfillEdit("updated", { id: `truncated:${page.id}`, name: page.name, type: "PAGE", x: 0, y: 0, parent: null }, page.name, ["truncated"]));
         continue;
@@ -318,7 +335,7 @@
       const diff = diffSnapshots(prevRecords, nextRecords);
       edits.push(...gapfillEditsForPage(diff, page.name));
     }
-    writeSnapshot(pages);
+    writeSnapshot(pages, snapshotProviderFrom(walked, snapshotPage));
     return edits;
   }
 
@@ -5543,8 +5560,8 @@
     }
     if (changes.length > 0 || edits.length > 0) resetIdleTimer();
   }
-  figma.loadAllPagesAsync().then(() => {
-    const gapfillEdits = runGapfillDiff(figma.root.children);
+  figma.loadAllPagesAsync().then(async () => {
+    const gapfillEdits = await runGapfillDiff(figma.root.children);
     if (gapfillEdits.length > 0) {
       figma.ui.postMessage({
         type: "EDIT_FEED",

--- a/plugin/src/main/edit-gapfill.ts
+++ b/plugin/src/main/edit-gapfill.ts
@@ -85,6 +85,25 @@ export function splitSnapshotChunks(records: readonly NodeSnapshot[]): string[] 
   return chunks;
 }
 
+/** Boot-path seam: `runGapfillDiff` has ALREADY walked every page once for its diff, so
+ *  the baseline write must reuse those results instead of walking the whole document a
+ *  second time (the double walk was measured as the boot freeze on large files). Reusing
+ *  the PRE-diff snapshot is also the correct baseline: an edit made while the diff is
+ *  yielding must NOT be baked into the baseline it was absent from, or the next session's
+ *  gap-fill would never report it. Pure — unit-tested directly. */
+export function snapshotProviderFrom<P extends { id: string }, R>(
+  precomputed: ReadonlyMap<string, R>,
+  fallback: (page: P) => R,
+): (page: P) => R {
+  return (page) => precomputed.get(page.id) ?? fallback(page);
+}
+
+/** One macrotask hop between per-page walks, so the boot diff never holds the plugin's
+ *  single thread for the whole document at once (the UI-freeze half of the boot cost). */
+function yieldToHost(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 const MOVE_EPSILON = 0.5;
 
 export interface RecordPair { prev: NodeSnapshot; next: NodeSnapshot }
@@ -282,14 +301,21 @@ export function resolvePageWrite(
  *
  *  Best-effort throughout: a write failure degrades to "no gap-fill this session", never
  *  a crash (risk register). */
-export function writeSnapshot(pages: readonly PageNode[]): void {
+export function writeSnapshot(
+  pages: readonly PageNode[],
+  // Injectable so the boot path can reuse the walk `runGapfillDiff` already took (see
+  // `snapshotProviderFrom`). The default keeps every OTHER caller — idle debounce and the
+  // `close` handler, both of which have no prior walk to reuse and MUST stay fully
+  // synchronous — exactly as it was.
+  snapshotFor: (page: PageNode) => PageSnapshotResult = snapshotPage,
+): void {
   const prevManifest = readManifest();
   const manifest: SnapshotManifest = { v: 1, pages: [] };
   const currentPageIds = new Set(pages.map((p) => p.id));
 
   for (const page of pages) {
     const prevEntry = prevManifest?.pages.find((p) => p.pageId === page.id);
-    const result = resolvePageWrite(page, prevEntry, () => snapshotPage(page));
+    const result = resolvePageWrite(page, prevEntry, () => snapshotFor(page));
     if (!result) continue; // brand-new page, first attempt failed — nothing to carry, nothing to write
     if (result.chunksToWrite === null) {
       manifest.pages.push(result.entry); // carrying the previous entry forward verbatim
@@ -349,13 +375,23 @@ export function writeSnapshot(pages: readonly PageNode[]): void {
  *   Honest under-reporting beats a wrong fact: suppress the WHOLE diff for that page and
  *   emit only the truncation notice.
  */
-export function runGapfillDiff(pages: readonly PageNode[]): EditInput[] {
+export async function runGapfillDiff(pages: readonly PageNode[]): Promise<EditInput[]> {
   const prev = readManifest();
   if (!prev) {
-    writeSnapshot(pages); // first-ever run — nothing to diff, but start the baseline now
+    // First-ever run — nothing to diff, but start the baseline now. Walked here (with
+    // yields) so the write below reuses the results; a page whose walk throws is simply
+    // not cached, and `resolvePageWrite`'s own fallback attempt keeps its per-page skip
+    // semantics for exactly that page.
+    const firstRun = new Map<string, PageSnapshotResult>();
+    for (const page of pages) {
+      await yieldToHost();
+      try { firstRun.set(page.id, snapshotPage(page)); } catch { /* resolvePageWrite re-attempts and skips */ }
+    }
+    writeSnapshot(pages, snapshotProviderFrom(firstRun, snapshotPage));
     return [];
   }
   const edits: EditInput[] = [];
+  const walked = new Map<string, PageSnapshotResult>();
   const currentPageIds = new Set(pages.map((p) => p.id));
 
   for (const deletedId of deletedPageIds(prev.pages.map((p) => p.pageId), currentPageIds)) {
@@ -370,9 +406,14 @@ export function runGapfillDiff(pages: readonly PageNode[]): EditInput[] {
   }
 
   for (const page of pages) {
+    await yieldToHost();
     const prevEntry = prev.pages.find((p) => p.pageId === page.id);
     const prevRecords = prevEntry ? readPageChunks(prevEntry) : [];
+    // A throw here still aborts the whole diff (caught by main.ts's `.catch` → capture
+    // disabled), exactly as before — only the DOUBLE walk and the single-tick execution
+    // changed, never the failure semantics.
     const { records: nextRecords, truncated: nextTruncated } = snapshotPage(page);
+    walked.set(page.id, { records: nextRecords, truncated: nextTruncated });
     if (pageWasTruncated(prevEntry?.truncated, nextTruncated)) {
       edits.push(toGapfillEdit('updated', { id: `truncated:${page.id}`, name: page.name, type: 'PAGE', x: 0, y: 0, parent: null }, page.name, ['truncated']));
       continue; // never a created/deleted/renamed/moved fact for this page this round
@@ -380,6 +421,9 @@ export function runGapfillDiff(pages: readonly PageNode[]): EditInput[] {
     const diff = diffSnapshots(prevRecords, nextRecords);
     edits.push(...gapfillEditsForPage(diff, page.name));
   }
-  writeSnapshot(pages); // the diff window now starts at THIS observation, not session start
+  // The diff window now starts at THIS observation, not session start — and the baseline
+  // is the walk taken ABOVE, never a re-walk: an edit made during a yield stays absent
+  // from the baseline, so the next session's gap-fill reports it instead of losing it.
+  writeSnapshot(pages, snapshotProviderFrom(walked, snapshotPage));
   return edits;
 }

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -425,14 +425,18 @@ function onDocumentChange(event: DocumentChangeEvent): void {
 
 // Subscribe only after all pages are loaded (dynamic-page requirement).
 figma.loadAllPagesAsync()
-  .then(() => {
+  .then(async () => {
     // Reconnect gap-fill (wave 4.4 phase 02 §2) — ONE diff against the PREVIOUS session's
     // snapshot, covering the window this plugin was closed (page switches need no
     // gap-fill: `documentchange` is document-wide once `loadAllPagesAsync` has run, the
-    // spec's own verdict). Runs BEFORE subscribing to `documentchange`, so a live edit in
-    // this same tick can never race the boot diff's read of the about-to-be-superseded
-    // snapshot. `runGapfillDiff` itself writes the fresh baseline before returning.
-    const gapfillEdits = runGapfillDiff(figma.root.children);
+    // spec's own verdict). Completes BEFORE subscribing to `documentchange`, so a live
+    // edit can never race the boot diff's read of the about-to-be-superseded snapshot.
+    // The diff yields between pages (boot must not hold the plugin thread for the whole
+    // document — the measured freeze on large files); an edit made during a yield is not
+    // seen live (no subscription yet) AND is absent from the pre-edit baseline the diff
+    // writes, so the NEXT session's gap-fill reports it — delayed, never lost.
+    // `runGapfillDiff` itself writes the fresh baseline before resolving.
+    const gapfillEdits = await runGapfillDiff(figma.root.children);
     if (gapfillEdits.length > 0) {
       // Stage-4 fix round (M3) — posted DIRECTLY, never through `coalesceEdits`.
       // `coalesceEdits` keys by nodeId ALONE across the WHOLE batch, with no notion of

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1465,7 +1465,7 @@ code {
     } catch {
     }
   });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "39e7111" : "dev"}`;
+  versionEl.textContent = `v0.1.0 \xB7 ${true ? "6a89393" : "dev"}`;
   setInterval(render, 1e3);
   render();
 

--- a/tests/edit-gapfill.test.ts
+++ b/tests/edit-gapfill.test.ts
@@ -5,7 +5,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   SNAPSHOT_CHUNK_BYTES, deletedPageIds, diffSnapshots, gapfillEditsForPage, mergeUpdatedRecords,
-  normalizeSnapshotCoord, pageWasTruncated, resolvePageWrite, splitSnapshotChunks,
+  normalizeSnapshotCoord, pageWasTruncated, resolvePageWrite, snapshotProviderFrom, splitSnapshotChunks,
   type NodeSnapshot,
 } from '../plugin/src/main/edit-gapfill.ts';
 
@@ -243,5 +243,31 @@ describe('resolvePageWrite — per-page atomicity: one page\'s failure never cor
     const otherResult = resolvePageWrite(otherPage, otherPrev, () => ({ records: [], truncated: false }));
     expect(otherResult!.entry).toEqual({ pageId: 'page-2', pageName: 'Other', chunks: 0, truncated: false });
     expect(prevEntry).toEqual({ pageId: 'page-1', pageName: 'Screens', chunks: 2, truncated: false }); // untouched
+  });
+});
+
+describe('snapshotProviderFrom — the boot write reuses the walk the diff already took', () => {
+  it('a cached page returns the precomputed result WITHOUT invoking the fallback walker', () => {
+    const cached = { records: [node()], truncated: false };
+    let walks = 0;
+    const provider = snapshotProviderFrom(
+      new Map([['page-1', cached]]),
+      () => { walks += 1; return { records: [], truncated: false }; },
+    );
+    expect(provider({ id: 'page-1' })).toBe(cached);
+    expect(walks).toBe(0); // the whole point: no second walk for a page already snapshotted
+  });
+
+  it('an uncached page falls back to the walker (and only for that page)', () => {
+    const fresh = { records: [], truncated: false };
+    let walks = 0;
+    const provider = snapshotProviderFrom(
+      new Map([['page-1', { records: [node()], truncated: true }]]),
+      () => { walks += 1; return fresh; },
+    );
+    expect(provider({ id: 'page-2' })).toBe(fresh);
+    expect(walks).toBe(1);
+    provider({ id: 'page-1' });
+    expect(walks).toBe(1); // the cached page still never re-walks
   });
 });


### PR DESCRIPTION
## What

Plugin boot on large files froze Figma's UI: the gap-fill diff walked every page's full node tree **twice** (once for the diff, once again inside `writeSnapshot`'s baseline re-walk), all in one synchronous tick.

## Changes

- `runGapfillDiff` caches each page's walk and passes `writeSnapshot` a provider (`snapshotProviderFrom`, pure + unit-tested) that reuses it — one walk per page at boot.
- The diff yields a macrotask between pages, so boot never holds the plugin thread for the whole document.
- Correctness bonus: the baseline is now the PRE-diff snapshot, so an edit made during a yield is reported by the next session's gap-fill instead of being silently baked into the baseline.

## Unchanged

- Diff completes **before** `documentchange` is subscribed (race guard preserved).
- Idle-debounce and `close`-handler writes keep the default synchronous full walk (`close` must stay sync per Figma's own guidance).
- Snapshot format on `sharedPluginData`, failure semantics (mid-diff throw → capture disabled).

## Verification

- `npm run typecheck` exit 0; `npm test` 1677/1677 (129 files); `npm run build` clean; `npm run lint:comments` clean — all re-run on this branch after the last edit.
- Break-to-test: mutating the provider to always re-walk turns exactly the 2 new tests red; restored → 38/38 green in the gap-fill suite.