### PR TITLE
feat(plugin): add adaptive agent rail

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,24 +226,24 @@ answer (`cycles: 0`, exit 0), not an error, and the plugin disconnecting mid-wai
 with a reconnect hint rather than hanging to the deadline. Edits it declined to attribute
 are reported as a count rather than dropped.
 
-## The panel
+## The adaptive agent rail
 
-Once loaded, the plugin opens a small (340×480) panel — the bridge's face. **Keep it open**
-while you (or an agent) drive the CLI; closing it drops the connection.
+Once loaded, the plugin opens as a `240×44` rail. **Keep it open** while you or an agent
+drive the CLI; closing it drops the connection. The rail always shows connection health and
+the current operation. Multi-file targeting and pending sync appear only when they matter.
 
-**Status states** — the big pill updates live as the broker comes and goes:
+Open the inspector for Activity, Context, or Details. It expands to `288×280` at most:
 
-| Pill | Meaning |
-|---|---|
-| **No broker yet** (muted) | Normal idle — not an error. The broker starts automatically on your first CLI command. |
-| **Looking for broker…** (amber, pulsing) | Scanning `localhost:9410–9419`. After ~10s it nudges you to run `figma-agent status`. |
-| **Handshaking…** (blue) | Broker found; registering this plugin. |
-| **Connected** (green) | Ready — the CLI can drive this file. Shows the port + connection uptime. |
+- **Activity** shows concurrent work, newest-first history, and a readable failure reason.
+- **Context** shows file, page, selection, and the PEERS-authoritative target control.
+- **Details** shows the connection sentence, first-run/recovery guidance, and build identity.
 
-**Activity log** lists recent commands (tool · duration · time-ago, newest first) so you can
-watch an agent work — each row carrying the label of the harness that sent it when one was
-given (`--agent`). **Connection details** (collapsible) exposes port, protocol version,
-heartbeat age, reconnect attempts, and the file/page.
+Pending edits stay on the rail as a count badge. Opening the badge reveals the existing
+**Sync now / Later** flow; a failed or unbound sync remains visible and retryable, and only a
+genuine success clears the count. First-run and actionable failures may open the inspector
+once to expose their recovery text. Opening Activity acknowledges the rail's unresolved-failure
+count; the activity history and failure reason remain available. Every icon action is a locally
+vendored Lucide SVG with a tooltip, accessible name, keyboard focus, and a 32px target.
 
 ## Multiple files open at once
 

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -5338,8 +5338,13 @@
   }
 
   // plugin/src/ui/panel-model.ts
-  var PANEL_WIDTH = 300;
-  var PANEL_HEIGHT = 420;
+  var RAIL_WIDTH = 240;
+  var RAIL_HEIGHT = 44;
+  var INSPECTOR_WIDTH = 288;
+  var INSPECTOR_HEIGHT = 280;
+  function viewportFor(mode) {
+    return mode === "inspector" ? { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT } : { width: RAIL_WIDTH, height: RAIL_HEIGHT };
+  }
 
   // plugin/src/main/readonly-guard.ts
   function createReadOnlyGuardState() {
@@ -5361,8 +5366,8 @@
   // plugin/src/main/main.ts
   figma.showUI(__html__, {
     visible: true,
-    width: PANEL_WIDTH,
-    height: PANEL_HEIGHT,
+    width: RAIL_WIDTH,
+    height: RAIL_HEIGHT,
     title: "design:os by JANG",
     themeColors: true
   });
@@ -5583,6 +5588,11 @@
   });
   figma.ui.onmessage = async (msg) => {
     const chrome = msg;
+    if (chrome && chrome.type === "PANEL_VIEWPORT" && (chrome.mode === "rail" || chrome.mode === "inspector")) {
+      const viewport = viewportFor(chrome.mode);
+      figma.ui.resize(viewport.width, viewport.height);
+      return;
+    }
     if (chrome && chrome.type === "SYNC_CONFIG") {
       const data = chrome.data;
       const raw = data?.idleMs;

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -47,14 +47,14 @@ import {
   writeEdgeCorrections,
 } from './correction-edge-store';
 import type { CorrectionEvent } from '../../../shared/supervised-memory';
-import { PANEL_WIDTH, PANEL_HEIGHT } from '../ui/panel-model';
+import { RAIL_WIDTH, RAIL_HEIGHT, viewportFor } from '../ui/panel-model';
 import {
   createReadOnlyGuardState, isReadOnlyExecJs, recordDocumentChangeBatch,
   snapshotChangeEvents, violatedSinceSnapshot,
 } from './readonly-guard';
 
-// Panel IA v2: one opening size — no compact/expanded split, no user-resizable
-// Details toggle left to preserve (the whole PANEL_RESIZE path is gone below).
+// The adaptive panel opens as a rail. The iframe can request one of two named modes;
+// main owns the dimensions and never trusts arbitrary width/height input.
 //
 // Owner decree 2026-07-30: the plugin window's own (host-drawn) title bar cannot be
 // removed and duplicated the panel's internal masthead, which is now gone (panel.html) —
@@ -68,7 +68,7 @@ import {
 // `html.figma-light { ... }` override block (a sibling of the default dark :root) is
 // what actually repaints every color token; this flag is what makes that class exist.
 figma.showUI(__html__, {
-  visible: true, width: PANEL_WIDTH, height: PANEL_HEIGHT, title: 'design:os by JANG', themeColors: true,
+  visible: true, width: RAIL_WIDTH, height: RAIL_HEIGHT, title: 'design:os by JANG', themeColors: true,
 });
 
 // Absorption phase-03 (FigJam) — which design-only boot capabilities this session
@@ -493,10 +493,13 @@ interface UiRequest {
 }
 
 figma.ui.onmessage = async (msg: unknown) => {
-  // Panel IA v2 removed the Details toggle — its PANEL_RESIZE message was the only
-  // emitter, so the handler that used to live here (and phase-01's width-preserving
-  // resize on top of it) is gone with it. One opening size, never resized again.
-  const chrome = msg as { type?: unknown; data?: unknown } | null;
+  const chrome = msg as { type?: unknown; mode?: unknown; data?: unknown } | null;
+  if (chrome && chrome.type === 'PANEL_VIEWPORT'
+      && (chrome.mode === 'rail' || chrome.mode === 'inspector')) {
+    const viewport = viewportFor(chrome.mode);
+    figma.ui.resize(viewport.width, viewport.height);
+    return;
+  }
   // Live-sync (spec 004 P4): the broker's idle window, relayed by the iframe.
   if (chrome && chrome.type === 'SYNC_CONFIG') {
     const data = chrome.data as { idleMs?: unknown; bound?: unknown } | undefined;

--- a/plugin/src/ui/lucide-icons.ts
+++ b/plugin/src/ui/lucide-icons.ts
@@ -1,0 +1,82 @@
+/**
+ * Minimal local subset of lucide icons. Geometry is derived from lucide v0.468.0.
+ * Copyright (c) Lucide Contributors, distributed under the ISC License.
+ * https://lucide.dev/license
+ */
+const SVG_NS = 'http://www.w3.org/2000/svg';
+
+type SvgNode = readonly [tag: 'path' | 'circle' | 'line' | 'rect', attributes: Readonly<Record<string, string>>];
+
+export type LucideIconName =
+  | 'activity' | 'chevron-down' | 'chevron-up' | 'circle-check' | 'circle-off'
+  | 'circle-x' | 'files' | 'info' | 'loader-circle' | 'panels-top-left'
+  | 'pin' | 'refresh-cw';
+
+const ICONS: Readonly<Record<LucideIconName, readonly SvgNode[]>> = {
+  activity: [['path', { d: 'M22 12h-4l-3 9L9 3l-3 9H2' }]],
+  'chevron-down': [['path', { d: 'm6 9 6 6 6-6' }]],
+  'chevron-up': [['path', { d: 'm18 15-6-6-6 6' }]],
+  'circle-check': [
+    ['circle', { cx: '12', cy: '12', r: '10' }],
+    ['path', { d: 'm9 12 2 2 4-4' }],
+  ],
+  'circle-off': [
+    ['path', { d: 'M20.42 15.89A10 10 0 1 1 8.11 3.58' }],
+    ['path', { d: 'm2 2 20 20' }],
+  ],
+  'circle-x': [
+    ['circle', { cx: '12', cy: '12', r: '10' }],
+    ['path', { d: 'm15 9-6 6' }],
+    ['path', { d: 'm9 9 6 6' }],
+  ],
+  files: [
+    ['path', { d: 'M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z' }],
+    ['path', { d: 'M14 2v6h6' }],
+    ['path', { d: 'M2 6h2' }],
+    ['path', { d: 'M2 10h2' }],
+    ['path', { d: 'M2 14h2' }],
+    ['path', { d: 'M2 18h2' }],
+  ],
+  info: [
+    ['circle', { cx: '12', cy: '12', r: '10' }],
+    ['path', { d: 'M12 16v-4' }],
+    ['path', { d: 'M12 8h.01' }],
+  ],
+  'loader-circle': [
+    ['path', { d: 'M21 12a9 9 0 1 1-6.22-8.56' }],
+  ],
+  'panels-top-left': [
+    ['rect', { width: '18', height: '18', x: '3', y: '3', rx: '2' }],
+    ['path', { d: 'M3 9h18' }],
+    ['path', { d: 'M9 21V9' }],
+  ],
+  pin: [
+    ['path', { d: 'M12 17v5' }],
+    ['path', { d: 'M5 17h14' }],
+    ['path', { d: 'M6 17 7 7l-2-2h14l-2 2 1 10' }],
+  ],
+  'refresh-cw': [
+    ['path', { d: 'M21 12a9 9 0 0 1-15.17 6.55L3 16' }],
+    ['path', { d: 'M3 21v-5h5' }],
+    ['path', { d: 'M3 12A9 9 0 0 1 18.17 5.45L21 8' }],
+    ['path', { d: 'M16 8h5V3' }],
+  ],
+};
+
+export function makeLucideIcon(name: LucideIconName): SVGSVGElement {
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('viewBox', '0 0 24 24');
+  svg.setAttribute('fill', 'none');
+  svg.setAttribute('stroke', 'currentColor');
+  svg.setAttribute('stroke-width', '2');
+  svg.setAttribute('stroke-linecap', 'round');
+  svg.setAttribute('stroke-linejoin', 'round');
+  svg.setAttribute('aria-hidden', 'true');
+  svg.setAttribute('class', 'fga-icon');
+  for (const [tag, attributes] of ICONS[name]) {
+    const node = document.createElementNS(SVG_NS, tag);
+    for (const [key, value] of Object.entries(attributes)) node.setAttribute(key, value);
+    svg.appendChild(node);
+  }
+  return svg;
+}

--- a/plugin/src/ui/panel-activity-view.ts
+++ b/plugin/src/ui/panel-activity-view.ts
@@ -1,0 +1,130 @@
+import {
+  diffRowKeys, pushActivity, timeAgo, formatTimestamp,
+  type ActivityRecord, type ActivityResult,
+} from './activity-feed';
+import { activitySentence } from './activity-sentence';
+import { makeLucideIcon, type LucideIconName } from './lucide-icons';
+import { applyActivityOutcome, BoundedKeySet, currentActivity, landTerminalActivity } from './panel-view-state';
+
+export function replaceIcon(target: HTMLElement, name: LucideIconName, spinning = false): void {
+  const kept = Array.from(target.children).filter((child) =>
+    child.classList.contains('rail-badge') || child.classList.contains('current-label') || child.classList.contains('failure-count'));
+  const icon = makeLucideIcon(name);
+  if (spinning) icon.classList.add('is-spinning');
+  target.replaceChildren(icon, ...kept);
+}
+
+export function labelControl(target: HTMLButtonElement, label: string): void {
+  target.title = label;
+  target.setAttribute('aria-label', label);
+}
+
+export interface FailureBadgeTarget {
+  hidden: boolean;
+  textContent: string | null;
+  setAttribute(name: string, value: string): void;
+}
+
+export function renderFailureBadge(target: FailureBadgeTarget, count: number): void {
+  target.hidden = count === 0;
+  target.textContent = count === 0 ? '' : String(count);
+  target.setAttribute('aria-label', `${count} unresolved failure${count === 1 ? '' : 's'}`);
+}
+
+function sentence(record: ActivityRecord): string {
+  return record.sentence ?? activitySentence({
+    tool: record.tool, label: record.label, result: record.result,
+    errorCode: record.errorCode, errorMessage: !record.ok ? record.result : undefined,
+    nodeName: record.nodeName, pending: record.pending, ok: record.ok,
+  });
+}
+
+function row(record: ActivityRecord, now: number, stale: boolean, fresh: boolean): HTMLElement {
+  const item = document.createElement('li');
+  item.className = ['activity-row', stale && 'is-stale', fresh && 'is-new'].filter(Boolean).join(' ');
+  const state = record.pending ? 'running' : record.ok ? 'ok' : 'failed';
+  const iconWrap = document.createElement('span');
+  iconWrap.className = 'log-icon-wrap';
+  iconWrap.dataset.state = state;
+  iconWrap.setAttribute('aria-label', state);
+  const icon = makeLucideIcon(record.pending ? 'loader-circle' : record.ok ? 'circle-check' : 'circle-x');
+  if (record.pending) icon.classList.add('is-spinning');
+  iconWrap.append(icon);
+  const body = document.createElement('div');
+  body.className = 'log-body';
+  const text = document.createElement('div');
+  text.className = record.pending || record.ok ? 'log-label' : 'log-label log-label--wrap';
+  const agent = document.createElement('span');
+  agent.className = 'log-agent';
+  agent.textContent = `${record.agent ?? 'cli'} · `;
+  const line = sentence(record);
+  text.append(agent, document.createTextNode(line));
+  text.title = line;
+  const meta = document.createElement('div');
+  meta.className = 'log-meta';
+  meta.textContent = record.pending ? 'running' : timeAgo(now, record.at);
+  meta.title = formatTimestamp(record.at);
+  body.append(text, meta);
+  item.append(iconWrap, body);
+  return item;
+}
+
+export class ActivityView {
+  private records: ActivityRecord[] = [];
+  private previousKeys: string[] = [];
+  readonly failures = new BoundedKeySet();
+
+  constructor(
+    private readonly list: HTMLElement,
+    private readonly currentButton: HTMLButtonElement,
+    private readonly currentLabel: HTMLElement,
+    private readonly failureCount: HTMLElement,
+  ) {}
+
+  push(record: ActivityRecord): void { this.records = pushActivity(this.records, record); }
+
+  resolve(patch: ActivityResult, trackFailure = true): void {
+    this.records = landTerminalActivity(this.records, patch);
+    if (trackFailure) applyActivityOutcome(this.failures, patch.id, patch.ok);
+  }
+
+  acknowledgeFailures(): void { this.failures.acknowledge(); }
+
+  render(now = Date.now()): void {
+    const shown = this.records.slice(0, 20);
+    if (shown.length === 0) {
+      this.previousKeys = [];
+      if (this.list.children.length === 0) {
+        const empty = document.createElement('li');
+        empty.className = 'activity-empty';
+        empty.textContent = 'No activity yet';
+        this.list.append(empty);
+      }
+    } else {
+      const keys = shown.map((record) => record.id);
+      const fresh = new Set(diffRowKeys(this.previousKeys, keys));
+      this.list.replaceChildren(...shown.map((record, index) => row(record, now, index > 0, fresh.has(record.id))));
+      this.previousKeys = keys;
+    }
+    this.renderRail();
+  }
+
+  private renderRail(): void {
+    const current = currentActivity(this.records);
+    const count = this.failures.unresolvedCount;
+    renderFailureBadge(this.failureCount, count);
+    const suffix = count === 0 ? '' : `. ${count} unresolved failure${count === 1 ? '' : 's'}`;
+    if (!current) {
+      replaceIcon(this.currentButton, 'activity');
+      this.currentLabel.textContent = 'Idle';
+      this.currentButton.className = `rail-control current-control${count ? ' tone-danger' : ''}`;
+      labelControl(this.currentButton, `Current activity: Idle${suffix}`);
+      return;
+    }
+    const state = current.pending ? 'running' : current.ok ? 'complete' : 'failed';
+    replaceIcon(this.currentButton, current.pending ? 'loader-circle' : current.ok ? 'circle-check' : 'circle-x', current.pending);
+    this.currentLabel.textContent = sentence(current);
+    this.currentButton.className = `rail-control current-control tone-${count ? 'danger' : current.pending ? 'warning' : current.ok ? 'success' : 'danger'}`;
+    labelControl(this.currentButton, `Current activity ${state}: ${sentence(current)}${suffix}`);
+  }
+}

--- a/plugin/src/ui/panel-model.ts
+++ b/plugin/src/ui/panel-model.ts
@@ -1,217 +1,84 @@
-// Pure view-model for the panel — no DOM, no WebSocket, no Figma API. Everything the
-// panel decides (which sentence/tone per connection state, the file/peers note, onboarding
-// gating, age formatting) lives here so it is unit-testable without a DOM. The activity
-// feed's own model lives in activity-feed.ts; the feed's SENTENCE mapping lives in
-// activity-sentence.ts — this file owns only the connection chrome (IA v2 Block 1) and
-// the file/peers note (Block 2).
 import type { ConnectionState } from '../../../shared/protocol';
 
-/** Which token pair the status dot renders with (maps to --fga-tone-<tone>). */
 export type Tone = 'success' | 'warning' | 'info' | 'muted';
+export const RAIL_WIDTH = 240;
+export const RAIL_HEIGHT = 44;
+export const INSPECTOR_WIDTH = 288;
+export const INSPECTOR_HEIGHT = 280;
+export const SYNC_STUCK_TIMEOUT_MS = 30_000;
+export type ViewportMode = 'rail' | 'inspector';
+export type SyncSource = 'manual' | 'auto';
 
-/** Age (ms) at which a still-probing connection stops saying "looking" and names the fix. */
-const PROBE_TROUBLESHOOT_MS = 10_000;
-
-/**
- * Block 1's ONE sentence: the problem, and the next action, in plain language — never a
- * pill/label/meta split, never an error code, never a port number. Replaces `stateView` +
- * `troubleshootHint` + `compactMeta` (all three used to split what is now one sentence).
- */
-export function statusSentence(
-  state: ConnectionState,
-  ageMs: number,
-  hadConnection: boolean,
-): { text: string; tone: Tone } {
-  switch (state) {
-    case 'connected':
-      // Owner addendum 2026-07-30: success states are minimal — the tone dot already
-      // signals "connected", so the sentence doesn't need to re-explain what that means.
-      return { text: 'Connected', tone: 'success' };
-    case 'probing':
-      return ageMs >= PROBE_TROUBLESHOOT_MS
-        // Problem states keep problem + next action, trimmed to the shortest honest
-        // sentence — "in a terminal" was filler (the command IS the terminal instruction).
-        ? { text: 'Broker not running — run figma-agent status.', tone: 'warning' }
-        : { text: 'Looking for the broker', tone: 'warning' };
-    case 'handshake':
-      return { text: 'Connecting', tone: 'info' };
-    case 'disconnected':
-    default:
-      return hadConnection
-        ? { text: 'Connection lost — reconnecting.', tone: 'muted' }
-        : { text: 'Not connected — your first command starts the broker.', tone: 'muted' };
-  }
+export function statusSentence(state: ConnectionState, ageMs: number, hadConnection: boolean): { text: string; tone: Tone } {
+  if (state === 'connected') return { text: 'Connected', tone: 'success' };
+  if (state === 'probing') return ageMs >= 10_000
+    ? { text: 'Broker not running — run figma-agent status.', tone: 'warning' }
+    : { text: 'Looking for the broker', tone: 'warning' };
+  if (state === 'handshake') return { text: 'Connecting', tone: 'info' };
+  return hadConnection
+    ? { text: 'Connection lost — reconnecting.', tone: 'muted' }
+    : { text: 'Not connected — your first command starts the broker.', tone: 'muted' };
 }
 
-/** Compact elapsed label: "just now", "8s", "2m 05s", "1h 03m". Input is ms (≥0). */
 export function formatAge(ms: number): string {
   if (!Number.isFinite(ms) || ms < 0) return '—';
-  const s = Math.floor(ms / 1000);
-  if (s < 1) return 'just now';
-  if (s < 60) return `${s}s`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ${String(s % 60).padStart(2, '0')}s`;
-  const h = Math.floor(m / 60);
-  return `${h}h ${String(m % 60).padStart(2, '0')}m`;
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 1) return 'just now';
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${String(seconds % 60).padStart(2, '0')}s`;
+  return `${Math.floor(minutes / 60)}h ${String(minutes % 60).padStart(2, '0')}m`;
 }
 
-/**
- * Whether the onboarding card shows: only before the very first successful
- * connection, and only while we're waiting. Once connected, it never returns.
- * SURVIVES the IA v2 cut (it is priority-1 content, not a debug affordance) —
- * re-parented directly under the status sentence.
- */
 export function showOnboarding(state: ConnectionState, hadConnection: boolean): boolean {
   return !hadConnection && (state === 'disconnected' || state === 'probing');
 }
 
-// ─── Panel geometry ───────────────────────────────────────────────────────────
-// IA v2 drops the compact/expanded split (Details toggle cut) — one opening size.
-export const PANEL_WIDTH = 300;
-export const PANEL_HEIGHT = 420;
+export function viewportFor(mode: ViewportMode): { width: number; height: number } {
+  return mode === 'inspector' ? { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT } : { width: RAIL_WIDTH, height: RAIL_HEIGHT };
+}
 
-// ─── Block 2 — CONTEXT: the file/peers note ──────────────────────────────────
-// The panel's honest answer to "which file will my command hit?" — must never say
-// "command target" when the broker's routing target is elsewhere. Driven by the new
-// PEERS event (broker → every connected plugin, count + isActiveTarget).
-//
-// `pinned` (#35 P2, additive — defaults `false` so every pre-existing call site/test is
-// untouched): PEERS' own `pinned` flag, true when THIS plugin is the target because the
-// owner explicitly pinned it via "Target this plugin", not merely because it is the
-// most-recently-active file. Distinct wording, never a separate boolean note, so the one
-// line stays the single source of "why does my command land here".
-export function fileNote(count: number, isActiveTarget: boolean, pinned = false): string {
-  if (count <= 1) return isActiveTarget ? (pinned ? 'pinned target' : 'command target') : ''; // count<=1 && !isActiveTarget cannot happen today
+export function shouldForceInspector(state: ConnectionState, ageMs: number, hadConnection: boolean): boolean {
+  return showOnboarding(state, hadConnection) || (state === 'disconnected' && hadConnection) || (state === 'probing' && ageMs >= 10_000);
+}
+
+export function fileNote(count: number, active: boolean, pinned = false): string {
+  if (count <= 1) return active ? (pinned ? 'pinned target' : 'command target') : '';
   const others = count - 1;
   const files = others === 1 ? 'file' : 'files';
-  // Wording pass (owner directive 2026-07-30): "connected" is redundant here — the whole
-  // Context block only ever shows OTHER connected files — and "commands go to another
-  // file" trims to "elsewhere" without losing the honest claim.
-  if (!isActiveTarget) return `${others} other ${files} — commands go elsewhere`;
+  if (!active) return `${others} other ${files} — commands go elsewhere`;
   return pinned ? `pinned target · ${others} other ${files}` : `command target · ${others} other ${files}`;
 }
 
-// ─── Target pin (#35 P2) — the "Target this plugin" button's own label ──────
-// A toggle: pinned → "Targeted" (click clears it, no check-mark glyph — this
-// button has no icon, so the label TEXT alone carries the pinned/unpinned
-// state); unpinned → "Target this plugin" (click sets it). Kept as a pure
-// mapping so the DOM glue (panel-ui.ts) never composes this string itself.
-export function targetButtonLabel(pinned: boolean): string {
-  return pinned ? 'Targeted' : 'Target this plugin';
-}
+export function targetButtonLabel(pinned: boolean): string { return pinned ? 'Targeted' : 'Target this plugin'; }
 
-// ─── Idle-commit sync prompt (spec 004 P4) ────────────────────────────────────
-// The panel gains ONE line at the idle point: "N changes ready — Sync now / Later"
-// (reuses the existing status surface; no new panel). These pure helpers format that
-// line + the post-sync confirmation; panel-ui.ts is the DOM glue that shows/hides it.
-
-/** "3 changes ready" / "1 change ready" — pluralized, count floored at 1 for display. */
 export function syncPromptLabel(count: number): string {
-  const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
-  return `${n} change${n === 1 ? '' : 's'} ready`;
+  const value = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
+  return `${value} change${value === 1 ? '' : 's'} ready`;
 }
 
-/**
- * Post-apply confirmation line for the prompt.
- *
- * `landed` is what the kernel actually wrote to the registry (spec 005 P4) — NOT the
- * number of canvas events that were sent. An apply can succeed and change nothing (every
- * new component still pending re-ingest), and calling that "Synced" is the dishonesty
- * this argument exists to kill (Art VIII). The summary itself comes from
- * shared/figma-sync-summary.ts, so the broker and this line make the same claim.
- * No glyph: the icon beside this line (a Phosphor check-circle) carries the mark instead.
- */
 export function syncResultLabel(ok: boolean, summary: string, landed = true, unbound = false): string {
-  const clean = typeof summary === 'string' && summary.trim().length > 0 ? summary.trim() : (ok ? 'done' : 'failed');
-  // Registry-integrity phase 01 (5.1), §3: an unbound file refused instead of guessing a
-  // project — the summary IS the fix ("run: figma-agent bind ..."), so it renders bare
-  // rather than under a "Sync failed" verdict the owner would read as a bug to retry.
+  const clean = summary.trim() || (ok ? 'done' : 'failed');
   if (unbound) return clean;
   if (!ok) return `Sync failed — ${clean}`;
   return landed ? `Synced — ${clean}` : `Nothing synced — ${clean}`;
 }
 
-/**
- * The "Sync now" button's own label. Fix round (finding 2): an E_UNBOUND refusal must not
- * read as "click again to retry the same failing thing" — the button itself says what to
- * do first. A click still fires the identical SYNC_REQUEST regardless of label, so retry
- * works the instant the owner runs `figma-agent bind` and clicks again; the label just
- * stops lying about what that click will do until then.
- */
-export function syncNowLabel(unbound: boolean): string {
-  return unbound ? 'Bind & retry' : 'Sync now';
-}
+export function syncNowLabel(unbound: boolean): string { return unbound ? 'Bind & retry' : 'Sync now'; }
 
-// ─── Activity feed sentences for sync runs (owner addendum, task #145) ─────────────────
-//
-// Scouted, not assumed: the manual "Sync now" click already pushed/resolved an Activity
-// row (panel-ui.ts), but its sentence came from activity-sentence.ts's generic
-// `RECONCILE` stem (continuous: 'Syncing', plain: 'Synced') — a bare word, because the
-// row's `result` string (`→ ${syncResultLabel(...)}`) never matched the count-regex
-// (starts with a WORD, not a digit) and a failure never even passed `errorMessage`. These
-// three functions compose the FULL sentence directly and land it on `ActivityRecord.sentence`
-// (used verbatim by the renderer) instead of forcing it through that generic mapper.
-//
-// "Auto" vs "manual": no auto-trigger exists in this tree today (verified — the only
-// `SYNC_REQUEST` dispatch site is this button's click handler); `source` is a plain
-// parameter here (not a stored field) so backlog 4.4 P3's future watcher-driven
-// auto-apply can call `syncStartSentence('auto', fileLabel)` the day it exists, with zero
-// further redesign.
-export type SyncSource = 'manual' | 'auto';
-
-/** Sync STARTED — the pending Activity row's sentence. Long, full-meaning (Activity is
- *  the one surface exempt from the terse-truncate rule). */
 export function syncStartSentence(source: SyncSource, fileLabel: string): string {
   return source === 'auto'
     ? `Auto-sync started — ${fileLabel} went idle, applying its pending changes`
     : `Sync started — checking ${fileLabel} for pending Figma changes to apply`;
 }
 
-/**
- * Sync RESULT — the resolved Activity row's sentence, once the outcome is known.
- * `unbound` keeps `syncResultLabel`'s own bare message unwrapped: it already reads as a
- * full, actionable sentence ("No project bound for X — run: figma-agent bind --file ..."),
- * and wrapping it in a "Sync failed for" verdict would bury the fix behind a message the
- * owner would read as a bug to retry rather than a one-time setup step.
- */
 export function syncResultSentence(ok: boolean, summary: string, landed: boolean, unbound: boolean, fileLabel: string): string {
-  const clean = typeof summary === 'string' && summary.trim().length > 0 ? summary.trim() : (ok ? 'done' : 'failed');
+  const clean = summary.trim() || (ok ? 'done' : 'failed');
   if (unbound) return clean;
   if (!ok) return `Sync failed for ${fileLabel} — ${clean}`;
   return landed ? `Synced ${fileLabel} — ${clean}` : `Nothing synced for ${fileLabel} — ${clean}`;
 }
 
-/**
- * Live-observed durability gap (owner's screen): a SYNC_REQUEST landed on a broker that
- * got hot-replaced before answering — the retry succeeded on the new broker, but the
- * FIRST panel row never got its SYNC_RESULT and spun "Syncing" forever. This is the exact
- * class concurrency & jobs (backlog 1.1+2.6+4.3) fixes for the CLI (timeout → poll); the
- * panel needs its own bounded guard, since it has no job table to poll.
- */
-export const SYNC_STUCK_TIMEOUT_MS = 30_000;
-export function syncStuckSentence(): string {
-  return 'Sync did not answer — the broker restarted mid-run; press Sync again';
-}
-
-/**
- * Stage-4 fix round (minor 9) — a second "Sync now" click while the first run is still
- * pending used to leave that FIRST row spinning "Syncing" forever: a new row started, the
- * old row's own stuck-timer later found `reconcileRun.id` had already moved on to the
- * second run and silently did nothing (by design — never resolve a row a REAL result may
- * still land on). Never orphan it: the click handler now resolves the still-pending FIRST
- * row with this sentence before starting the second run.
- */
-export function syncSupersededSentence(): string {
-  return 'Superseded by a newer sync';
-}
-
-/**
- * Whether a SYNC_RESULT outcome should clear main.ts's pending-change counter — closing
- * review round, defect #2: it used to clear on ANY non-E_UNBOUND outcome, so a genuine
- * reconcile failure or "a sync is already running" also silently zeroed it, even though
- * nothing applied. Only a true success may clear it; every failure (E_UNBOUND included)
- * must leave the counter and prompt intact so retry stays possible.
- */
-export function shouldClearPendingCount(ok: boolean): boolean {
-  return ok === true;
-}
+export function syncStuckSentence(): string { return 'Sync did not answer — the broker restarted mid-run; press Sync again'; }
+export function syncSupersededSentence(): string { return 'Superseded by a newer sync'; }
+export function shouldClearPendingCount(ok: boolean): boolean { return ok === true; }

--- a/plugin/src/ui/panel-ui.ts
+++ b/plugin/src/ui/panel-ui.ts
@@ -1,408 +1,130 @@
-// Panel IA v2 — the thin DOM controller. It CONSUMES the P1 connection state machine
-// (the `figma-agent:conn-state` CustomEvent), the `figma-agent:activity` event, and the
-// new `figma-agent:peers` event (all dispatched by ui-relay.ts) and renders the panel.html
-// chrome: three blocks (Status / Context / Activity) + the sync prompt. No framework, no
-// Figma API, no WebSocket — all protocol/connection logic stays in the relay; all pure
-// formatting stays in panel-model.ts / activity-sentence.ts. This file is glue.
-//
-// Load order matters: ui-relay.ts imports this module FIRST, so these listeners
-// are attached before the relay fires its first transition (a fresh subscriber
-// would otherwise miss the opening PROBE).
 import { PORT_RANGE_START } from '../../../shared/protocol';
 import type { ConnectionState, ConnectionStatePayload } from '../../../shared/protocol';
+import { toActivityRecord, toActivityResult } from './activity-feed';
+import { ActivityView, labelControl, replaceIcon } from './panel-activity-view';
 import {
-  statusSentence, showOnboarding, fileNote, PANEL_HEIGHT,
-  syncPromptLabel, syncResultLabel, syncNowLabel, shouldClearPendingCount,
-  syncStartSentence, syncResultSentence, syncStuckSentence, syncSupersededSentence, SYNC_STUCK_TIMEOUT_MS,
-  targetButtonLabel,
+  fileNote, showOnboarding, statusSentence, syncNowLabel, syncPromptLabel,
+  syncResultLabel, syncResultSentence, syncStartSentence, syncStuckSentence,
+  syncSupersededSentence, targetButtonLabel, shouldClearPendingCount,
+  SYNC_STUCK_TIMEOUT_MS, type ViewportMode,
 } from './panel-model';
-import {
-  toActivityRecord, toActivityResult, pushActivity, resolveActivity, diffRowKeys,
-  type ActivityRecord,
-} from './activity-feed';
-import { activitySentence } from './activity-sentence';
+import { BoundedKeySet, connectionForce } from './panel-view-state';
 
-// Injected by scripts/build.mjs via esbuild `define` — a content hash of the
-// code.js this UI bundle shipped alongside, so a reload can be verified as the
-// new build rather than a stale cached iframe. Undefined in dev/test (no
-// esbuild define pass); `typeof` never throws on an unresolved identifier.
 declare const __BUILD_ID__: string;
-
 const el = (id: string): HTMLElement => document.getElementById(id) as HTMLElement;
-
-const dot = el('fga-dot');
+const btn = (id: string): HTMLButtonElement => el(id) as HTMLButtonElement;
+const panel = el('fga-panel');
+const inspector = el('fga-inspector');
+const connectionBtn = btn('fga-connection-btn');
+const currentBtn = btn('fga-current-btn');
+const targetRailBtn = btn('fga-target-rail-btn');
+const syncRailBtn = btn('fga-sync-rail-btn');
+const syncBadge = el('fga-sync-badge');
+const toggleBtn = btn('fga-toggle-btn');
 const sentence = el('fga-sentence');
 const onboarding = el('fga-onboarding');
-const ctxFile = el('fga-ctx-file');
-const ctxFileNote = el('fga-ctx-file-note');
-const ctxPage = el('fga-ctx-page');
-const ctxSelection = el('fga-ctx-selection');
-const targetBtn = el('fga-target-btn') as HTMLButtonElement;
-const activityList = el('fga-activity');
-const versionEl = el('fga-version');
 const syncPrompt = el('fga-sync');
 const syncMsg = el('fga-sync-msg');
-const syncNowBtn = el('fga-sync-now');
-const syncLaterBtn = el('fga-sync-later');
+const syncNowBtn = btn('fga-sync-now');
+const targetBtn = btn('fga-target-btn');
+const activityView = new ActivityView(el('fga-activity'), currentBtn, el('fga-current-label'), el('fga-failure-count'));
+type Tab = 'activity' | 'context' | 'details';
+const tabNames: Tab[] = ['activity', 'context', 'details'];
+const tabs = Object.fromEntries(tabNames.map((name) => [name, btn(`fga-tab-${name}`)])) as Record<Tab, HTMLButtonElement>;
+const tabPanels = Object.fromEntries(tabNames.map((name) => [name, el(`fga-panel-${name}`)])) as Record<Tab, HTMLElement>;
 
 let payload: ConnectionStatePayload | null = null;
-let hadConnection = false; // ever reached `connected` — flips onboarding off forever
-let activity: ActivityRecord[] = []; // newest-first, capped at 50 by pushActivity
-let sceneFile = '';
-let scenePage = '';
-let selectionName: string | null = null;
-let selectionCount = 0;
-let peersCount = 1;
-let peersIsActiveTarget = true; // sole plugin ⇒ trivially the target until PEERS says otherwise
-let peersPinned = false; // #35 P2: THIS plugin is the target because the owner pinned it, not merely recency
+let hadConnection = false;
+let sceneFile = '', scenePage = '', selectionName: string | null = null, selectionCount = 0;
+let peersCount = 1, peersIsActiveTarget = true, peersPinned = false, pendingSyncCount = 0;
+let selectedTab: Tab = 'activity', inspectorOpen = false, userExpanded = false, forcedOnly = false;
+let connectionFailure = false, syncFailure = false, connectionTransition = 0;
+let previousConnectionState: ConnectionState | null = null;
+const disclosed = new BoundedKeySet();
 
-// ─── Icons (Phosphor inline SVG — no text glyphs anywhere, §1) ───────────────
-// Official @phosphor-icons/core v2 path data, "regular" weight, 256x256 viewBox, MIT —
-// check-circle / x-circle / circle-notch, matching the family the existing footer caret
-// already uses. Injected via createElementNS (never innerHTML). Each icon is
-// `aria-hidden` — the ACCESSIBLE label lives on the wrapping element the icon sits in
-// (`.log-icon-wrap[aria-label]` below), so the glyph itself never needs to speak for
-// itself. Only the three states the activity feed actually renders: done, failed,
-// in-flight (spins; stops under prefers-reduced-motion — see panel.html).
-const SVG_NS = 'http://www.w3.org/2000/svg';
-type IconName = 'check' | 'x' | 'notch';
-const ICONS: Record<IconName, string> = {
-  // check-circle, regular — the wrapper's aria-label carries the state; colour (via
-  // CSS) carries "success" visually.
-  check: 'M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34ZM232,128A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z',
-  // x-circle, regular.
-  x: 'M165.66,101.66,139.31,128l26.35,26.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32ZM232,128A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z',
-  // circle-notch, regular — CSS rotates it (fga-spin).
-  notch: 'M232,128a104,104,0,0,1-208,0c0-41,23.81-78.36,60.66-95.27a8,8,0,0,1,6.68,14.54C60.15,61.59,40,93.27,40,128a88,88,0,0,0,176,0c0-34.73-20.15-66.41-51.34-80.73a8,8,0,0,1,6.68-14.54C208.19,49.64,232,87,232,128Z',
-};
-
-function makeIcon(name: IconName): SVGSVGElement {
-  const svg = document.createElementNS(SVG_NS, 'svg');
-  svg.setAttribute('viewBox', '0 0 256 256');
-  svg.setAttribute('fill', 'currentColor');
-  svg.setAttribute('aria-hidden', 'true');
-  svg.setAttribute('class', 'log-icon');
-  const path = document.createElementNS(SVG_NS, 'path');
-  path.setAttribute('d', ICONS[name]);
-  svg.appendChild(path);
-  return svg;
+function viewport(mode: ViewportMode): void { parent.postMessage({ pluginMessage: { type: 'PANEL_VIEWPORT', mode } }, '*'); }
+function selectTab(tab: Tab, focus = false): void {
+  selectedTab = tab;
+  for (const name of tabNames) {
+    const selected = name === tab;
+    tabs[name].setAttribute('aria-selected', String(selected));
+    tabs[name].tabIndex = selected ? 0 : -1;
+    tabPanels[name].hidden = !selected;
+  }
+  if (focus) tabs[tab].focus();
 }
-
-// ─── Rendering ──────────────────────────────────────────────────────────────
-
-/** Block 2 — CONTEXT: File (+ command-target/peers note) / Page / Selection. */
-function renderContext(): void {
-  ctxFile.textContent = sceneFile || '—';
-  ctxFile.title = sceneFile || ''; // the row ellipsises — hover still tells the truth
-  ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
-  ctxPage.textContent = scenePage || '—';
-  ctxPage.title = scenePage || '';
-  ctxSelection.textContent = selectionText();
+function setInspector(open: boolean, tab = selectedTab, intent = false): void {
+  inspectorOpen = open;
+  if (intent) { userExpanded = open; forcedOnly = false; }
+  panel.dataset.view = open ? 'inspector' : 'rail';
+  inspector.hidden = !open;
+  toggleBtn.setAttribute('aria-expanded', String(open));
+  labelControl(toggleBtn, open ? 'Close inspector' : 'Open inspector');
+  replaceIcon(toggleBtn, open ? 'chevron-up' : 'chevron-down');
+  if (open) selectTab(tab);
+  viewport(open ? 'inspector' : 'rail');
+}
+function forceOnce(key: string, tab: Tab): void {
+  if (disclosed.has(key)) return;
+  disclosed.add(key);
+  if (!userExpanded) forcedOnly = true;
+  setInspector(true, tab);
+}
+function unresolved(): boolean { return connectionFailure || syncFailure || activityView.failures.unresolvedCount > 0; }
+function updateSignal(): void { panel.dataset.unresolved = String(unresolved()); }
+function acknowledgeActivity(): void { activityView.acknowledgeFailures(); updateSignal(); activityView.render(); }
+function openUser(tab: Tab): void { if (tab === 'activity') acknowledgeActivity(); setInspector(true, tab, true); }
+function context(): void {
+  el('fga-ctx-file').textContent = sceneFile || '—'; el('fga-ctx-file').title = sceneFile;
+  el('fga-ctx-file-note').textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
+  el('fga-ctx-page').textContent = scenePage || '—'; el('fga-ctx-page').title = scenePage;
+  el('fga-ctx-selection').textContent = selectionCount <= 0 ? 'None' : `${selectionName ?? '(unnamed)'}${selectionCount > 1 ? ` +${selectionCount - 1} more` : ''}`;
   targetBtn.textContent = targetButtonLabel(peersPinned);
+  targetRailBtn.hidden = peersCount <= 1;
+  if (!targetRailBtn.hidden) {
+    labelControl(targetRailBtn, `${peersCount} files. ${fileNote(peersCount, peersIsActiveTarget, peersPinned)}`);
+    replaceIcon(targetRailBtn, peersPinned ? 'pin' : 'files');
+    targetRailBtn.classList.toggle('tone-info', peersIsActiveTarget);
+  }
 }
-
-/** "None" / "Hero card" / "Hero card +2 more". Never fabricates a name. The <dt>
- *  "Selection" label already frames this — "None" reads as "Selection: None". */
-function selectionText(): string {
-  if (selectionCount <= 0) return 'None';
-  const first = selectionName ?? '(unnamed)';
-  return selectionCount > 1 ? `${first} +${selectionCount - 1} more` : first;
-}
-
-/** How many of the buffered rows the feed shows (the band scrolls past this). */
-const ACTIVITY_ROWS = 20;
-
-/**
- * One feed row: [icon][sentence] + a caption line with relative time. The sentence
- * (activity-sentence.ts) says what the agent DID, in English, with a node name when the
- * reply carried one — never a command name, never a wire error code.
- *
- * `isNew` (backlog 4.7): only a row whose key was NOT in the previous render gets the
- * `.is-new` class, which is the ONLY thing the entrance animation is now scoped to
- * (panel.html) — every row is still rebuilt each render (simplest fix within this
- * file's existing full-rebuild structure), but a rebuilt-yet-unchanged row is visually
- * inert instead of replaying its arrival animation on every 1s heartbeat tick.
- */
-function activityRow(r: ActivityRecord, now: number, stale: boolean, isNew: boolean): HTMLElement {
-  const li = document.createElement('li');
-  const classes = ['activity-row', 'fga-row'];
-  if (stale) classes.push('is-stale');
-  if (isNew) classes.push('is-new');
-  li.className = classes.join(' ');
-
-  const state = r.pending ? 'running' : (r.ok ? 'ok' : 'failed');
-  const iconName: IconName = r.pending ? 'notch' : (r.ok ? 'check' : 'x');
-  const iconWrap = document.createElement('span');
-  iconWrap.className = 'log-icon-wrap fga-icon';
-  iconWrap.dataset.state = state;
-  iconWrap.setAttribute('aria-label', state); // the accessible label; the svg inside is aria-hidden
-  iconWrap.appendChild(makeIcon(iconName));
-
-  const body = document.createElement('div');
-  body.className = 'log-body';
-
-  const text = document.createElement('div');
-  // Owner-observed (live screenshot): a failure's reason ("The script stopped: runtime
-  // error: <truncated>") was being clipped with an ellipsis character — Activity is the
-  // one surface exempt from the terse-truncate rule (wording-panel decision), so a
-  // failure reason must be readable without hovering. Only FAILED rows wrap
-  // (`.log-label--wrap`); ok/running rows keep the single-line ellipsis truncation —
-  // their sentences never carry this much text.
-  text.className = !r.pending && !r.ok ? 'log-label log-label--wrap' : 'log-label';
-  // A pre-composed sentence (sync results, job status) lands VERBATIM — the caller
-  // already holds the full human sentence, so the generic tool/count/name mapper below
-  // never runs for it (see ActivityRecord.sentence's own doc for why forcing either
-  // through that mapper was the bug).
-  const line = r.sentence ?? activitySentence({
-    tool: r.tool, label: r.label, result: r.result, errorCode: r.errorCode,
-    errorMessage: !r.ok ? r.result : undefined, nodeName: r.nodeName,
-    pending: r.pending, ok: r.ok,
-  });
-  // auto-connect slice 2 — the agent label is its OWN span, never folded into the
-  // sentence string above (activitySentence stays deliberately label-free — see its own
-  // header comment): a separate node so the sentence text (and activitySentence's own
-  // contract) never has to know a caller can attach an agent id. The `cli` default is
-  // applied HERE, at render time — an unlabelled request never stamps a default onto
-  // the wire (RequestMsg.agent stays additive; see makeRequestFrame). U+00B7 (middle
-  // dot) separator — NOT U+2022 (bullet), which the panel's typography gate bans.
-  const agentSpan = document.createElement('span');
-  agentSpan.className = 'log-agent';
-  agentSpan.textContent = `${r.agent ?? 'cli'} · `;
-  text.append(agentSpan, document.createTextNode(line));
-  text.title = line; // the row ellipsises (ok/running) — hover still tells the truth there
-
-  const caption = document.createElement('div');
-  caption.className = 'log-meta';
-  caption.textContent = r.pending ? 'running' : timeAgoCaption(now, r.at);
-  caption.title = formatTimestampCaption(r.at);
-
-  body.append(text, caption);
-  li.append(iconWrap, body);
-  return li;
-}
-
-// Small local wrappers so this module only imports what it uses from activity-feed.ts's
-// formatting helpers, without re-exporting them under new names there.
-function timeAgoCaption(now: number, at: number): string {
-  const s = Math.floor((now - at) / 1000);
-  if (s < 1) return 'now';
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  return `${Math.floor(m / 60)}h ago`;
-}
-function formatTimestampCaption(at: number): string {
-  if (!Number.isFinite(at)) return '—';
-  const d = new Date(at);
-  const pad = (n: number): string => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-}
-
-// The ids shown in the PREVIOUS renderActivity() call — diffed against the next render
-// so an unchanged row doesn't replay its entrance animation on every 1s heartbeat tick
-// (backlog 4.7). Starts empty: the very first render's rows are all "new", which is
-// correct — nothing has ever been shown before.
-let previousRowKeys: string[] = [];
-
-function renderActivity(now: number): void {
-  if (activity.length === 0) { previousRowKeys = []; return; } // leave the static "No activity yet" empty-state row
-  const shown = activity.slice(0, ACTIVITY_ROWS);
-  const nextKeys = shown.map((r) => r.id);
-  const newKeys = new Set(diffRowKeys(previousRowKeys, nextKeys));
-  activityList.replaceChildren(
-    ...shown.map((r, i) => activityRow(r, now, i > 0, newKeys.has(r.id))),
-  );
-  previousRowKeys = nextKeys;
-}
-
 function render(): void {
-  const now = Date.now();
-  const state: ConnectionState = payload?.state ?? 'disconnected';
-  const view = statusSentence(state, payload ? now - payload.since : 0, hadConnection);
-
-  dot.dataset.tone = view.tone;
-  dot.classList.toggle('is-pulsing', state === 'probing');
-  sentence.textContent = view.text;
-  sentence.dataset.tone = view.tone; // the pill is gone — the sentence itself is now the tone-carrying text
+  const now = Date.now(), state: ConnectionState = payload?.state ?? 'disconnected', age = payload ? now - payload.since : 0;
+  const view = statusSentence(state, age, hadConnection);
+  sentence.textContent = view.text; sentence.dataset.tone = view.tone;
   onboarding.hidden = !showOnboarding(state, hadConnection);
-  renderContext();
-  renderActivity(now);
+  replaceIcon(connectionBtn, state === 'connected' ? 'circle-check' : state === 'probing' || state === 'handshake' ? 'loader-circle' : 'circle-off', state === 'probing' || state === 'handshake');
+  connectionBtn.className = `rail-control tone-${view.tone}`; labelControl(connectionBtn, view.text);
+  context(); activityView.render(now);
+  const showSync = pendingSyncCount > 0 || syncFailure;
+  syncRailBtn.hidden = !showSync;
+  if (showSync) { syncBadge.textContent = String(Math.max(1, pendingSyncCount)); replaceIcon(syncRailBtn, syncFailure ? 'circle-x' : 'refresh-cw'); syncRailBtn.className = `rail-control tone-${syncFailure ? 'danger' : 'warning'}`; labelControl(syncRailBtn, syncFailure ? `${syncMsg.textContent || 'Sync failed'}. Open sync actions` : `${syncPromptLabel(pendingSyncCount)}. Open sync actions`); }
+  const force = connectionForce(state, age, hadConnection, connectionTransition);
+  connectionFailure = force?.kind === 'probe-timeout' || force?.kind === 'connection-lost';
+  updateSignal(); if (force) forceOnce(force.key, 'details');
+  if (state === 'connected' && forcedOnly && !userExpanded && !unresolved()) { forcedOnly = false; setInspector(false); }
 }
 
-// ─── Event wiring ─────────────────────────────────────────────────────────────
-window.addEventListener('figma-agent:conn-state', (ev) => {
-  const p = (ev as CustomEvent).detail as ConnectionStatePayload | undefined;
-  if (!p || typeof p.state !== 'string') return;
-  if (p.state === 'connected') hadConnection = true;
-  payload = p;
-  render();
-});
+connectionBtn.onclick = () => setInspector(true, 'details', true);
+currentBtn.onclick = () => openUser('activity');
+const toggleTarget = (): void => { try { window.dispatchEvent(new CustomEvent(peersPinned ? 'figma-agent:clear-target' : 'figma-agent:set-target')); } catch { /* DOM unavailable */ } };
+targetRailBtn.onclick = toggleTarget; targetBtn.onclick = toggleTarget;
+syncRailBtn.onclick = () => { syncPrompt.hidden = false; openUser('activity'); };
+toggleBtn.onclick = () => { if (!inspectorOpen && selectedTab === 'activity') acknowledgeActivity(); setInspector(!inspectorOpen, selectedTab, true); };
+for (const tab of tabNames) {
+  tabs[tab].onclick = () => { if (tab === 'activity') acknowledgeActivity(); selectTab(tab); };
+  tabs[tab].onkeydown = (event) => { const index = tabNames.indexOf(tab); const target = event.key === 'ArrowRight' ? tabNames[(index + 1) % 3] : event.key === 'ArrowLeft' ? tabNames[(index + 2) % 3] : event.key === 'Home' ? tabNames[0] : event.key === 'End' ? tabNames[2] : null; if (target) { event.preventDefault(); if (target === 'activity') acknowledgeActivity(); selectTab(target, true); } };
+}
+document.addEventListener('keydown', (event) => { if (event.key === 'Escape' && inspectorOpen) { event.preventDefault(); setInspector(false, selectedTab, true); toggleBtn.focus(); } });
+window.addEventListener('figma-agent:conn-state', (event) => { const next = (event as CustomEvent).detail as ConnectionStatePayload | undefined; if (!next || typeof next.state !== 'string') return; if (next.state !== previousConnectionState) connectionTransition += 1; previousConnectionState = next.state; if (next.state === 'connected') hadConnection = true; payload = next; render(); });
+window.addEventListener('figma-agent:activity', (event) => { const detail = (event as CustomEvent).detail as { phase?: unknown } | undefined; if (detail?.phase === 'done') { const patch = toActivityResult(detail); if (!patch) return; activityView.resolve(patch); if (!patch.ok) forceOnce(`activity-failure:${patch.id}`, 'activity'); } else { const record = toActivityRecord(detail); if (!record) return; activityView.push(record); } updateSignal(); render(); });
+window.addEventListener('figma-agent:peers', (event) => { const data = (event as CustomEvent).detail as { count?: unknown; isActiveTarget?: unknown; pinned?: unknown } | undefined; if (typeof data?.count === 'number' && Number.isFinite(data.count)) peersCount = data.count; if (typeof data?.isActiveTarget === 'boolean') peersIsActiveTarget = data.isActiveTarget; peersPinned = data?.pinned === true; context(); });
+window.addEventListener('message', (event: MessageEvent) => { const message = (event.data as { pluginMessage?: { type?: string; data?: Record<string, unknown> } } | null)?.pluginMessage; if (!message) return; if (message.type === 'IDLE_READY' && message.data) { pendingSyncCount = typeof message.data.count === 'number' ? Math.max(1, Math.floor(message.data.count)) : 1; syncFailure = false; syncMsg.textContent = syncPromptLabel(pendingSyncCount); syncNowBtn.textContent = syncNowLabel(false); syncPrompt.hidden = true; render(); return; } if (message.type === 'FILE_INFO' && message.data) { if (typeof message.data.fileName === 'string') sceneFile = message.data.fileName; if (typeof message.data.page === 'string') scenePage = message.data.page; selectionName = typeof message.data.selectionName === 'string' ? message.data.selectionName : null; selectionCount = typeof message.data.selectionCount === 'number' ? message.data.selectionCount : 0; context(); } });
 
-// The relay announces each request twice: `start` opens the row (so the panel shows
-// what is running WHILE the user waits), `done` lands the outcome onto that same row, by id.
-window.addEventListener('figma-agent:activity', (ev) => {
-  const detail = (ev as CustomEvent).detail as { phase?: unknown } | undefined;
-  if (detail?.phase === 'done') {
-    const patch = toActivityResult(detail);
-    if (!patch) return;
-    activity = resolveActivity(activity, patch);
-  } else {
-    const rec = toActivityRecord(detail);
-    if (!rec) return;
-    activity = pushActivity(activity, rec);
-  }
-  renderActivity(Date.now());
-});
+let run: { id: string; at: number } | null = null, stuckTimer: ReturnType<typeof setTimeout> | null = null;
+syncNowBtn.onclick = () => { const at = Date.now(), id = `reconcile_${at}`; syncMsg.textContent = 'Syncing'; if (run) { if (stuckTimer) clearTimeout(stuckTimer); activityView.resolve({ id: run.id, ok: false, ms: at - run.at, sentence: syncSupersededSentence() }, false); } run = { id, at }; activityView.push({ id, tool: 'RECONCILE', label: 'Reconcile · apply', pending: true, ok: true, ms: 0, at, sentence: syncStartSentence('manual', sceneFile || '(unnamed file)') }); render(); try { window.dispatchEvent(new CustomEvent('figma-agent:sync-request')); } catch { /* DOM unavailable */ } stuckTimer = setTimeout(() => { if (run?.id !== id) return; const now = Date.now(); activityView.resolve({ id, ok: false, ms: now - at, sentence: syncStuckSentence() }); run = null; stuckTimer = null; syncFailure = true; syncMsg.textContent = syncStuckSentence(); syncPrompt.hidden = false; forceOnce(`activity-failure:${id}`, 'activity'); render(); }, SYNC_STUCK_TIMEOUT_MS); };
+btn('fga-sync-later').onclick = () => { syncPrompt.hidden = true; };
+window.addEventListener('figma-agent:sync-result', (event) => { const data = (event as CustomEvent).detail as { ok?: boolean; summary?: string; landed?: boolean; code?: string } | undefined; const unbound = data?.code === 'E_UNBOUND', ok = data?.ok === true, summary = typeof data?.summary === 'string' ? data.summary : '', landed = data?.landed !== false; syncMsg.textContent = syncResultLabel(ok, summary, landed, unbound); syncNowBtn.textContent = syncNowLabel(unbound); const current = run; if (current) { if (stuckTimer) clearTimeout(stuckTimer); activityView.resolve({ id: current.id, ok, ms: Date.now() - current.at, sentence: syncResultSentence(ok, summary, landed, unbound, sceneFile || '(unnamed file)') }); run = null; stuckTimer = null; } const commit = shouldClearPendingCount(ok); parent.postMessage({ pluginMessage: { type: 'SYNC_DONE', commit } }, '*'); syncFailure = !ok; if (commit) pendingSyncCount = 0; syncPrompt.hidden = false; if (!ok) forceOnce(`activity-failure:${current?.id ?? Date.now()}`, 'activity'); if (commit) setTimeout(() => { syncPrompt.hidden = true; render(); }, 4000); render(); });
 
-// Peers (panel IA v2): the broker's honest answer to "which file will my command hit?".
-// `pinned` (#35 P2, additive): true only when THIS plugin is the standing target pin, not
-// merely the most-recently-active file — an older broker never sends it, so it stays
-// false (the pre-#35 behavior) rather than crash on the missing field.
-window.addEventListener('figma-agent:peers', (ev) => {
-  const d = (ev as CustomEvent).detail as { count?: unknown; isActiveTarget?: unknown; pinned?: unknown } | undefined;
-  if (typeof d?.count === 'number' && Number.isFinite(d.count)) peersCount = d.count;
-  if (typeof d?.isActiveTarget === 'boolean') peersIsActiveTarget = d.isActiveTarget;
-  peersPinned = typeof d?.pinned === 'boolean' && d.pinned;
-  renderContext();
-});
-
-// Scene identity for Block 2 — main announces it (FILE_INFO, now carrying selection
-// too); ui-relay also forwards it to the broker. This listener is read-only and independent.
-window.addEventListener('message', (ev: MessageEvent) => {
-  const pm = (ev.data as { pluginMessage?: { type?: string; data?: Record<string, unknown> } } | null)?.pluginMessage;
-  if (!pm) return;
-  // Live-sync idle prompt (spec 004 P4): main fired IDLE_READY → show "N changes ready".
-  if (pm.type === 'IDLE_READY' && pm.data) {
-    const count = typeof pm.data.count === 'number' ? pm.data.count : 1;
-    syncMsg.textContent = syncPromptLabel(count);
-    syncNowBtn.textContent = syncNowLabel(false); // a fresh prompt is never mid-refusal
-    syncPrompt.hidden = false;
-    return;
-  }
-  if (pm.type !== 'FILE_INFO' || !pm.data) return;
-  if (typeof pm.data.fileName === 'string') sceneFile = pm.data.fileName;
-  if (typeof pm.data.page === 'string') scenePage = pm.data.page;
-  selectionName = typeof pm.data.selectionName === 'string' ? pm.data.selectionName : null;
-  selectionCount = typeof pm.data.selectionCount === 'number' ? pm.data.selectionCount : 0;
-  renderContext();
-});
-
-// ─── Idle-commit prompt actions (spec 004 P4) ─────────────────────────────────
-// "Sync now" → ask the relay to send SYNC_REQUEST to the broker (which runs `ui figma
-// reconcile --apply`) AND tell main the batch was acknowledged. "Later" just hides it —
-// the next documentchange restarts the idle timer. SYNC_RESULT confirms in place.
-// A reconcile is the one operation the feed cannot learn about from the wire: it runs
-// in the kernel (`ui figma reconcile --apply`, spawned by the broker) and sends no
-// command through this relay. Its two ends ARE observable here though — the click and
-// the SYNC_RESULT — so the feed logs it from those, keyed by this id.
-let reconcileRun: { id: string; at: number } | null = null;
-// Live-observed durability gap (owner addendum, task #145): a SYNC_REQUEST can land on a
-// broker that gets hot-replaced before answering — the CLI-side retry succeeds on the new
-// broker, but this panel's own pending row never gets its SYNC_RESULT and would spin
-// "Syncing" forever without a bounded guard. Cleared the moment a real result lands.
-let reconcileStuckTimer: ReturnType<typeof setTimeout> | null = null;
-
-syncNowBtn.addEventListener('click', () => {
-  syncMsg.textContent = 'Syncing';
-  const at = Date.now();
-  const id = `reconcile_${at}`;
-  // Stage-4 fix round (minor 9) — a second click while the FIRST run is still pending
-  // (no SYNC_RESULT/timeout has landed yet) used to just overwrite `reconcileRun`,
-  // leaving that first row spinning "Syncing" forever: its own stuck-timer later finds
-  // `reconcileRun.id` has moved on and — correctly — refuses to touch a row a REAL
-  // result might still land on. Resolve it as superseded HERE instead, before the
-  // second run starts, so no row is ever left orphaned.
-  if (reconcileRun) {
-    if (reconcileStuckTimer !== null) { clearTimeout(reconcileStuckTimer); reconcileStuckTimer = null; }
-    activity = resolveActivity(activity, {
-      id: reconcileRun.id, ok: false, ms: at - reconcileRun.at, sentence: syncSupersededSentence(),
-    });
-  }
-  reconcileRun = { id, at };
-  const fileLabel = sceneFile ?? '(unnamed file)';
-  activity = pushActivity(activity, {
-    id, tool: 'RECONCILE', label: 'Reconcile · apply',
-    pending: true, ok: true, ms: 0, at,
-    sentence: syncStartSentence('manual', fileLabel),
-  });
-  renderActivity(at);
-  try { window.dispatchEvent(new CustomEvent('figma-agent:sync-request')); } catch { /* no DOM events */ }
-  // Fix round (finding 2): SYNC_DONE (which resets main's pending-change counter) used to
-  // post HERE, on click — before the result is even known. An E_UNBOUND refusal applies
-  // NOTHING, so consuming the counter at click-time silently dropped the pending changes'
-  // one visible signal. It now posts from the sync-result listener below, once the
-  // outcome is known, carrying whether to actually reset.
-  if (reconcileStuckTimer !== null) clearTimeout(reconcileStuckTimer);
-  reconcileStuckTimer = setTimeout(() => {
-    if (reconcileRun?.id !== id) return; // already resolved (or superseded) by a real SYNC_RESULT
-    const now = Date.now();
-    activity = resolveActivity(activity, { id, ok: false, ms: now - at, sentence: syncStuckSentence() });
-    reconcileRun = null;
-    reconcileStuckTimer = null;
-    renderActivity(now);
-  }, SYNC_STUCK_TIMEOUT_MS);
-});
-
-syncLaterBtn.addEventListener('click', () => { syncPrompt.hidden = true; });
-
-window.addEventListener('figma-agent:sync-result', (ev) => {
-  const d = (ev as CustomEvent).detail as
-    { ok?: boolean; summary?: string; landed?: boolean; code?: string } | undefined;
-  // `landed` absent (an older broker) → assume it landed; a present `false` is honoured.
-  // `code === 'E_UNBOUND'` (registry-integrity fix round, finding 2): the broker refused
-  // instead of guessing a project — renders the bind command, not a pass/fail verdict.
-  const unbound = d?.code === 'E_UNBOUND';
-  const ok = d?.ok === true;
-  const summary = typeof d?.summary === 'string' ? d.summary : '';
-  const landed = d?.landed !== false;
-  const label = syncResultLabel(ok, summary, landed, unbound);
-  syncMsg.textContent = label;
-  syncNowBtn.textContent = syncNowLabel(unbound);
-  // The prompt line normally auto-dismisses in 4s; the feed row is the durable record —
-  // it composes its OWN long-form sentence (task #145) rather than reusing the prompt's
-  // short label, naming the file and never collapsing to the bare word "Synced".
-  if (reconcileRun) {
-    if (reconcileStuckTimer !== null) { clearTimeout(reconcileStuckTimer); reconcileStuckTimer = null; }
-    const now = Date.now();
-    const fileLabel = sceneFile ?? '(unnamed file)';
-    activity = resolveActivity(activity, {
-      id: reconcileRun.id, ok, ms: now - reconcileRun.at,
-      sentence: syncResultSentence(ok, summary, landed, unbound, fileLabel),
-    });
-    reconcileRun = null;
-    renderActivity(now);
-  }
-  // Closing review round, defect #2: ONLY a genuine success may clear main's pending-change
-  // counter — a real reconcile failure or "already running" applied nothing either, so
-  // clearing it there was just as dishonest as clearing it on an unbound refusal. Every
-  // failure (E_UNBOUND included) keeps both the counter and this prompt, so retry stays
-  // possible; only a success auto-dismisses.
-  const commit = shouldClearPendingCount(ok);
-  parent.postMessage({ pluginMessage: { type: 'SYNC_DONE', commit } }, '*');
-  syncPrompt.hidden = false;
-  if (commit) setTimeout(() => { syncPrompt.hidden = true; }, 4000);
-});
-
-// #35 P2 — "Target this plugin": a toggle. Pinned → clicking sends CLEAR_TARGET;
-// unpinned → SET_TARGET. `peersPinned` (from the last PEERS event) is the state read at
-// click time — no local optimistic flip: the button's own label/state is driven entirely
-// by the broker's next PEERS broadcast, the same "the wire is the source of truth" shape
-// every other panel affordance here already follows (sync prompt, activity feed).
-targetBtn.addEventListener('click', () => {
-  const event = peersPinned ? 'figma-agent:clear-target' : 'figma-agent:set-target';
-  try { window.dispatchEvent(new CustomEvent(event)); } catch { /* no DOM events */ }
-});
-
-versionEl.textContent = `v0.1.0 · ${typeof __BUILD_ID__ === 'string' ? __BUILD_ID__ : 'dev'}`;
-
-// A 1s heartbeat keeps the live ages (uptime, retry elapsed, time-ago) fresh
-// between transitions.
-setInterval(render, 1000);
-render();
-
-// probeAttempts / PORT_RANGE_START were the old meta-line's "Attempt N" counter — IA v2's
-// statusSentence carries no attempt count, so nothing here needs it; the import stays
-// only because `figma-agent:conn-state`'s payload shape is still typed against it
-// upstream. Referencing it directly would be dead code, so it is deliberately unused.
-void PORT_RANGE_START;
-void PANEL_HEIGHT;
+el('fga-version').textContent = `v0.1.0 · ${typeof __BUILD_ID__ === 'string' ? __BUILD_ID__ : 'dev'}`;
+replaceIcon(targetRailBtn, 'files'); replaceIcon(syncRailBtn, 'refresh-cw'); replaceIcon(toggleBtn, 'chevron-down');
+setInterval(render, 1000); render(); void PORT_RANGE_START;

--- a/plugin/src/ui/panel-view-state.ts
+++ b/plugin/src/ui/panel-view-state.ts
@@ -1,0 +1,83 @@
+import type { ConnectionState } from '../../../shared/protocol';
+import { pushActivity, resolveActivity, type ActivityRecord, type ActivityResult } from './activity-feed';
+
+export const VIEW_KEY_LIMIT = 64;
+
+export class BoundedKeySet {
+  private readonly keys = new Set<string>();
+  private overflow = 0;
+
+  constructor(private readonly limit = VIEW_KEY_LIMIT) {}
+
+  add(key: string): void {
+    if (this.keys.has(key)) this.keys.delete(key);
+    this.keys.add(key);
+    while (this.keys.size > this.limit) {
+      const oldest = this.keys.values().next().value as string | undefined;
+      if (oldest === undefined) break;
+      this.keys.delete(oldest);
+      this.overflow += 1;
+    }
+  }
+
+  delete(key: string): void { this.keys.delete(key); }
+  has(key: string): boolean { return this.keys.has(key); }
+  get size(): number { return this.keys.size; }
+  get unresolvedCount(): number { return this.keys.size + this.overflow; }
+  get overflowCount(): number { return this.overflow; }
+  values(): string[] { return [...this.keys]; }
+  acknowledge(): void { this.keys.clear(); this.overflow = 0; }
+}
+
+export function applyActivityOutcome(failures: BoundedKeySet, id: string, ok: boolean): void {
+  if (ok) failures.delete(id);
+  else failures.add(id);
+}
+
+export function currentActivity(records: readonly ActivityRecord[]): ActivityRecord | undefined {
+  return records.find((record) => record.pending) ?? records[0];
+}
+
+export function unresolvedActivityCount(failures: BoundedKeySet): number {
+  return failures.unresolvedCount;
+}
+
+export function landTerminalActivity(
+  records: readonly ActivityRecord[],
+  patch: ActivityResult,
+  at = Date.now(),
+): ActivityRecord[] {
+  if (records.some((record) => record.id === patch.id)) return resolveActivity(records, patch);
+  const outcome = patch.ok ? 'completed' : 'failed';
+  const detail = patch.sentence ?? patch.result ?? outcome;
+  return pushActivity(records, {
+    id: patch.id, tool: 'REQUEST', pending: false, ok: patch.ok, ms: patch.ms, at,
+    result: patch.result, errorCode: patch.code, nodeName: patch.nodeName,
+    sentence: `Late result for request ${patch.id} — ${detail}`,
+  });
+}
+
+export type ConnectionForceKind = 'onboarding' | 'probe-timeout' | 'connection-lost';
+export interface ConnectionForce {
+  key: string;
+  kind: ConnectionForceKind;
+}
+
+/** Semantic keys make the 10-second threshold distinct from the earlier onboarding view. */
+export function connectionForce(
+  state: ConnectionState,
+  ageMs: number,
+  hadConnection: boolean,
+  transitionId: number,
+): ConnectionForce | null {
+  if (state === 'probing' && ageMs >= 10_000) {
+    return { key: `probe-timeout:${transitionId}`, kind: 'probe-timeout' };
+  }
+  if (state === 'disconnected' && hadConnection) {
+    return { key: `connection-lost:${transitionId}`, kind: 'connection-lost' };
+  }
+  if (!hadConnection && (state === 'disconnected' || state === 'probing')) {
+    return { key: `onboarding:${transitionId}`, kind: 'onboarding' };
+  }
+  return null;
+}

--- a/plugin/src/ui/panel.html
+++ b/plugin/src/ui/panel.html
@@ -273,7 +273,6 @@
   --fga-tone-success: #5BA46F;    /* the reference's own green, ~8% less saturated — 5.96 (body, text), 4.20 (row-active, indicator) */
   --fga-tone-warning: #C9A356;    /* web-amber → ochre; stops shouting next to the greys — 7.56 (body, text) */
   --fga-tone-info: #8FB4D9;       /* desaturated steel, not "link blue" — 8.28 (body, text); also --fga-focus's value, 3:1+ on all three surfaces */
-  --fga-tone-muted: #9B9B9B;      /* already neutral; aligned with --fga-text-muted — 6.45 (body, indicator) */
   --fga-tone-danger: #D98A8A;     /* muted terracotta, icon-only (never text) — 4.78 (row-active, indicator) */
   --fga-radius: 8px;              /* inputs, cards, buttons */
   --fga-radius-sm: 6px;           /* chips */
@@ -329,7 +328,7 @@
 
    Full recompute (WCAG 2.1, text 4.5:1 / non-text-indicator 3:1), against every
    surface a token is REACHABLE on in this file's actual markup (status-sentence and
-   status-dot sit on --fga-chrome, which equals --fga-surface's hex here; activity-row
+   rail icons sit on --fga-chrome, which equals --fga-surface's hex here; activity-row
    icons sit on --fga-row-active when fresh, --fga-surface when stale; section-label
    and .activity-empty reach --fga-body via the Context block / plain body):
      --fga-text     (#1A1A1A) vs body 16.25, surface/chrome 17.40, row-active 14.73 — PASS everywhere
@@ -348,9 +347,8 @@
      --fga-tone-warning (#8A6A1F) vs chrome 5.05 (text) · vs row-active 4.27 (indicator) — PASS
      --fga-tone-info    (#2B5E8C) vs chrome 6.81 (text) · vs row-active 5.77 (indicator);
                     also --fga-focus's value — vs body 6.36, surface/chrome 6.81, row-active 5.77,
-                    all far past the 3:1 focus-ring floor — PASS
+                    all well past the 3:1 focus-ring floor — PASS
      --fga-tone-danger  (#B3372F) — icon-only, never text — vs row-active 5.07 (indicator) — PASS
-     --fga-tone-muted   (#6B6B6B, = text-muted) vs chrome/body — PASS (see text-muted above)
      --fga-border-strong (#767676, decorative-boundary token, not owner-specified — derived)
                     vs surface (sync-btn's own bg) 4.54, vs row-active (hover) 3.84 — both
                     clear the 3:1 non-text floor
@@ -371,7 +369,6 @@ html.figma-light {
   --fga-tone-success: #1F7A3D;
   --fga-tone-warning: #8A6A1F;
   --fga-tone-info: #2B5E8C;
-  --fga-tone-muted: #6B6B6B;
   --fga-tone-danger: #B3372F;
   --fga-hairline: rgba(0, 0, 0, 0.12);       /* raised-card border — black flip of the dark 0.08 */
   --fga-hairline-soft: rgba(0, 0, 0, 0.08);  /* nested/secondary edges, row hover — black flip of 0.06 */
@@ -394,7 +391,8 @@ html.figma-light {
    onboarding card is priority-1 content and stays, re-parented under the status
    sentence. One font family throughout (`--font-family-body`, declared ONCE on
    `body` and inherited); every text glyph that used to be cross/check is now an
-   inline Phosphor-style SVG (panel-ui.ts's `ICONS` map). ──────────────────── */
+   inline SVG marks. The adaptive rail replaces them with the locally vendored Lucide
+   descriptor factory in panel-ui.ts. ──────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
 img, svg { max-width: 100%; }
 
@@ -440,21 +438,17 @@ body {
    Gate D exempts this selector by name. */
 ::selection { background: rgba(143, 180, 217, 0.28); color: var(--fga-text); }
 
-/* Spatial rhythm (phase 03 §1): one row layout, one icon grid, one dot grid —
+/* Spatial rhythm (phase 03 §1): one row layout and one icon grid —
    applied via markup classes (`fga-row`, `fga-icon`) rather than duplicated
    per-selector, so `.status-row` and `.activity-row` share the same flex
-   layout instead of re-declaring it. Two size families, not one: SVG icons
-   ride the 14px grid; the two CSS-drawn dots (`.status-dot`, `.identity-dot`)
-   are dots, not icons — unified at 8px so there is one dot size, one icon
-   size, and no third. */
+   layout instead of re-declaring it. SVG icons ride the 14px grid. */
 .fga-row { display: flex; align-items: flex-start; gap: var(--space-1); }
-/* Optical centring on the FIRST line box rather than the flex box: a 14px icon
+/* Optical centring on the FIRST line box rather than the flex box: the legacy icon
    beside a 13px/1.5-line-height line sits high if you centre on the box. line
    box = 13 * 1.5 = 19.5px, so (19.5 - 14)/2 = 2.75px — derived, not eyeballed,
    and it stays correct if the size token moves. */
 .fga-icon { width: 14px; height: 14px; flex: 0 0 auto; }
 .fga-row > .fga-icon { margin-top: calc((1.5em - 14px) / 2); }
-.status-dot, .identity-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 
 /* Block 1 — STATUS: sticky, one dot + one sentence. No pill/meta split, no
    port numbers, no attempt counts — the sentence names the problem AND the
@@ -476,33 +470,6 @@ body {
 }
 .status-row { min-width: 0; }
 
-/* Live marker — a circle, tone-coloured. Pings outward while probing. Plain
-   CSS shape (Phosphor `circle`, filled) — no SVG needed for an unadorned dot.
-   Sizing comes from the shared `.status-dot, .identity-dot` rule above; this
-   one only adds what is unique to the status dot (position + tone colour). */
-.status-dot {
-  position: relative;
-  /* Sits beside the TITLE line (14px / --fga-lh-title), not the body line the
-     shared .fga-icon formula assumes — derived against its own context rather
-     than reused blind: (14px * 1.35 - 8px) / 2. */
-  margin-top: calc((var(--fga-font-title) * var(--fga-lh-title) - 8px) / 2);
-  background: var(--fga-tone-muted);
-  /* Motion (§4): tone crossfades instead of jumping. Named properties only. */
-  transition: background-color var(--fga-motion) var(--fga-ease);
-}
-.status-dot[data-tone="success"] { background: var(--fga-tone-success); }
-.status-dot[data-tone="warning"] { background: var(--fga-tone-warning); }
-.status-dot[data-tone="info"]    { background: var(--fga-tone-info); }
-.status-dot[data-tone="muted"]   { background: var(--fga-tone-muted); }
-.status-dot::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  background: inherit;
-  opacity: 0;
-}
-.status-dot.is-pulsing::after { animation: fga-ping 1.6s ease-out infinite; }
 
 /* The ONE title — replaces the old pill+meta split. Tone-coloured (the pill's
    job), states the problem and the next action in one sentence (the meta's job). */
@@ -730,19 +697,18 @@ code {
    (the newest, non-stale one) gets the border-lift; every other row is inert
    on hover. */
 .activity-row:not(.is-stale):hover { border-color: var(--fga-hairline-soft); }
-/* Status reads by SHAPE first, colour second: an inline Phosphor-style SVG per
+/* Status reads by SHAPE first, colour second: an inline SVG per
    state (check-circle / x-circle / circle-notch), never a text glyph. The
    accessible label lives on this WRAPPING span (aria-label="ok"/"failed"/
    "running"); the svg inside is aria-hidden — its meaning is already spoken.
    Sizing + optical centring come from the shared `.fga-icon` rule (§1) —
    `.log-icon-wrap` carries that class too; this selector only adds colour. */
-.log-icon { display: block; width: 100%; height: 100%; }
-.log-icon-wrap[data-state="ok"]      .log-icon { color: var(--fga-tone-success); }
-.log-icon-wrap[data-state="failed"]  .log-icon { color: var(--fga-tone-danger); }
-.log-icon-wrap[data-state="running"] .log-icon { color: var(--fga-tone-warning); animation: fga-spin 1s linear infinite; }
+.log-icon-wrap[data-state="ok"]      .fga-icon { color: var(--fga-tone-success); }
+.log-icon-wrap[data-state="failed"]  .fga-icon { color: var(--fga-tone-danger); }
+.log-icon-wrap[data-state="running"] .fga-icon { color: var(--fga-tone-warning); }
 /* Stale (non-newest) rows dim the icon too — same equal-specificity family as the
    tone rules above, so it must come after them in source order to win the tie. */
-.activity-row.is-stale .log-icon { color: var(--fga-text-dim); }
+.activity-row.is-stale .fga-icon { color: var(--fga-text-dim); }
 .log-body {
   flex: 1 1 auto;
   min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
@@ -822,31 +788,6 @@ code {
   outline-offset: 2px;
 }
 
-/* Footer band — identity row only (status-dot mirror + build id). The Docs/Copy/
-   Details actions row that used to sit below it is cut entirely (§2); the file
-   name it also used to carry now lives in Block 2's Context row instead. */
-.footer-row {
-  border-top: 1px dotted var(--fga-divider);
-  padding: var(--space-1) var(--space-2);
-  padding-top: var(--fga-divider-gap);
-  margin-top: auto;
-}
-.identity-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-hair);
-  min-width: 0;
-}
-/* CSS mirror of #fga-dot's tone — panel-ui.ts writes the tone onto #fga-dot only;
-   a second JS write target would be a behaviour change, so the mirror is derived
-   here instead. Falls back to muted if :has() is unsupported — quiet, never broken. */
-/* Sizing comes from the shared `.status-dot, .identity-dot` rule (§1: one dot
-   grid, 8px — was 6px). This rule adds only the default (muted) fill. */
-.identity-dot { background: var(--fga-tone-muted); }
-.panel:has(#fga-dot[data-tone="success"]) .identity-dot { background: var(--fga-tone-success); }
-.panel:has(#fga-dot[data-tone="warning"]) .identity-dot { background: var(--fga-tone-warning); }
-.panel:has(#fga-dot[data-tone="info"])    .identity-dot { background: var(--fga-tone-info); }
 #fga-version { flex: 0 0 auto; font-size: var(--fga-font-caption); color: var(--fga-text-muted); font-variant-numeric: tabular-nums; }
 
 /* ── Responsive contract (240px → 640px+, any height, locked) ─────────────────
@@ -854,22 +795,16 @@ code {
    anywhere on the path that keeps its intrinsic width pushes the row past the
    panel edge. overflow-x:hidden would then merely HIDE the overflow. */
 .panel > * { min-width: 0; max-width: 100%; }
-.status-row > *, .identity-row > *, .sync-prompt > *,
+.status-row > *, .sync-prompt > *,
 .log-body, .log-body > *, .detail-cell, .detail-cell > *, .activity-row > * { min-width: 0; }
 
 /* Truncation: the trio is a set — ellipsis without the other two does nothing. */
 .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-/* Motion — the probing marker pings outward (transform + opacity only, never a
-   layout property). Snappy 0.1s ease-out is the brand curve. The pending feed
-   icon spins (transform only) — a continuous linear rotation is the one place
+/* Motion — the pending feed icon spins (transform only). Continuous linear rotation is the one place
    `linear` is correct (taste-lint's checkLinearOrAllTransition only inspects
    `transition:`, never `animation:`). Every animated/transitioned selector is
    guarded below. */
-@keyframes fga-ping {
-  0%   { opacity: 0.5; transform: scale(1); }
-  100% { opacity: 0;   transform: scale(2.4); }
-}
 @keyframes fga-spin {
   to { transform: rotate(360deg); }
 }
@@ -879,80 +814,170 @@ code {
   to   { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .status-dot.is-pulsing::after,
-  .log-icon-wrap[data-state="running"] .log-icon,
+  .log-icon-wrap[data-state="running"] .fga-icon,
   .activity-row.is-new { animation: none; } /* .is-new, not bare .activity-row — the
     entrance animation lives on the two-class selector, so the guard must match its
     specificity or `animation: none` here would lose the cascade to `.is-new`'s rule. */
-  .inline-link, .sync-prompt, .status-dot, .status-sentence, .activity-row { transition: none; }
+  .inline-link, .sync-prompt, .status-sentence, .activity-row { transition: none; }
+}
+
+/* Adaptive Agent Rail. The host viewport owns the two exact sizes; this document owns
+   disclosure within them. Existing theme tokens remain the color source of truth. */
+body { overflow: hidden; }
+.panel { height: 100%; overflow: hidden; }
+.agent-rail {
+  height: 44px;
+  padding: 0 var(--space-1);
+  display: grid;
+  grid-template-columns: 32px minmax(32px, 1fr) auto auto 32px;
+  gap: var(--space-hair);
+  align-items: center;
+  background: var(--fga-chrome);
+}
+.rail-control {
+  position: relative;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--fga-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-hair);
+  background: transparent;
+  color: var(--fga-text-muted);
+  cursor: pointer;
+  transition: background-color var(--fga-motion) var(--fga-ease), border-color var(--fga-motion) var(--fga-ease), color var(--fga-motion) var(--fga-ease);
+}
+.rail-control:hover, .rail-control[aria-expanded="true"] { background: var(--fga-row-active); color: var(--fga-text); }
+.rail-control:active { background: var(--fga-surface); }
+.rail-control:focus-visible, .tab-button:focus-visible, .sync-btn:focus-visible, .inline-link:focus-visible {
+  outline: 2px solid var(--fga-focus);
+  outline-offset: 1px;
+}
+.current-control { width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
+.current-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.failure-count {
+  min-width: 14px;
+  padding: 0 var(--space-hair);
+  border-radius: var(--radius-full);
+  background: var(--fga-tone-danger);
+  color: var(--fga-body);
+  font-size: var(--fga-font-caption);
+  line-height: var(--fga-lh-caption);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.fga-icon { display: block; width: 16px; height: 16px; flex: 0 0 auto; }
+.tone-success { color: var(--fga-tone-success); }
+.tone-warning { color: var(--fga-tone-warning); }
+.tone-info { color: var(--fga-tone-info); }
+.tone-danger { color: var(--fga-tone-danger); }
+.rail-badge {
+  position: absolute;
+  inset: 0 0 auto auto;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 4px;
+  border-radius: var(--radius-full);
+  background: var(--fga-tone-warning);
+  color: var(--fga-body);
+  font-size: var(--fga-font-caption);
+  line-height: var(--fga-lh-caption);
+  font-variant-numeric: tabular-nums;
+}
+.inspector { height: calc(100% - 44px); background: var(--fga-body); overflow: hidden; }
+.inspector-tabs { height: 36px; display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: 1px dotted var(--fga-divider); }
+.tab-button {
+  min-width: 0;
+  min-height: 32px;
+  border: 0;
+  background: transparent;
+  color: var(--fga-text-muted);
+  font: inherit;
+  cursor: pointer;
+}
+.tab-button:hover { color: var(--fga-text); background: var(--fga-row-active); }
+.tab-button[aria-selected="true"] { color: var(--fga-text); background: var(--fga-surface); }
+.inspector-content { height: calc(100% - 36px); overflow-y: auto; overflow-x: hidden; }
+.inspector-panel { min-width: 0; padding: var(--space-1); }
+.inspector-panel[hidden], .inspector[hidden], .rail-control[hidden], .sync-prompt[hidden] { display: none; }
+.inspector .context, .inspector .activity, .inspector .status-hero { position: static; border-top: 0; padding: 0; background: transparent; }
+.inspector .detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.details-stack { display: flex; flex-direction: column; gap: var(--space-1); }
+.details-card { padding: var(--space-1); border: 1px solid var(--fga-hairline); border-top-color: var(--fga-topedge); border-radius: var(--fga-radius); }
+.details-card .status-sentence { margin: 0; }
+.version-row { color: var(--fga-text-muted); font-size: var(--fga-font-caption); font-variant-numeric: tabular-nums; }
+.sync-prompt { margin: var(--space-1); }
+.is-spinning { animation: fga-spin 1s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .is-spinning { animation: none; }
+  .rail-control { transition: none; }
 }
 </style>
 </head>
 <body>
-<main class="panel" id="fga-panel">
-  <!-- Owner decree 2026-07-30: the internal masthead ("Figma Design Agent") is removed —
-       it duplicated the Figma plugin window's own chrome title directly above it, and
-       that OS/host-drawn title bar cannot be removed (verified against showUI docs). The
-       sticky status block is now the panel's first visible row. -->
-  <section class="status-hero fga-block" id="fga-status" aria-live="polite" aria-label="Connection status">
-    <div class="status-row fga-row">
-      <span class="status-dot" id="fga-dot" data-tone="muted"></span>
-      <p class="status-sentence" id="fga-sentence" data-tone="muted">Not connected — your first command starts the broker.</p>
+<main class="panel" id="fga-panel" data-view="rail">
+  <header class="agent-rail" id="fga-rail" aria-label="Agent status">
+    <button class="rail-control" id="fga-connection-btn" type="button" title="Connection details" aria-label="Connection details"></button>
+    <button class="rail-control current-control" id="fga-current-btn" type="button" title="Current activity: Idle" aria-label="Current activity: Idle">
+      <span class="current-label" id="fga-current-label">Idle</span>
+      <span class="failure-count" id="fga-failure-count" role="status" aria-live="polite" aria-atomic="true" aria-label="0 unresolved failures" hidden></span>
+    </button>
+    <button class="rail-control" id="fga-target-rail-btn" type="button" title="File target" aria-label="File target" hidden></button>
+    <button class="rail-control" id="fga-sync-rail-btn" type="button" title="Pending sync" aria-label="Pending sync" hidden><span class="rail-badge" id="fga-sync-badge">1</span></button>
+    <button class="rail-control" id="fga-toggle-btn" type="button" title="Open inspector" aria-label="Open inspector" aria-expanded="false" aria-controls="fga-inspector"></button>
+  </header>
+
+  <section class="inspector" id="fga-inspector" aria-label="Agent inspector" hidden>
+    <div class="inspector-tabs" role="tablist" aria-label="Inspector views">
+      <button class="tab-button" id="fga-tab-activity" type="button" role="tab" aria-selected="true" tabindex="0" aria-controls="fga-panel-activity">Activity</button>
+      <button class="tab-button" id="fga-tab-context" type="button" role="tab" aria-selected="false" tabindex="-1" aria-controls="fga-panel-context">Context</button>
+      <button class="tab-button" id="fga-tab-details" type="button" role="tab" aria-selected="false" tabindex="-1" aria-controls="fga-panel-details">Details</button>
     </div>
+    <div class="inspector-content">
+      <section class="sync-prompt" id="fga-sync" aria-live="polite" aria-atomic="true" hidden>
+        <p class="sync-msg" id="fga-sync-msg">changes ready</p>
+        <div class="sync-actions">
+          <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
+          <button class="inline-link" id="fga-sync-later" type="button">Later</button>
+        </div>
+      </section>
 
-    <!-- Onboarding: priority-1 content, not a debug affordance — re-parented here
-         (block 1) so it answers the "disconnected, never connected" state directly.
-         JS toggles [hidden] via showOnboarding (panel-model.ts). -->
-    <section class="onboarding" id="fga-onboarding" aria-label="Getting started">
-      <ul class="onboarding-list">
-        <li>Bridges the figma-agent CLI to this file.</li>
-        <li>Verify: <code>figma-agent status</code></li>
-        <li>Keep this panel open.</li>
-      </ul>
-    </section>
-  </section>
+      <section class="inspector-panel" id="fga-panel-activity" role="tabpanel" aria-labelledby="fga-tab-activity">
+        <section class="activity" id="fga-activity-block" aria-label="Activity log">
+          <ul class="activity-list" id="fga-activity" aria-live="polite" aria-atomic="true">
+            <li class="activity-empty">No activity yet</li>
+          </ul>
+        </section>
+      </section>
 
-  <section class="context fga-block" id="fga-context" aria-label="File context">
-    <h2 class="section-label">Context</h2>
-    <dl class="detail-grid">
-      <div class="detail-cell">
-        <dt>File</dt>
-        <dd id="fga-ctx-file">—</dd>
-        <p class="detail-note" id="fga-ctx-file-note"></p>
-      </div>
-      <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
-      <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
-    </dl>
-    <!-- #35 P2: pins the daemon's routing target to THIS plugin instance (a runtime-only,
-         human-set pin — see broker-daemon.ts's `targetInstancePin`). Toggles between
-         "Target this plugin" and "Targeted" — panel-ui.ts wires the click, panel-model.ts
-         owns the label text. -->
-    <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
-  </section>
+      <section class="inspector-panel" id="fga-panel-context" role="tabpanel" aria-labelledby="fga-tab-context" hidden>
+        <section class="context" id="fga-context" aria-label="File context">
+          <dl class="detail-grid">
+            <div class="detail-cell"><dt>File</dt><dd id="fga-ctx-file">—</dd><p class="detail-note" id="fga-ctx-file-note"></p></div>
+            <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
+            <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
+          </dl>
+          <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
+        </section>
+      </section>
 
-  <section class="activity fga-block" id="fga-activity-block" aria-label="Activity log">
-    <h2 class="section-label">Activity</h2>
-    <ul class="activity-list" id="fga-activity" aria-live="polite">
-      <li class="activity-empty">No activity yet</li>
-    </ul>
-  </section>
-
-  <!-- Live-sync idle-commit prompt (spec 004 P4): one line, shown only at the idle
-       point. "Sync now" applies the change-log via the deterministic kernel. -->
-  <section class="sync-prompt" id="fga-sync" aria-live="polite" hidden>
-    <p class="sync-msg" id="fga-sync-msg">changes ready</p>
-    <div class="sync-actions">
-      <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
-      <button class="inline-link" id="fga-sync-later" type="button">Later</button>
+      <section class="inspector-panel" id="fga-panel-details" role="tabpanel" aria-labelledby="fga-tab-details" hidden>
+        <div class="details-stack">
+          <section class="details-card status-hero" id="fga-status" aria-live="polite" aria-atomic="true" aria-label="Connection status">
+            <p class="status-sentence" id="fga-sentence" data-tone="muted">Not connected — your first command starts the broker.</p>
+          </section>
+          <section class="onboarding" id="fga-onboarding" aria-label="Getting started">
+            <ul class="onboarding-list"><li>Bridges the figma-agent CLI to this file.</li><li>Verify: <code>figma-agent status</code></li><li>Keep this panel open.</li></ul>
+          </section>
+          <div class="version-row" id="fga-version">v0.1.0</div>
+        </div>
+      </section>
     </div>
   </section>
-
-  <footer class="footer-row">
-    <div class="identity-row">
-      <span class="identity-dot"></span>
-      <span id="fga-version">v0.1.0</span>
-    </div>
-  </footer>
 </main>
 <script>
 /*__FIGMA_AGENT_UI_BUNDLE__*/

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -273,7 +273,6 @@
   --fga-tone-success: #5BA46F;    /* the reference's own green, ~8% less saturated — 5.96 (body, text), 4.20 (row-active, indicator) */
   --fga-tone-warning: #C9A356;    /* web-amber → ochre; stops shouting next to the greys — 7.56 (body, text) */
   --fga-tone-info: #8FB4D9;       /* desaturated steel, not "link blue" — 8.28 (body, text); also --fga-focus's value, 3:1+ on all three surfaces */
-  --fga-tone-muted: #9B9B9B;      /* already neutral; aligned with --fga-text-muted — 6.45 (body, indicator) */
   --fga-tone-danger: #D98A8A;     /* muted terracotta, icon-only (never text) — 4.78 (row-active, indicator) */
   --fga-radius: 8px;              /* inputs, cards, buttons */
   --fga-radius-sm: 6px;           /* chips */
@@ -329,7 +328,7 @@
 
    Full recompute (WCAG 2.1, text 4.5:1 / non-text-indicator 3:1), against every
    surface a token is REACHABLE on in this file's actual markup (status-sentence and
-   status-dot sit on --fga-chrome, which equals --fga-surface's hex here; activity-row
+   rail icons sit on --fga-chrome, which equals --fga-surface's hex here; activity-row
    icons sit on --fga-row-active when fresh, --fga-surface when stale; section-label
    and .activity-empty reach --fga-body via the Context block / plain body):
      --fga-text     (#1A1A1A) vs body 16.25, surface/chrome 17.40, row-active 14.73 — PASS everywhere
@@ -348,9 +347,8 @@
      --fga-tone-warning (#8A6A1F) vs chrome 5.05 (text) · vs row-active 4.27 (indicator) — PASS
      --fga-tone-info    (#2B5E8C) vs chrome 6.81 (text) · vs row-active 5.77 (indicator);
                     also --fga-focus's value — vs body 6.36, surface/chrome 6.81, row-active 5.77,
-                    all far past the 3:1 focus-ring floor — PASS
+                    all well past the 3:1 focus-ring floor — PASS
      --fga-tone-danger  (#B3372F) — icon-only, never text — vs row-active 5.07 (indicator) — PASS
-     --fga-tone-muted   (#6B6B6B, = text-muted) vs chrome/body — PASS (see text-muted above)
      --fga-border-strong (#767676, decorative-boundary token, not owner-specified — derived)
                     vs surface (sync-btn's own bg) 4.54, vs row-active (hover) 3.84 — both
                     clear the 3:1 non-text floor
@@ -371,7 +369,6 @@ html.figma-light {
   --fga-tone-success: #1F7A3D;
   --fga-tone-warning: #8A6A1F;
   --fga-tone-info: #2B5E8C;
-  --fga-tone-muted: #6B6B6B;
   --fga-tone-danger: #B3372F;
   --fga-hairline: rgba(0, 0, 0, 0.12);       /* raised-card border — black flip of the dark 0.08 */
   --fga-hairline-soft: rgba(0, 0, 0, 0.08);  /* nested/secondary edges, row hover — black flip of 0.06 */
@@ -394,7 +391,8 @@ html.figma-light {
    onboarding card is priority-1 content and stays, re-parented under the status
    sentence. One font family throughout (`--font-family-body`, declared ONCE on
    `body` and inherited); every text glyph that used to be cross/check is now an
-   inline Phosphor-style SVG (panel-ui.ts's `ICONS` map). ──────────────────── */
+   inline SVG marks. The adaptive rail replaces them with the locally vendored Lucide
+   descriptor factory in panel-ui.ts. ──────────────────────────────────────── */
 *, *::before, *::after { box-sizing: border-box; }
 img, svg { max-width: 100%; }
 
@@ -440,21 +438,17 @@ body {
    Gate D exempts this selector by name. */
 ::selection { background: rgba(143, 180, 217, 0.28); color: var(--fga-text); }
 
-/* Spatial rhythm (phase 03 §1): one row layout, one icon grid, one dot grid —
+/* Spatial rhythm (phase 03 §1): one row layout and one icon grid —
    applied via markup classes (`fga-row`, `fga-icon`) rather than duplicated
    per-selector, so `.status-row` and `.activity-row` share the same flex
-   layout instead of re-declaring it. Two size families, not one: SVG icons
-   ride the 14px grid; the two CSS-drawn dots (`.status-dot`, `.identity-dot`)
-   are dots, not icons — unified at 8px so there is one dot size, one icon
-   size, and no third. */
+   layout instead of re-declaring it. SVG icons ride the 14px grid. */
 .fga-row { display: flex; align-items: flex-start; gap: var(--space-1); }
-/* Optical centring on the FIRST line box rather than the flex box: a 14px icon
+/* Optical centring on the FIRST line box rather than the flex box: the legacy icon
    beside a 13px/1.5-line-height line sits high if you centre on the box. line
    box = 13 * 1.5 = 19.5px, so (19.5 - 14)/2 = 2.75px — derived, not eyeballed,
    and it stays correct if the size token moves. */
 .fga-icon { width: 14px; height: 14px; flex: 0 0 auto; }
 .fga-row > .fga-icon { margin-top: calc((1.5em - 14px) / 2); }
-.status-dot, .identity-dot { width: 8px; height: 8px; border-radius: 50%; flex: 0 0 auto; }
 
 /* Block 1 — STATUS: sticky, one dot + one sentence. No pill/meta split, no
    port numbers, no attempt counts — the sentence names the problem AND the
@@ -476,33 +470,6 @@ body {
 }
 .status-row { min-width: 0; }
 
-/* Live marker — a circle, tone-coloured. Pings outward while probing. Plain
-   CSS shape (Phosphor `circle`, filled) — no SVG needed for an unadorned dot.
-   Sizing comes from the shared `.status-dot, .identity-dot` rule above; this
-   one only adds what is unique to the status dot (position + tone colour). */
-.status-dot {
-  position: relative;
-  /* Sits beside the TITLE line (14px / --fga-lh-title), not the body line the
-     shared .fga-icon formula assumes — derived against its own context rather
-     than reused blind: (14px * 1.35 - 8px) / 2. */
-  margin-top: calc((var(--fga-font-title) * var(--fga-lh-title) - 8px) / 2);
-  background: var(--fga-tone-muted);
-  /* Motion (§4): tone crossfades instead of jumping. Named properties only. */
-  transition: background-color var(--fga-motion) var(--fga-ease);
-}
-.status-dot[data-tone="success"] { background: var(--fga-tone-success); }
-.status-dot[data-tone="warning"] { background: var(--fga-tone-warning); }
-.status-dot[data-tone="info"]    { background: var(--fga-tone-info); }
-.status-dot[data-tone="muted"]   { background: var(--fga-tone-muted); }
-.status-dot::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  border-radius: 50%;
-  background: inherit;
-  opacity: 0;
-}
-.status-dot.is-pulsing::after { animation: fga-ping 1.6s ease-out infinite; }
 
 /* The ONE title — replaces the old pill+meta split. Tone-coloured (the pill's
    job), states the problem and the next action in one sentence (the meta's job). */
@@ -730,19 +697,18 @@ code {
    (the newest, non-stale one) gets the border-lift; every other row is inert
    on hover. */
 .activity-row:not(.is-stale):hover { border-color: var(--fga-hairline-soft); }
-/* Status reads by SHAPE first, colour second: an inline Phosphor-style SVG per
+/* Status reads by SHAPE first, colour second: an inline SVG per
    state (check-circle / x-circle / circle-notch), never a text glyph. The
    accessible label lives on this WRAPPING span (aria-label="ok"/"failed"/
    "running"); the svg inside is aria-hidden — its meaning is already spoken.
    Sizing + optical centring come from the shared `.fga-icon` rule (§1) —
    `.log-icon-wrap` carries that class too; this selector only adds colour. */
-.log-icon { display: block; width: 100%; height: 100%; }
-.log-icon-wrap[data-state="ok"]      .log-icon { color: var(--fga-tone-success); }
-.log-icon-wrap[data-state="failed"]  .log-icon { color: var(--fga-tone-danger); }
-.log-icon-wrap[data-state="running"] .log-icon { color: var(--fga-tone-warning); animation: fga-spin 1s linear infinite; }
+.log-icon-wrap[data-state="ok"]      .fga-icon { color: var(--fga-tone-success); }
+.log-icon-wrap[data-state="failed"]  .fga-icon { color: var(--fga-tone-danger); }
+.log-icon-wrap[data-state="running"] .fga-icon { color: var(--fga-tone-warning); }
 /* Stale (non-newest) rows dim the icon too — same equal-specificity family as the
    tone rules above, so it must come after them in source order to win the tie. */
-.activity-row.is-stale .log-icon { color: var(--fga-text-dim); }
+.activity-row.is-stale .fga-icon { color: var(--fga-text-dim); }
 .log-body {
   flex: 1 1 auto;
   min-width: 0; /* lets the ellipsis in .log-label / .log-meta actually engage */
@@ -822,31 +788,6 @@ code {
   outline-offset: 2px;
 }
 
-/* Footer band — identity row only (status-dot mirror + build id). The Docs/Copy/
-   Details actions row that used to sit below it is cut entirely (§2); the file
-   name it also used to carry now lives in Block 2's Context row instead. */
-.footer-row {
-  border-top: 1px dotted var(--fga-divider);
-  padding: var(--space-1) var(--space-2);
-  padding-top: var(--fga-divider-gap);
-  margin-top: auto;
-}
-.identity-row {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--space-hair);
-  min-width: 0;
-}
-/* CSS mirror of #fga-dot's tone — panel-ui.ts writes the tone onto #fga-dot only;
-   a second JS write target would be a behaviour change, so the mirror is derived
-   here instead. Falls back to muted if :has() is unsupported — quiet, never broken. */
-/* Sizing comes from the shared `.status-dot, .identity-dot` rule (§1: one dot
-   grid, 8px — was 6px). This rule adds only the default (muted) fill. */
-.identity-dot { background: var(--fga-tone-muted); }
-.panel:has(#fga-dot[data-tone="success"]) .identity-dot { background: var(--fga-tone-success); }
-.panel:has(#fga-dot[data-tone="warning"]) .identity-dot { background: var(--fga-tone-warning); }
-.panel:has(#fga-dot[data-tone="info"])    .identity-dot { background: var(--fga-tone-info); }
 #fga-version { flex: 0 0 auto; font-size: var(--fga-font-caption); color: var(--fga-text-muted); font-variant-numeric: tabular-nums; }
 
 /* ── Responsive contract (240px → 640px+, any height, locked) ─────────────────
@@ -854,22 +795,16 @@ code {
    anywhere on the path that keeps its intrinsic width pushes the row past the
    panel edge. overflow-x:hidden would then merely HIDE the overflow. */
 .panel > * { min-width: 0; max-width: 100%; }
-.status-row > *, .identity-row > *, .sync-prompt > *,
+.status-row > *, .sync-prompt > *,
 .log-body, .log-body > *, .detail-cell, .detail-cell > *, .activity-row > * { min-width: 0; }
 
 /* Truncation: the trio is a set — ellipsis without the other two does nothing. */
 .truncate { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
-/* Motion — the probing marker pings outward (transform + opacity only, never a
-   layout property). Snappy 0.1s ease-out is the brand curve. The pending feed
-   icon spins (transform only) — a continuous linear rotation is the one place
+/* Motion — the pending feed icon spins (transform only). Continuous linear rotation is the one place
    `linear` is correct (taste-lint's checkLinearOrAllTransition only inspects
    `transition:`, never `animation:`). Every animated/transitioned selector is
    guarded below. */
-@keyframes fga-ping {
-  0%   { opacity: 0.5; transform: scale(1); }
-  100% { opacity: 0;   transform: scale(2.4); }
-}
 @keyframes fga-spin {
   to { transform: rotate(360deg); }
 }
@@ -879,80 +814,170 @@ code {
   to   { opacity: 1; transform: none; }
 }
 @media (prefers-reduced-motion: reduce) {
-  .status-dot.is-pulsing::after,
-  .log-icon-wrap[data-state="running"] .log-icon,
+  .log-icon-wrap[data-state="running"] .fga-icon,
   .activity-row.is-new { animation: none; } /* .is-new, not bare .activity-row — the
     entrance animation lives on the two-class selector, so the guard must match its
     specificity or `animation: none` here would lose the cascade to `.is-new`'s rule. */
-  .inline-link, .sync-prompt, .status-dot, .status-sentence, .activity-row { transition: none; }
+  .inline-link, .sync-prompt, .status-sentence, .activity-row { transition: none; }
+}
+
+/* Adaptive Agent Rail. The host viewport owns the two exact sizes; this document owns
+   disclosure within them. Existing theme tokens remain the color source of truth. */
+body { overflow: hidden; }
+.panel { height: 100%; overflow: hidden; }
+.agent-rail {
+  height: 44px;
+  padding: 0 var(--space-1);
+  display: grid;
+  grid-template-columns: 32px minmax(32px, 1fr) auto auto 32px;
+  gap: var(--space-hair);
+  align-items: center;
+  background: var(--fga-chrome);
+}
+.rail-control {
+  position: relative;
+  width: 32px;
+  min-width: 32px;
+  height: 32px;
+  padding: 0;
+  border: 1px solid transparent;
+  border-radius: var(--fga-radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-hair);
+  background: transparent;
+  color: var(--fga-text-muted);
+  cursor: pointer;
+  transition: background-color var(--fga-motion) var(--fga-ease), border-color var(--fga-motion) var(--fga-ease), color var(--fga-motion) var(--fga-ease);
+}
+.rail-control:hover, .rail-control[aria-expanded="true"] { background: var(--fga-row-active); color: var(--fga-text); }
+.rail-control:active { background: var(--fga-surface); }
+.rail-control:focus-visible, .tab-button:focus-visible, .sync-btn:focus-visible, .inline-link:focus-visible {
+  outline: 2px solid var(--fga-focus);
+  outline-offset: 1px;
+}
+.current-control { width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
+.current-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.failure-count {
+  min-width: 14px;
+  padding: 0 var(--space-hair);
+  border-radius: var(--radius-full);
+  background: var(--fga-tone-danger);
+  color: var(--fga-body);
+  font-size: var(--fga-font-caption);
+  line-height: var(--fga-lh-caption);
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+.fga-icon { display: block; width: 16px; height: 16px; flex: 0 0 auto; }
+.tone-success { color: var(--fga-tone-success); }
+.tone-warning { color: var(--fga-tone-warning); }
+.tone-info { color: var(--fga-tone-info); }
+.tone-danger { color: var(--fga-tone-danger); }
+.rail-badge {
+  position: absolute;
+  inset: 0 0 auto auto;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 4px;
+  border-radius: var(--radius-full);
+  background: var(--fga-tone-warning);
+  color: var(--fga-body);
+  font-size: var(--fga-font-caption);
+  line-height: var(--fga-lh-caption);
+  font-variant-numeric: tabular-nums;
+}
+.inspector { height: calc(100% - 44px); background: var(--fga-body); overflow: hidden; }
+.inspector-tabs { height: 36px; display: grid; grid-template-columns: repeat(3, 1fr); border-bottom: 1px dotted var(--fga-divider); }
+.tab-button {
+  min-width: 0;
+  min-height: 32px;
+  border: 0;
+  background: transparent;
+  color: var(--fga-text-muted);
+  font: inherit;
+  cursor: pointer;
+}
+.tab-button:hover { color: var(--fga-text); background: var(--fga-row-active); }
+.tab-button[aria-selected="true"] { color: var(--fga-text); background: var(--fga-surface); }
+.inspector-content { height: calc(100% - 36px); overflow-y: auto; overflow-x: hidden; }
+.inspector-panel { min-width: 0; padding: var(--space-1); }
+.inspector-panel[hidden], .inspector[hidden], .rail-control[hidden], .sync-prompt[hidden] { display: none; }
+.inspector .context, .inspector .activity, .inspector .status-hero { position: static; border-top: 0; padding: 0; background: transparent; }
+.inspector .detail-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+.details-stack { display: flex; flex-direction: column; gap: var(--space-1); }
+.details-card { padding: var(--space-1); border: 1px solid var(--fga-hairline); border-top-color: var(--fga-topedge); border-radius: var(--fga-radius); }
+.details-card .status-sentence { margin: 0; }
+.version-row { color: var(--fga-text-muted); font-size: var(--fga-font-caption); font-variant-numeric: tabular-nums; }
+.sync-prompt { margin: var(--space-1); }
+.is-spinning { animation: fga-spin 1s linear infinite; }
+@media (prefers-reduced-motion: reduce) {
+  .is-spinning { animation: none; }
+  .rail-control { transition: none; }
 }
 </style>
 </head>
 <body>
-<main class="panel" id="fga-panel">
-  <!-- Owner decree 2026-07-30: the internal masthead ("Figma Design Agent") is removed —
-       it duplicated the Figma plugin window's own chrome title directly above it, and
-       that OS/host-drawn title bar cannot be removed (verified against showUI docs). The
-       sticky status block is now the panel's first visible row. -->
-  <section class="status-hero fga-block" id="fga-status" aria-live="polite" aria-label="Connection status">
-    <div class="status-row fga-row">
-      <span class="status-dot" id="fga-dot" data-tone="muted"></span>
-      <p class="status-sentence" id="fga-sentence" data-tone="muted">Not connected — your first command starts the broker.</p>
+<main class="panel" id="fga-panel" data-view="rail">
+  <header class="agent-rail" id="fga-rail" aria-label="Agent status">
+    <button class="rail-control" id="fga-connection-btn" type="button" title="Connection details" aria-label="Connection details"></button>
+    <button class="rail-control current-control" id="fga-current-btn" type="button" title="Current activity: Idle" aria-label="Current activity: Idle">
+      <span class="current-label" id="fga-current-label">Idle</span>
+      <span class="failure-count" id="fga-failure-count" role="status" aria-live="polite" aria-atomic="true" aria-label="0 unresolved failures" hidden></span>
+    </button>
+    <button class="rail-control" id="fga-target-rail-btn" type="button" title="File target" aria-label="File target" hidden></button>
+    <button class="rail-control" id="fga-sync-rail-btn" type="button" title="Pending sync" aria-label="Pending sync" hidden><span class="rail-badge" id="fga-sync-badge">1</span></button>
+    <button class="rail-control" id="fga-toggle-btn" type="button" title="Open inspector" aria-label="Open inspector" aria-expanded="false" aria-controls="fga-inspector"></button>
+  </header>
+
+  <section class="inspector" id="fga-inspector" aria-label="Agent inspector" hidden>
+    <div class="inspector-tabs" role="tablist" aria-label="Inspector views">
+      <button class="tab-button" id="fga-tab-activity" type="button" role="tab" aria-selected="true" tabindex="0" aria-controls="fga-panel-activity">Activity</button>
+      <button class="tab-button" id="fga-tab-context" type="button" role="tab" aria-selected="false" tabindex="-1" aria-controls="fga-panel-context">Context</button>
+      <button class="tab-button" id="fga-tab-details" type="button" role="tab" aria-selected="false" tabindex="-1" aria-controls="fga-panel-details">Details</button>
     </div>
+    <div class="inspector-content">
+      <section class="sync-prompt" id="fga-sync" aria-live="polite" aria-atomic="true" hidden>
+        <p class="sync-msg" id="fga-sync-msg">changes ready</p>
+        <div class="sync-actions">
+          <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
+          <button class="inline-link" id="fga-sync-later" type="button">Later</button>
+        </div>
+      </section>
 
-    <!-- Onboarding: priority-1 content, not a debug affordance — re-parented here
-         (block 1) so it answers the "disconnected, never connected" state directly.
-         JS toggles [hidden] via showOnboarding (panel-model.ts). -->
-    <section class="onboarding" id="fga-onboarding" aria-label="Getting started">
-      <ul class="onboarding-list">
-        <li>Bridges the figma-agent CLI to this file.</li>
-        <li>Verify: <code>figma-agent status</code></li>
-        <li>Keep this panel open.</li>
-      </ul>
-    </section>
-  </section>
+      <section class="inspector-panel" id="fga-panel-activity" role="tabpanel" aria-labelledby="fga-tab-activity">
+        <section class="activity" id="fga-activity-block" aria-label="Activity log">
+          <ul class="activity-list" id="fga-activity" aria-live="polite" aria-atomic="true">
+            <li class="activity-empty">No activity yet</li>
+          </ul>
+        </section>
+      </section>
 
-  <section class="context fga-block" id="fga-context" aria-label="File context">
-    <h2 class="section-label">Context</h2>
-    <dl class="detail-grid">
-      <div class="detail-cell">
-        <dt>File</dt>
-        <dd id="fga-ctx-file">—</dd>
-        <p class="detail-note" id="fga-ctx-file-note"></p>
-      </div>
-      <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
-      <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
-    </dl>
-    <!-- #35 P2: pins the daemon's routing target to THIS plugin instance (a runtime-only,
-         human-set pin — see broker-daemon.ts's `targetInstancePin`). Toggles between
-         "Target this plugin" and "Targeted" — panel-ui.ts wires the click, panel-model.ts
-         owns the label text. -->
-    <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
-  </section>
+      <section class="inspector-panel" id="fga-panel-context" role="tabpanel" aria-labelledby="fga-tab-context" hidden>
+        <section class="context" id="fga-context" aria-label="File context">
+          <dl class="detail-grid">
+            <div class="detail-cell"><dt>File</dt><dd id="fga-ctx-file">—</dd><p class="detail-note" id="fga-ctx-file-note"></p></div>
+            <div class="detail-cell"><dt>Page</dt><dd id="fga-ctx-page">—</dd></div>
+            <div class="detail-cell"><dt>Selection</dt><dd id="fga-ctx-selection">None</dd></div>
+          </dl>
+          <button class="sync-btn" id="fga-target-btn" type="button">Target this plugin</button>
+        </section>
+      </section>
 
-  <section class="activity fga-block" id="fga-activity-block" aria-label="Activity log">
-    <h2 class="section-label">Activity</h2>
-    <ul class="activity-list" id="fga-activity" aria-live="polite">
-      <li class="activity-empty">No activity yet</li>
-    </ul>
-  </section>
-
-  <!-- Live-sync idle-commit prompt (spec 004 P4): one line, shown only at the idle
-       point. "Sync now" applies the change-log via the deterministic kernel. -->
-  <section class="sync-prompt" id="fga-sync" aria-live="polite" hidden>
-    <p class="sync-msg" id="fga-sync-msg">changes ready</p>
-    <div class="sync-actions">
-      <button class="sync-btn" id="fga-sync-now" type="button">Sync now</button>
-      <button class="inline-link" id="fga-sync-later" type="button">Later</button>
+      <section class="inspector-panel" id="fga-panel-details" role="tabpanel" aria-labelledby="fga-tab-details" hidden>
+        <div class="details-stack">
+          <section class="details-card status-hero" id="fga-status" aria-live="polite" aria-atomic="true" aria-label="Connection status">
+            <p class="status-sentence" id="fga-sentence" data-tone="muted">Not connected — your first command starts the broker.</p>
+          </section>
+          <section class="onboarding" id="fga-onboarding" aria-label="Getting started">
+            <ul class="onboarding-list"><li>Bridges the figma-agent CLI to this file.</li><li>Verify: <code>figma-agent status</code></li><li>Keep this panel open.</li></ul>
+          </section>
+          <div class="version-row" id="fga-version">v0.1.0</div>
+        </div>
+      </section>
     </div>
   </section>
-
-  <footer class="footer-row">
-    <div class="identity-row">
-      <span class="identity-dot"></span>
-      <span id="fga-version">v0.1.0</span>
-    </div>
-  </footer>
 </main>
 <script>
 "use strict";
@@ -1019,68 +1044,27 @@ code {
     return { base, delay };
   }
 
-  // plugin/src/ui/panel-model.ts
-  var PROBE_TROUBLESHOOT_MS = 1e4;
-  function statusSentence(state, ageMs, hadConnection2) {
-    switch (state) {
-      case "connected":
-        return { text: "Connected", tone: "success" };
-      case "probing":
-        return ageMs >= PROBE_TROUBLESHOOT_MS ? { text: "Broker not running \u2014 run figma-agent status.", tone: "warning" } : { text: "Looking for the broker", tone: "warning" };
-      case "handshake":
-        return { text: "Connecting", tone: "info" };
-      case "disconnected":
-      default:
-        return hadConnection2 ? { text: "Connection lost \u2014 reconnecting.", tone: "muted" } : { text: "Not connected \u2014 your first command starts the broker.", tone: "muted" };
-    }
-  }
-  function showOnboarding(state, hadConnection2) {
-    return !hadConnection2 && (state === "disconnected" || state === "probing");
-  }
-  function fileNote(count, isActiveTarget, pinned = false) {
-    if (count <= 1) return isActiveTarget ? pinned ? "pinned target" : "command target" : "";
-    const others = count - 1;
-    const files = others === 1 ? "file" : "files";
-    if (!isActiveTarget) return `${others} other ${files} \u2014 commands go elsewhere`;
-    return pinned ? `pinned target \xB7 ${others} other ${files}` : `command target \xB7 ${others} other ${files}`;
-  }
-  function targetButtonLabel(pinned) {
-    return pinned ? "Targeted" : "Target this plugin";
-  }
-  function syncPromptLabel(count) {
-    const n = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
-    return `${n} change${n === 1 ? "" : "s"} ready`;
-  }
-  function syncResultLabel(ok, summary, landed = true, unbound = false) {
-    const clean = typeof summary === "string" && summary.trim().length > 0 ? summary.trim() : ok ? "done" : "failed";
-    if (unbound) return clean;
-    if (!ok) return `Sync failed \u2014 ${clean}`;
-    return landed ? `Synced \u2014 ${clean}` : `Nothing synced \u2014 ${clean}`;
-  }
-  function syncNowLabel(unbound) {
-    return unbound ? "Bind & retry" : "Sync now";
-  }
-  function syncStartSentence(source, fileLabel) {
-    return source === "auto" ? `Auto-sync started \u2014 ${fileLabel} went idle, applying its pending changes` : `Sync started \u2014 checking ${fileLabel} for pending Figma changes to apply`;
-  }
-  function syncResultSentence(ok, summary, landed, unbound, fileLabel) {
-    const clean = typeof summary === "string" && summary.trim().length > 0 ? summary.trim() : ok ? "done" : "failed";
-    if (unbound) return clean;
-    if (!ok) return `Sync failed for ${fileLabel} \u2014 ${clean}`;
-    return landed ? `Synced ${fileLabel} \u2014 ${clean}` : `Nothing synced for ${fileLabel} \u2014 ${clean}`;
-  }
-  var SYNC_STUCK_TIMEOUT_MS = 3e4;
-  function syncStuckSentence() {
-    return "Sync did not answer \u2014 the broker restarted mid-run; press Sync again";
-  }
-  function syncSupersededSentence() {
-    return "Superseded by a newer sync";
-  }
-  function shouldClearPendingCount(ok) {
-    return ok === true;
-  }
-
   // plugin/src/ui/activity-feed.ts
+  function formatClock(at) {
+    if (!Number.isFinite(at)) return "--:--:--";
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+  }
+  function formatTimestamp(at) {
+    if (!Number.isFinite(at)) return "\u2014";
+    const d = new Date(at);
+    const pad = (n) => String(n).padStart(2, "0");
+    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${formatClock(at)}`;
+  }
+  function timeAgo(nowMs, atMs) {
+    const s = Math.floor((nowMs - atMs) / 1e3);
+    if (s < 1) return "now";
+    if (s < 60) return `${s}s`;
+    const m = Math.floor(s / 60);
+    if (m < 60) return `${m}m`;
+    return `${Math.floor(m / 60)}h`;
+  }
   function toActivityRecord(detail) {
     if (detail === null || typeof detail !== "object") return null;
     const d = detail;
@@ -1192,25 +1176,345 @@ code {
     return verbs.plain;
   }
 
+  // plugin/src/ui/lucide-icons.ts
+  var SVG_NS = "http://www.w3.org/2000/svg";
+  var ICONS = {
+    activity: [["path", { d: "M22 12h-4l-3 9L9 3l-3 9H2" }]],
+    "chevron-down": [["path", { d: "m6 9 6 6 6-6" }]],
+    "chevron-up": [["path", { d: "m18 15-6-6-6 6" }]],
+    "circle-check": [
+      ["circle", { cx: "12", cy: "12", r: "10" }],
+      ["path", { d: "m9 12 2 2 4-4" }]
+    ],
+    "circle-off": [
+      ["path", { d: "M20.42 15.89A10 10 0 1 1 8.11 3.58" }],
+      ["path", { d: "m2 2 20 20" }]
+    ],
+    "circle-x": [
+      ["circle", { cx: "12", cy: "12", r: "10" }],
+      ["path", { d: "m15 9-6 6" }],
+      ["path", { d: "m9 9 6 6" }]
+    ],
+    files: [
+      ["path", { d: "M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" }],
+      ["path", { d: "M14 2v6h6" }],
+      ["path", { d: "M2 6h2" }],
+      ["path", { d: "M2 10h2" }],
+      ["path", { d: "M2 14h2" }],
+      ["path", { d: "M2 18h2" }]
+    ],
+    info: [
+      ["circle", { cx: "12", cy: "12", r: "10" }],
+      ["path", { d: "M12 16v-4" }],
+      ["path", { d: "M12 8h.01" }]
+    ],
+    "loader-circle": [
+      ["path", { d: "M21 12a9 9 0 1 1-6.22-8.56" }]
+    ],
+    "panels-top-left": [
+      ["rect", { width: "18", height: "18", x: "3", y: "3", rx: "2" }],
+      ["path", { d: "M3 9h18" }],
+      ["path", { d: "M9 21V9" }]
+    ],
+    pin: [
+      ["path", { d: "M12 17v5" }],
+      ["path", { d: "M5 17h14" }],
+      ["path", { d: "M6 17 7 7l-2-2h14l-2 2 1 10" }]
+    ],
+    "refresh-cw": [
+      ["path", { d: "M21 12a9 9 0 0 1-15.17 6.55L3 16" }],
+      ["path", { d: "M3 21v-5h5" }],
+      ["path", { d: "M3 12A9 9 0 0 1 18.17 5.45L21 8" }],
+      ["path", { d: "M16 8h5V3" }]
+    ]
+  };
+  function makeLucideIcon(name) {
+    const svg = document.createElementNS(SVG_NS, "svg");
+    svg.setAttribute("viewBox", "0 0 24 24");
+    svg.setAttribute("fill", "none");
+    svg.setAttribute("stroke", "currentColor");
+    svg.setAttribute("stroke-width", "2");
+    svg.setAttribute("stroke-linecap", "round");
+    svg.setAttribute("stroke-linejoin", "round");
+    svg.setAttribute("aria-hidden", "true");
+    svg.setAttribute("class", "fga-icon");
+    for (const [tag, attributes] of ICONS[name]) {
+      const node = document.createElementNS(SVG_NS, tag);
+      for (const [key, value] of Object.entries(attributes)) node.setAttribute(key, value);
+      svg.appendChild(node);
+    }
+    return svg;
+  }
+
+  // plugin/src/ui/panel-view-state.ts
+  var VIEW_KEY_LIMIT = 64;
+  var BoundedKeySet = class {
+    constructor(limit = VIEW_KEY_LIMIT) {
+      this.limit = limit;
+      this.keys = /* @__PURE__ */ new Set();
+      this.overflow = 0;
+    }
+    add(key) {
+      if (this.keys.has(key)) this.keys.delete(key);
+      this.keys.add(key);
+      while (this.keys.size > this.limit) {
+        const oldest = this.keys.values().next().value;
+        if (oldest === void 0) break;
+        this.keys.delete(oldest);
+        this.overflow += 1;
+      }
+    }
+    delete(key) {
+      this.keys.delete(key);
+    }
+    has(key) {
+      return this.keys.has(key);
+    }
+    get size() {
+      return this.keys.size;
+    }
+    get unresolvedCount() {
+      return this.keys.size + this.overflow;
+    }
+    get overflowCount() {
+      return this.overflow;
+    }
+    values() {
+      return [...this.keys];
+    }
+    acknowledge() {
+      this.keys.clear();
+      this.overflow = 0;
+    }
+  };
+  function applyActivityOutcome(failures, id, ok) {
+    if (ok) failures.delete(id);
+    else failures.add(id);
+  }
+  function currentActivity(records) {
+    return records.find((record) => record.pending) ?? records[0];
+  }
+  function landTerminalActivity(records, patch, at = Date.now()) {
+    if (records.some((record) => record.id === patch.id)) return resolveActivity(records, patch);
+    const outcome = patch.ok ? "completed" : "failed";
+    const detail = patch.sentence ?? patch.result ?? outcome;
+    return pushActivity(records, {
+      id: patch.id,
+      tool: "REQUEST",
+      pending: false,
+      ok: patch.ok,
+      ms: patch.ms,
+      at,
+      result: patch.result,
+      errorCode: patch.code,
+      nodeName: patch.nodeName,
+      sentence: `Late result for request ${patch.id} \u2014 ${detail}`
+    });
+  }
+  function connectionForce(state, ageMs, hadConnection2, transitionId) {
+    if (state === "probing" && ageMs >= 1e4) {
+      return { key: `probe-timeout:${transitionId}`, kind: "probe-timeout" };
+    }
+    if (state === "disconnected" && hadConnection2) {
+      return { key: `connection-lost:${transitionId}`, kind: "connection-lost" };
+    }
+    if (!hadConnection2 && (state === "disconnected" || state === "probing")) {
+      return { key: `onboarding:${transitionId}`, kind: "onboarding" };
+    }
+    return null;
+  }
+
+  // plugin/src/ui/panel-activity-view.ts
+  function replaceIcon(target, name, spinning = false) {
+    const kept = Array.from(target.children).filter((child) => child.classList.contains("rail-badge") || child.classList.contains("current-label") || child.classList.contains("failure-count"));
+    const icon = makeLucideIcon(name);
+    if (spinning) icon.classList.add("is-spinning");
+    target.replaceChildren(icon, ...kept);
+  }
+  function labelControl(target, label) {
+    target.title = label;
+    target.setAttribute("aria-label", label);
+  }
+  function renderFailureBadge(target, count) {
+    target.hidden = count === 0;
+    target.textContent = count === 0 ? "" : String(count);
+    target.setAttribute("aria-label", `${count} unresolved failure${count === 1 ? "" : "s"}`);
+  }
+  function sentence(record) {
+    return record.sentence ?? activitySentence({
+      tool: record.tool,
+      label: record.label,
+      result: record.result,
+      errorCode: record.errorCode,
+      errorMessage: !record.ok ? record.result : void 0,
+      nodeName: record.nodeName,
+      pending: record.pending,
+      ok: record.ok
+    });
+  }
+  function row(record, now, stale, fresh) {
+    const item = document.createElement("li");
+    item.className = ["activity-row", stale && "is-stale", fresh && "is-new"].filter(Boolean).join(" ");
+    const state = record.pending ? "running" : record.ok ? "ok" : "failed";
+    const iconWrap = document.createElement("span");
+    iconWrap.className = "log-icon-wrap";
+    iconWrap.dataset.state = state;
+    iconWrap.setAttribute("aria-label", state);
+    const icon = makeLucideIcon(record.pending ? "loader-circle" : record.ok ? "circle-check" : "circle-x");
+    if (record.pending) icon.classList.add("is-spinning");
+    iconWrap.append(icon);
+    const body = document.createElement("div");
+    body.className = "log-body";
+    const text = document.createElement("div");
+    text.className = record.pending || record.ok ? "log-label" : "log-label log-label--wrap";
+    const agent = document.createElement("span");
+    agent.className = "log-agent";
+    agent.textContent = `${record.agent ?? "cli"} \xB7 `;
+    const line = sentence(record);
+    text.append(agent, document.createTextNode(line));
+    text.title = line;
+    const meta = document.createElement("div");
+    meta.className = "log-meta";
+    meta.textContent = record.pending ? "running" : timeAgo(now, record.at);
+    meta.title = formatTimestamp(record.at);
+    body.append(text, meta);
+    item.append(iconWrap, body);
+    return item;
+  }
+  var ActivityView = class {
+    constructor(list, currentButton, currentLabel, failureCount) {
+      this.list = list;
+      this.currentButton = currentButton;
+      this.currentLabel = currentLabel;
+      this.failureCount = failureCount;
+      this.records = [];
+      this.previousKeys = [];
+      this.failures = new BoundedKeySet();
+    }
+    push(record) {
+      this.records = pushActivity(this.records, record);
+    }
+    resolve(patch, trackFailure = true) {
+      this.records = landTerminalActivity(this.records, patch);
+      if (trackFailure) applyActivityOutcome(this.failures, patch.id, patch.ok);
+    }
+    acknowledgeFailures() {
+      this.failures.acknowledge();
+    }
+    render(now = Date.now()) {
+      const shown = this.records.slice(0, 20);
+      if (shown.length === 0) {
+        this.previousKeys = [];
+        if (this.list.children.length === 0) {
+          const empty = document.createElement("li");
+          empty.className = "activity-empty";
+          empty.textContent = "No activity yet";
+          this.list.append(empty);
+        }
+      } else {
+        const keys = shown.map((record) => record.id);
+        const fresh = new Set(diffRowKeys(this.previousKeys, keys));
+        this.list.replaceChildren(...shown.map((record, index) => row(record, now, index > 0, fresh.has(record.id))));
+        this.previousKeys = keys;
+      }
+      this.renderRail();
+    }
+    renderRail() {
+      const current = currentActivity(this.records);
+      const count = this.failures.unresolvedCount;
+      renderFailureBadge(this.failureCount, count);
+      const suffix = count === 0 ? "" : `. ${count} unresolved failure${count === 1 ? "" : "s"}`;
+      if (!current) {
+        replaceIcon(this.currentButton, "activity");
+        this.currentLabel.textContent = "Idle";
+        this.currentButton.className = `rail-control current-control${count ? " tone-danger" : ""}`;
+        labelControl(this.currentButton, `Current activity: Idle${suffix}`);
+        return;
+      }
+      const state = current.pending ? "running" : current.ok ? "complete" : "failed";
+      replaceIcon(this.currentButton, current.pending ? "loader-circle" : current.ok ? "circle-check" : "circle-x", current.pending);
+      this.currentLabel.textContent = sentence(current);
+      this.currentButton.className = `rail-control current-control tone-${count ? "danger" : current.pending ? "warning" : current.ok ? "success" : "danger"}`;
+      labelControl(this.currentButton, `Current activity ${state}: ${sentence(current)}${suffix}`);
+    }
+  };
+
+  // plugin/src/ui/panel-model.ts
+  var SYNC_STUCK_TIMEOUT_MS = 3e4;
+  function statusSentence(state, ageMs, hadConnection2) {
+    if (state === "connected") return { text: "Connected", tone: "success" };
+    if (state === "probing") return ageMs >= 1e4 ? { text: "Broker not running \u2014 run figma-agent status.", tone: "warning" } : { text: "Looking for the broker", tone: "warning" };
+    if (state === "handshake") return { text: "Connecting", tone: "info" };
+    return hadConnection2 ? { text: "Connection lost \u2014 reconnecting.", tone: "muted" } : { text: "Not connected \u2014 your first command starts the broker.", tone: "muted" };
+  }
+  function showOnboarding(state, hadConnection2) {
+    return !hadConnection2 && (state === "disconnected" || state === "probing");
+  }
+  function fileNote(count, active, pinned = false) {
+    if (count <= 1) return active ? pinned ? "pinned target" : "command target" : "";
+    const others = count - 1;
+    const files = others === 1 ? "file" : "files";
+    if (!active) return `${others} other ${files} \u2014 commands go elsewhere`;
+    return pinned ? `pinned target \xB7 ${others} other ${files}` : `command target \xB7 ${others} other ${files}`;
+  }
+  function targetButtonLabel(pinned) {
+    return pinned ? "Targeted" : "Target this plugin";
+  }
+  function syncPromptLabel(count) {
+    const value = Number.isFinite(count) && count > 0 ? Math.floor(count) : 1;
+    return `${value} change${value === 1 ? "" : "s"} ready`;
+  }
+  function syncResultLabel(ok, summary, landed = true, unbound = false) {
+    const clean = summary.trim() || (ok ? "done" : "failed");
+    if (unbound) return clean;
+    if (!ok) return `Sync failed \u2014 ${clean}`;
+    return landed ? `Synced \u2014 ${clean}` : `Nothing synced \u2014 ${clean}`;
+  }
+  function syncNowLabel(unbound) {
+    return unbound ? "Bind & retry" : "Sync now";
+  }
+  function syncStartSentence(source, fileLabel) {
+    return source === "auto" ? `Auto-sync started \u2014 ${fileLabel} went idle, applying its pending changes` : `Sync started \u2014 checking ${fileLabel} for pending Figma changes to apply`;
+  }
+  function syncResultSentence(ok, summary, landed, unbound, fileLabel) {
+    const clean = summary.trim() || (ok ? "done" : "failed");
+    if (unbound) return clean;
+    if (!ok) return `Sync failed for ${fileLabel} \u2014 ${clean}`;
+    return landed ? `Synced ${fileLabel} \u2014 ${clean}` : `Nothing synced for ${fileLabel} \u2014 ${clean}`;
+  }
+  function syncStuckSentence() {
+    return "Sync did not answer \u2014 the broker restarted mid-run; press Sync again";
+  }
+  function syncSupersededSentence() {
+    return "Superseded by a newer sync";
+  }
+  function shouldClearPendingCount(ok) {
+    return ok === true;
+  }
+
   // plugin/src/ui/panel-ui.ts
   var el = (id) => document.getElementById(id);
-  var dot = el("fga-dot");
-  var sentence = el("fga-sentence");
+  var btn = (id) => el(id);
+  var panel = el("fga-panel");
+  var inspector = el("fga-inspector");
+  var connectionBtn = btn("fga-connection-btn");
+  var currentBtn = btn("fga-current-btn");
+  var targetRailBtn = btn("fga-target-rail-btn");
+  var syncRailBtn = btn("fga-sync-rail-btn");
+  var syncBadge = el("fga-sync-badge");
+  var toggleBtn = btn("fga-toggle-btn");
+  var sentence2 = el("fga-sentence");
   var onboarding = el("fga-onboarding");
-  var ctxFile = el("fga-ctx-file");
-  var ctxFileNote = el("fga-ctx-file-note");
-  var ctxPage = el("fga-ctx-page");
-  var ctxSelection = el("fga-ctx-selection");
-  var targetBtn = el("fga-target-btn");
-  var activityList = el("fga-activity");
-  var versionEl = el("fga-version");
   var syncPrompt = el("fga-sync");
   var syncMsg = el("fga-sync-msg");
-  var syncNowBtn = el("fga-sync-now");
-  var syncLaterBtn = el("fga-sync-later");
+  var syncNowBtn = btn("fga-sync-now");
+  var targetBtn = btn("fga-target-btn");
+  var activityView = new ActivityView(el("fga-activity"), currentBtn, el("fga-current-label"), el("fga-failure-count"));
+  var tabNames = ["activity", "context", "details"];
+  var tabs = Object.fromEntries(tabNames.map((name) => [name, btn(`fga-tab-${name}`)]));
+  var tabPanels = Object.fromEntries(tabNames.map((name) => [name, el(`fga-panel-${name}`)]));
   var payload = null;
   var hadConnection = false;
-  var activity = [];
   var sceneFile = "";
   var scenePage = "";
   var selectionName = null;
@@ -1218,254 +1522,258 @@ code {
   var peersCount = 1;
   var peersIsActiveTarget = true;
   var peersPinned = false;
-  var SVG_NS = "http://www.w3.org/2000/svg";
-  var ICONS = {
-    // check-circle, regular — the wrapper's aria-label carries the state; colour (via
-    // CSS) carries "success" visually.
-    check: "M173.66,98.34a8,8,0,0,1,0,11.32l-56,56a8,8,0,0,1-11.32,0l-24-24a8,8,0,0,1,11.32-11.32L112,148.69l50.34-50.35A8,8,0,0,1,173.66,98.34ZM232,128A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z",
-    // x-circle, regular.
-    x: "M165.66,101.66,139.31,128l26.35,26.34a8,8,0,0,1-11.32,11.32L128,139.31l-26.34,26.35a8,8,0,0,1-11.32-11.32L116.69,128,90.34,101.66a8,8,0,0,1,11.32-11.32L128,116.69l26.34-26.35a8,8,0,0,1,11.32,11.32ZM232,128A104,104,0,1,1,128,24,104.11,104.11,0,0,1,232,128Zm-16,0a88,88,0,1,0-88,88A88.1,88.1,0,0,0,216,128Z",
-    // circle-notch, regular — CSS rotates it (fga-spin).
-    notch: "M232,128a104,104,0,0,1-208,0c0-41,23.81-78.36,60.66-95.27a8,8,0,0,1,6.68,14.54C60.15,61.59,40,93.27,40,128a88,88,0,0,0,176,0c0-34.73-20.15-66.41-51.34-80.73a8,8,0,0,1,6.68-14.54C208.19,49.64,232,87,232,128Z"
-  };
-  function makeIcon(name) {
-    const svg = document.createElementNS(SVG_NS, "svg");
-    svg.setAttribute("viewBox", "0 0 256 256");
-    svg.setAttribute("fill", "currentColor");
-    svg.setAttribute("aria-hidden", "true");
-    svg.setAttribute("class", "log-icon");
-    const path = document.createElementNS(SVG_NS, "path");
-    path.setAttribute("d", ICONS[name]);
-    svg.appendChild(path);
-    return svg;
+  var pendingSyncCount = 0;
+  var selectedTab = "activity";
+  var inspectorOpen = false;
+  var userExpanded = false;
+  var forcedOnly = false;
+  var connectionFailure = false;
+  var syncFailure = false;
+  var connectionTransition = 0;
+  var previousConnectionState = null;
+  var disclosed = new BoundedKeySet();
+  function viewport(mode) {
+    parent.postMessage({ pluginMessage: { type: "PANEL_VIEWPORT", mode } }, "*");
   }
-  function renderContext() {
-    ctxFile.textContent = sceneFile || "\u2014";
-    ctxFile.title = sceneFile || "";
-    ctxFileNote.textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
-    ctxPage.textContent = scenePage || "\u2014";
-    ctxPage.title = scenePage || "";
-    ctxSelection.textContent = selectionText();
-    targetBtn.textContent = targetButtonLabel(peersPinned);
-  }
-  function selectionText() {
-    if (selectionCount <= 0) return "None";
-    const first = selectionName ?? "(unnamed)";
-    return selectionCount > 1 ? `${first} +${selectionCount - 1} more` : first;
-  }
-  var ACTIVITY_ROWS = 20;
-  function activityRow(r, now, stale, isNew) {
-    const li = document.createElement("li");
-    const classes = ["activity-row", "fga-row"];
-    if (stale) classes.push("is-stale");
-    if (isNew) classes.push("is-new");
-    li.className = classes.join(" ");
-    const state = r.pending ? "running" : r.ok ? "ok" : "failed";
-    const iconName = r.pending ? "notch" : r.ok ? "check" : "x";
-    const iconWrap = document.createElement("span");
-    iconWrap.className = "log-icon-wrap fga-icon";
-    iconWrap.dataset.state = state;
-    iconWrap.setAttribute("aria-label", state);
-    iconWrap.appendChild(makeIcon(iconName));
-    const body = document.createElement("div");
-    body.className = "log-body";
-    const text = document.createElement("div");
-    text.className = !r.pending && !r.ok ? "log-label log-label--wrap" : "log-label";
-    const line = r.sentence ?? activitySentence({
-      tool: r.tool,
-      label: r.label,
-      result: r.result,
-      errorCode: r.errorCode,
-      errorMessage: !r.ok ? r.result : void 0,
-      nodeName: r.nodeName,
-      pending: r.pending,
-      ok: r.ok
-    });
-    const agentSpan = document.createElement("span");
-    agentSpan.className = "log-agent";
-    agentSpan.textContent = `${r.agent ?? "cli"} \xB7 `;
-    text.append(agentSpan, document.createTextNode(line));
-    text.title = line;
-    const caption = document.createElement("div");
-    caption.className = "log-meta";
-    caption.textContent = r.pending ? "running" : timeAgoCaption(now, r.at);
-    caption.title = formatTimestampCaption(r.at);
-    body.append(text, caption);
-    li.append(iconWrap, body);
-    return li;
-  }
-  function timeAgoCaption(now, at) {
-    const s = Math.floor((now - at) / 1e3);
-    if (s < 1) return "now";
-    if (s < 60) return `${s}s ago`;
-    const m = Math.floor(s / 60);
-    if (m < 60) return `${m}m ago`;
-    return `${Math.floor(m / 60)}h ago`;
-  }
-  function formatTimestampCaption(at) {
-    if (!Number.isFinite(at)) return "\u2014";
-    const d = new Date(at);
-    const pad = (n) => String(n).padStart(2, "0");
-    return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
-  }
-  var previousRowKeys = [];
-  function renderActivity(now) {
-    if (activity.length === 0) {
-      previousRowKeys = [];
-      return;
+  function selectTab(tab, focus = false) {
+    selectedTab = tab;
+    for (const name of tabNames) {
+      const selected = name === tab;
+      tabs[name].setAttribute("aria-selected", String(selected));
+      tabs[name].tabIndex = selected ? 0 : -1;
+      tabPanels[name].hidden = !selected;
     }
-    const shown = activity.slice(0, ACTIVITY_ROWS);
-    const nextKeys = shown.map((r) => r.id);
-    const newKeys = new Set(diffRowKeys(previousRowKeys, nextKeys));
-    activityList.replaceChildren(
-      ...shown.map((r, i) => activityRow(r, now, i > 0, newKeys.has(r.id)))
-    );
-    previousRowKeys = nextKeys;
+    if (focus) tabs[tab].focus();
+  }
+  function setInspector(open, tab = selectedTab, intent = false) {
+    inspectorOpen = open;
+    if (intent) {
+      userExpanded = open;
+      forcedOnly = false;
+    }
+    panel.dataset.view = open ? "inspector" : "rail";
+    inspector.hidden = !open;
+    toggleBtn.setAttribute("aria-expanded", String(open));
+    labelControl(toggleBtn, open ? "Close inspector" : "Open inspector");
+    replaceIcon(toggleBtn, open ? "chevron-up" : "chevron-down");
+    if (open) selectTab(tab);
+    viewport(open ? "inspector" : "rail");
+  }
+  function forceOnce(key, tab) {
+    if (disclosed.has(key)) return;
+    disclosed.add(key);
+    if (!userExpanded) forcedOnly = true;
+    setInspector(true, tab);
+  }
+  function unresolved() {
+    return connectionFailure || syncFailure || activityView.failures.unresolvedCount > 0;
+  }
+  function updateSignal() {
+    panel.dataset.unresolved = String(unresolved());
+  }
+  function acknowledgeActivity() {
+    activityView.acknowledgeFailures();
+    updateSignal();
+    activityView.render();
+  }
+  function openUser(tab) {
+    if (tab === "activity") acknowledgeActivity();
+    setInspector(true, tab, true);
+  }
+  function context() {
+    el("fga-ctx-file").textContent = sceneFile || "\u2014";
+    el("fga-ctx-file").title = sceneFile;
+    el("fga-ctx-file-note").textContent = fileNote(peersCount, peersIsActiveTarget, peersPinned);
+    el("fga-ctx-page").textContent = scenePage || "\u2014";
+    el("fga-ctx-page").title = scenePage;
+    el("fga-ctx-selection").textContent = selectionCount <= 0 ? "None" : `${selectionName ?? "(unnamed)"}${selectionCount > 1 ? ` +${selectionCount - 1} more` : ""}`;
+    targetBtn.textContent = targetButtonLabel(peersPinned);
+    targetRailBtn.hidden = peersCount <= 1;
+    if (!targetRailBtn.hidden) {
+      labelControl(targetRailBtn, `${peersCount} files. ${fileNote(peersCount, peersIsActiveTarget, peersPinned)}`);
+      replaceIcon(targetRailBtn, peersPinned ? "pin" : "files");
+      targetRailBtn.classList.toggle("tone-info", peersIsActiveTarget);
+    }
   }
   function render() {
-    const now = Date.now();
-    const state = payload?.state ?? "disconnected";
-    const view = statusSentence(state, payload ? now - payload.since : 0, hadConnection);
-    dot.dataset.tone = view.tone;
-    dot.classList.toggle("is-pulsing", state === "probing");
-    sentence.textContent = view.text;
-    sentence.dataset.tone = view.tone;
+    const now = Date.now(), state = payload?.state ?? "disconnected", age = payload ? now - payload.since : 0;
+    const view = statusSentence(state, age, hadConnection);
+    sentence2.textContent = view.text;
+    sentence2.dataset.tone = view.tone;
     onboarding.hidden = !showOnboarding(state, hadConnection);
-    renderContext();
-    renderActivity(now);
+    replaceIcon(connectionBtn, state === "connected" ? "circle-check" : state === "probing" || state === "handshake" ? "loader-circle" : "circle-off", state === "probing" || state === "handshake");
+    connectionBtn.className = `rail-control tone-${view.tone}`;
+    labelControl(connectionBtn, view.text);
+    context();
+    activityView.render(now);
+    const showSync = pendingSyncCount > 0 || syncFailure;
+    syncRailBtn.hidden = !showSync;
+    if (showSync) {
+      syncBadge.textContent = String(Math.max(1, pendingSyncCount));
+      replaceIcon(syncRailBtn, syncFailure ? "circle-x" : "refresh-cw");
+      syncRailBtn.className = `rail-control tone-${syncFailure ? "danger" : "warning"}`;
+      labelControl(syncRailBtn, syncFailure ? `${syncMsg.textContent || "Sync failed"}. Open sync actions` : `${syncPromptLabel(pendingSyncCount)}. Open sync actions`);
+    }
+    const force = connectionForce(state, age, hadConnection, connectionTransition);
+    connectionFailure = force?.kind === "probe-timeout" || force?.kind === "connection-lost";
+    updateSignal();
+    if (force) forceOnce(force.key, "details");
+    if (state === "connected" && forcedOnly && !userExpanded && !unresolved()) {
+      forcedOnly = false;
+      setInspector(false);
+    }
   }
-  window.addEventListener("figma-agent:conn-state", (ev) => {
-    const p = ev.detail;
-    if (!p || typeof p.state !== "string") return;
-    if (p.state === "connected") hadConnection = true;
-    payload = p;
+  connectionBtn.onclick = () => setInspector(true, "details", true);
+  currentBtn.onclick = () => openUser("activity");
+  var toggleTarget = () => {
+    try {
+      window.dispatchEvent(new CustomEvent(peersPinned ? "figma-agent:clear-target" : "figma-agent:set-target"));
+    } catch {
+    }
+  };
+  targetRailBtn.onclick = toggleTarget;
+  targetBtn.onclick = toggleTarget;
+  syncRailBtn.onclick = () => {
+    syncPrompt.hidden = false;
+    openUser("activity");
+  };
+  toggleBtn.onclick = () => {
+    if (!inspectorOpen && selectedTab === "activity") acknowledgeActivity();
+    setInspector(!inspectorOpen, selectedTab, true);
+  };
+  for (const tab of tabNames) {
+    tabs[tab].onclick = () => {
+      if (tab === "activity") acknowledgeActivity();
+      selectTab(tab);
+    };
+    tabs[tab].onkeydown = (event) => {
+      const index = tabNames.indexOf(tab);
+      const target = event.key === "ArrowRight" ? tabNames[(index + 1) % 3] : event.key === "ArrowLeft" ? tabNames[(index + 2) % 3] : event.key === "Home" ? tabNames[0] : event.key === "End" ? tabNames[2] : null;
+      if (target) {
+        event.preventDefault();
+        if (target === "activity") acknowledgeActivity();
+        selectTab(target, true);
+      }
+    };
+  }
+  document.addEventListener("keydown", (event) => {
+    if (event.key === "Escape" && inspectorOpen) {
+      event.preventDefault();
+      setInspector(false, selectedTab, true);
+      toggleBtn.focus();
+    }
+  });
+  window.addEventListener("figma-agent:conn-state", (event) => {
+    const next = event.detail;
+    if (!next || typeof next.state !== "string") return;
+    if (next.state !== previousConnectionState) connectionTransition += 1;
+    previousConnectionState = next.state;
+    if (next.state === "connected") hadConnection = true;
+    payload = next;
     render();
   });
-  window.addEventListener("figma-agent:activity", (ev) => {
-    const detail = ev.detail;
+  window.addEventListener("figma-agent:activity", (event) => {
+    const detail = event.detail;
     if (detail?.phase === "done") {
       const patch = toActivityResult(detail);
       if (!patch) return;
-      activity = resolveActivity(activity, patch);
+      activityView.resolve(patch);
+      if (!patch.ok) forceOnce(`activity-failure:${patch.id}`, "activity");
     } else {
-      const rec = toActivityRecord(detail);
-      if (!rec) return;
-      activity = pushActivity(activity, rec);
+      const record = toActivityRecord(detail);
+      if (!record) return;
+      activityView.push(record);
     }
-    renderActivity(Date.now());
+    updateSignal();
+    render();
   });
-  window.addEventListener("figma-agent:peers", (ev) => {
-    const d = ev.detail;
-    if (typeof d?.count === "number" && Number.isFinite(d.count)) peersCount = d.count;
-    if (typeof d?.isActiveTarget === "boolean") peersIsActiveTarget = d.isActiveTarget;
-    peersPinned = typeof d?.pinned === "boolean" && d.pinned;
-    renderContext();
+  window.addEventListener("figma-agent:peers", (event) => {
+    const data = event.detail;
+    if (typeof data?.count === "number" && Number.isFinite(data.count)) peersCount = data.count;
+    if (typeof data?.isActiveTarget === "boolean") peersIsActiveTarget = data.isActiveTarget;
+    peersPinned = data?.pinned === true;
+    context();
   });
-  window.addEventListener("message", (ev) => {
-    const pm = ev.data?.pluginMessage;
-    if (!pm) return;
-    if (pm.type === "IDLE_READY" && pm.data) {
-      const count = typeof pm.data.count === "number" ? pm.data.count : 1;
-      syncMsg.textContent = syncPromptLabel(count);
+  window.addEventListener("message", (event) => {
+    const message = event.data?.pluginMessage;
+    if (!message) return;
+    if (message.type === "IDLE_READY" && message.data) {
+      pendingSyncCount = typeof message.data.count === "number" ? Math.max(1, Math.floor(message.data.count)) : 1;
+      syncFailure = false;
+      syncMsg.textContent = syncPromptLabel(pendingSyncCount);
       syncNowBtn.textContent = syncNowLabel(false);
-      syncPrompt.hidden = false;
+      syncPrompt.hidden = true;
+      render();
       return;
     }
-    if (pm.type !== "FILE_INFO" || !pm.data) return;
-    if (typeof pm.data.fileName === "string") sceneFile = pm.data.fileName;
-    if (typeof pm.data.page === "string") scenePage = pm.data.page;
-    selectionName = typeof pm.data.selectionName === "string" ? pm.data.selectionName : null;
-    selectionCount = typeof pm.data.selectionCount === "number" ? pm.data.selectionCount : 0;
-    renderContext();
-  });
-  var reconcileRun = null;
-  var reconcileStuckTimer = null;
-  syncNowBtn.addEventListener("click", () => {
-    syncMsg.textContent = "Syncing";
-    const at = Date.now();
-    const id = `reconcile_${at}`;
-    if (reconcileRun) {
-      if (reconcileStuckTimer !== null) {
-        clearTimeout(reconcileStuckTimer);
-        reconcileStuckTimer = null;
-      }
-      activity = resolveActivity(activity, {
-        id: reconcileRun.id,
-        ok: false,
-        ms: at - reconcileRun.at,
-        sentence: syncSupersededSentence()
-      });
+    if (message.type === "FILE_INFO" && message.data) {
+      if (typeof message.data.fileName === "string") sceneFile = message.data.fileName;
+      if (typeof message.data.page === "string") scenePage = message.data.page;
+      selectionName = typeof message.data.selectionName === "string" ? message.data.selectionName : null;
+      selectionCount = typeof message.data.selectionCount === "number" ? message.data.selectionCount : 0;
+      context();
     }
-    reconcileRun = { id, at };
-    const fileLabel = sceneFile ?? "(unnamed file)";
-    activity = pushActivity(activity, {
-      id,
-      tool: "RECONCILE",
-      label: "Reconcile \xB7 apply",
-      pending: true,
-      ok: true,
-      ms: 0,
-      at,
-      sentence: syncStartSentence("manual", fileLabel)
-    });
-    renderActivity(at);
+  });
+  var run = null;
+  var stuckTimer = null;
+  syncNowBtn.onclick = () => {
+    const at = Date.now(), id = `reconcile_${at}`;
+    syncMsg.textContent = "Syncing";
+    if (run) {
+      if (stuckTimer) clearTimeout(stuckTimer);
+      activityView.resolve({ id: run.id, ok: false, ms: at - run.at, sentence: syncSupersededSentence() }, false);
+    }
+    run = { id, at };
+    activityView.push({ id, tool: "RECONCILE", label: "Reconcile \xB7 apply", pending: true, ok: true, ms: 0, at, sentence: syncStartSentence("manual", sceneFile || "(unnamed file)") });
+    render();
     try {
       window.dispatchEvent(new CustomEvent("figma-agent:sync-request"));
     } catch {
     }
-    if (reconcileStuckTimer !== null) clearTimeout(reconcileStuckTimer);
-    reconcileStuckTimer = setTimeout(() => {
-      if (reconcileRun?.id !== id) return;
+    stuckTimer = setTimeout(() => {
+      if (run?.id !== id) return;
       const now = Date.now();
-      activity = resolveActivity(activity, { id, ok: false, ms: now - at, sentence: syncStuckSentence() });
-      reconcileRun = null;
-      reconcileStuckTimer = null;
-      renderActivity(now);
+      activityView.resolve({ id, ok: false, ms: now - at, sentence: syncStuckSentence() });
+      run = null;
+      stuckTimer = null;
+      syncFailure = true;
+      syncMsg.textContent = syncStuckSentence();
+      syncPrompt.hidden = false;
+      forceOnce(`activity-failure:${id}`, "activity");
+      render();
     }, SYNC_STUCK_TIMEOUT_MS);
-  });
-  syncLaterBtn.addEventListener("click", () => {
+  };
+  btn("fga-sync-later").onclick = () => {
     syncPrompt.hidden = true;
-  });
-  window.addEventListener("figma-agent:sync-result", (ev) => {
-    const d = ev.detail;
-    const unbound = d?.code === "E_UNBOUND";
-    const ok = d?.ok === true;
-    const summary = typeof d?.summary === "string" ? d.summary : "";
-    const landed = d?.landed !== false;
-    const label = syncResultLabel(ok, summary, landed, unbound);
-    syncMsg.textContent = label;
+  };
+  window.addEventListener("figma-agent:sync-result", (event) => {
+    const data = event.detail;
+    const unbound = data?.code === "E_UNBOUND", ok = data?.ok === true, summary = typeof data?.summary === "string" ? data.summary : "", landed = data?.landed !== false;
+    syncMsg.textContent = syncResultLabel(ok, summary, landed, unbound);
     syncNowBtn.textContent = syncNowLabel(unbound);
-    if (reconcileRun) {
-      if (reconcileStuckTimer !== null) {
-        clearTimeout(reconcileStuckTimer);
-        reconcileStuckTimer = null;
-      }
-      const now = Date.now();
-      const fileLabel = sceneFile ?? "(unnamed file)";
-      activity = resolveActivity(activity, {
-        id: reconcileRun.id,
-        ok,
-        ms: now - reconcileRun.at,
-        sentence: syncResultSentence(ok, summary, landed, unbound, fileLabel)
-      });
-      reconcileRun = null;
-      renderActivity(now);
+    const current = run;
+    if (current) {
+      if (stuckTimer) clearTimeout(stuckTimer);
+      activityView.resolve({ id: current.id, ok, ms: Date.now() - current.at, sentence: syncResultSentence(ok, summary, landed, unbound, sceneFile || "(unnamed file)") });
+      run = null;
+      stuckTimer = null;
     }
     const commit = shouldClearPendingCount(ok);
     parent.postMessage({ pluginMessage: { type: "SYNC_DONE", commit } }, "*");
+    syncFailure = !ok;
+    if (commit) pendingSyncCount = 0;
     syncPrompt.hidden = false;
+    if (!ok) forceOnce(`activity-failure:${current?.id ?? Date.now()}`, "activity");
     if (commit) setTimeout(() => {
       syncPrompt.hidden = true;
+      render();
     }, 4e3);
+    render();
   });
-  targetBtn.addEventListener("click", () => {
-    const event = peersPinned ? "figma-agent:clear-target" : "figma-agent:set-target";
-    try {
-      window.dispatchEvent(new CustomEvent(event));
-    } catch {
-    }
-  });
-  versionEl.textContent = `v0.1.0 \xB7 ${true ? "6a89393" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "15cb9e2" : "dev"}`;
+  replaceIcon(targetRailBtn, "files");
+  replaceIcon(syncRailBtn, "refresh-cw");
+  replaceIcon(toggleBtn, "chevron-down");
   setInterval(render, 1e3);
   render();
 

--- a/tests/figma-plugin-panel.test.ts
+++ b/tests/figma-plugin-panel.test.ts
@@ -1,42 +1,14 @@
-/**
- * The panel UI is DOGFOOD: its tokens come from ease-design's own `ds init`, and its
- * template must clear the SAME four core linters every generated artifact does. This is
- * the paired gate — the panel is a hand-authored HTML surface, so it runs
- * validate-layout / a11y-lint / taste-lint / content-lint with 0 errors.
- *
- * It lints the SOURCE template (plugin/src/ui/panel.html, pre-bundle-injection) — the
- * build only inlines the compiled JS at the marker, so the linted markup is what ships.
- *
- * The four linters live in the `design-os` kernel this plugin is split from. They are
- * NOT part of `ease-design`'s published npm surface (verified against the real
- * registry tarball — no `src/`, no compiled `dist/core/*`), and an npm git-dependency
- * on the kernel repo turned out not to help either: npm applies the kernel's own
- * publish `"files"` allowlist even to a git-dependency install, so `src/` never lands
- * in node_modules regardless of what the pinned commit's tree actually contains.
- * `kernel/design-os` is therefore a real git SUBMODULE (a raw checkout npm packing
- * never touches), pinned to one commit — ONE source of truth, no local fork of the
- * linter subsystem. Bump the pin (checkout a newer commit inside `kernel/design-os`,
- * commit the updated gitlink) when the kernel's lint rules advance. This bridge is
- * temporary: once the kernel publishes `ease-design/lint` as a real subpath export
- * (tracked separately), this submodule goes away and the panel test imports the
- * published package instead.
- */
-import { describe, expect, it } from "vitest";
-import { existsSync, readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { describe, expect, it } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 
-const KERNEL_CORE = fileURLToPath(new URL("../kernel/design-os/src/core/", import.meta.url));
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const KERNEL_CORE = `${ROOT}/kernel/design-os/src/core/`;
 if (!existsSync(`${KERNEL_CORE}layout-lint.ts`)) {
-  throw new Error(
-    "kernel/design-os submodule is not checked out (the panel gate imports its 4 " +
-    "linters from there) — run: git submodule update --init --depth 1",
-  );
+  throw new Error('kernel/design-os submodule is not checked out — run: git submodule update --init --depth 1');
 }
-// Dynamic + untyped on purpose: a static `import … from "../kernel/design-os/…"` would
-// let Vite's own (less actionable) resolution error fire first, before the existsSync
-// guard above ever runs — ES module imports are hoisted ahead of any top-level code.
-// The `any` this costs is confined to these four bindings, in a test file, in exchange
-// for the guard actually being the FIRST failure a missing submodule produces.
+
+// Dynamic imports keep the missing-submodule message above actionable.
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type AnyLintModule = any;
 const layoutLintMod: AnyLintModule = await import(/* @vite-ignore */ `${KERNEL_CORE}layout-lint.ts`);
@@ -50,498 +22,152 @@ const { allContentChecks } = contentChecksMod as {
   allContentChecks: ReadonlyArray<(src: string) => ReadonlyArray<{ severity: string }>>;
 };
 
-const PANEL = fileURLToPath(new URL("../plugin/src/ui/panel.html", import.meta.url));
-const MODEL = fileURLToPath(new URL("../plugin/src/ui/panel-model.ts", import.meta.url));
-// The activity feed's model split out of panel-model.ts once it grew a per-operation
-// vocabulary of its own; panel-model keeps the connection chrome. The rows' outcome
-// lines split again into activity-summary.ts — the relay's half. IA v2 (panel redesign
-// phase 02) added activity-sentence.ts on top: one English sentence per row, and the
-// DOM glue (panel-ui.ts) that used to write a `✗`/`✓` text glyph directly, so both are
-// read here too — the glyph ban and the sentence-module check need their source.
-const FEED = fileURLToPath(new URL("../plugin/src/ui/activity-feed.ts", import.meta.url));
-const SUMMARY = fileURLToPath(new URL("../plugin/src/ui/activity-summary.ts", import.meta.url));
-const SENTENCE = fileURLToPath(new URL("../plugin/src/ui/activity-sentence.ts", import.meta.url));
-const PANEL_UI = fileURLToPath(new URL("../plugin/src/ui/panel-ui.ts", import.meta.url));
+const read = (path: string): string => readFileSync(`${ROOT}/${path}`, 'utf8');
+const html = read('plugin/src/ui/panel.html');
+const model = read('plugin/src/ui/panel-model.ts');
+const panelUi = read('plugin/src/ui/panel-ui.ts');
+const activityView = read('plugin/src/ui/panel-activity-view.ts');
+const viewState = read('plugin/src/ui/panel-view-state.ts');
+const main = read('plugin/src/main/main.ts');
+const icons = existsSync(`${ROOT}/plugin/src/ui/lucide-icons.ts`) ? read('plugin/src/ui/lucide-icons.ts') : '';
 
-const html = readFileSync(PANEL, "utf8");
-const model = readFileSync(MODEL, "utf8");
-
-/** Matches a `:root { ... }` block OR the `html.figma-light { ... }` system-appearance
- *  theme-override block (added 2026-07-30) — both are token-DECLARATION zones, so every
- *  "chrome must use vars only" / "no raw hex" check strips both the same way. */
 const THEME_BLOCK_RE = /(?::root|html\.figma-light)\s*\{[\s\S]*?\}/g;
-const feed = readFileSync(FEED, "utf8");
-const summary = readFileSync(SUMMARY, "utf8");
-const sentenceSrc = readFileSync(SENTENCE, "utf8");
-const panelUi = readFileSync(PANEL_UI, "utf8");
+const chrome = html.replace(THEME_BLOCK_RE, '').replace(/\/\*[\s\S]*?\*\//g, '');
+const rules: [string, string][] = [...chrome.matchAll(/([^{}]+)\{([^}]*)\}/g)]
+  .map((match) => [(match[1] ?? '').trim(), match[2] ?? '']);
+const declarationsFor = (selector: string): string => rules
+  .filter(([selectors]) => selectors.split(',').some((item) => item.trim() === selector))
+  .map(([, declarations]) => declarations).join(';');
 
-/** Count content-lint ERROR-severity findings (consumes the shared allContentChecks set). */
 function contentErrors(source: string): number {
-  let errs = 0;
-  for (const c of allContentChecks) for (const f of c(source)) if (f.severity === "error") errs++;
-  return errs;
+  let errors = 0;
+  for (const check of allContentChecks) {
+    for (const finding of check(source)) if (finding.severity === 'error') errors += 1;
+  }
+  return errors;
 }
 
-describe("the plugin panel — the 4-linter gate", () => {
-  it("passes validate-layout / a11y-lint / taste-lint / content-lint with 0 errors", () => {
-    expect(lintLayout(html).errorCount, "layout errors").toBe(0);
-    expect(lintA11y(html).errorCount, "a11y errors").toBe(0);
-    expect(lintTaste(html).errorCount, "taste errors").toBe(0);
-    expect(contentErrors(html), "content errors").toBe(0);
+describe('adaptive panel source contract', () => {
+  it('passes the shared layout, accessibility, taste, and content linters', () => {
+    expect(lintLayout(html).errorCount, 'layout errors').toBe(0);
+    expect(lintA11y(html).errorCount, 'a11y errors').toBe(0);
+    expect(lintTaste(html).errorCount, 'taste errors').toBe(0);
+    expect(contentErrors(html), 'content errors').toBe(0);
   });
 
-  it("is a well-formed, language-tagged, titled document (screen-reader basics)", () => {
-    expect(html).toMatch(/^<!doctype html>/i);
-    expect(html).toMatch(/<html\b[^>]*\blang="en"/i);
-    expect(html).toMatch(/<title>[^<]+<\/title>/i);
-  });
-});
-
-describe("the plugin panel — dogfood tokens + provenance", () => {
-  it("embeds the compiled :root token block from ease-design's own DS", () => {
-    expect(html).toContain(":root {");
-    expect(html).toContain("--color-primary");
-    expect(html).toContain("--color-success");
-    expect(html).toContain("--font-family-body");
+  it('opens as the exact rail and whitelists only named viewport modes', () => {
+    expect(model).toContain('RAIL_WIDTH = 240');
+    expect(model).toContain('RAIL_HEIGHT = 44');
+    expect(model).toContain('INSPECTOR_WIDTH = 288');
+    expect(model).toContain('INSPECTOR_HEIGHT = 280');
+    expect(main).toMatch(/width:\s*RAIL_WIDTH,\s*height:\s*RAIL_HEIGHT/);
+    expect(main).toContain("chrome.type === 'PANEL_VIEWPORT'");
+    expect(main).toContain("chrome.mode === 'inspector'");
+    expect(main).toContain('viewportFor(chrome.mode)');
+    expect(main).toContain('figma.ui.resize(viewport.width, viewport.height)');
+    expect(main).not.toMatch(/chrome\.(?:width|height)/);
   });
 
-  it("records how to regenerate the tokens (provenance) and the persona", () => {
-    expect(html).toContain("brand/design");
-    expect(html).toContain("ui tokens compile");
-    expect(html).toContain("kinetic-swiss-punk");
+  it('owns a compact rail and a mounted three-view inspector', () => {
+    for (const id of [
+      'fga-panel', 'fga-rail', 'fga-connection-btn', 'fga-current-btn',
+      'fga-target-rail-btn', 'fga-sync-rail-btn', 'fga-toggle-btn', 'fga-inspector',
+      'fga-tab-activity', 'fga-tab-context', 'fga-tab-details',
+      'fga-panel-activity', 'fga-panel-context', 'fga-panel-details',
+    ]) expect(html, `missing #${id}`).toContain(`id="${id}"`);
+    expect(html).toContain('role="tablist"');
+    expect((html.match(/role="tab"/g) ?? []).length).toBe(3);
+    expect((html.match(/role="tabpanel"/g) ?? []).length).toBe(3);
+    expect(html).toMatch(/id="fga-inspector"[^>]*hidden/);
   });
 
-  it("overrides the body/display font to a system stack (iframe can't load a webfont)", () => {
-    expect(html).toContain("-apple-system");
-    // the override must come AFTER the compiled :root so it wins the cascade
-    expect(html.lastIndexOf("--font-family-body")).toBeGreaterThan(html.indexOf("Inter, sans-serif"));
-  });
-
-  it("uses no raw hex outside the pasted :root blocks or the html.figma-light theme block (every chrome color via var())", () => {
-    // Strip the :root{…} blocks AND the html.figma-light theme-override block (added
-    // 2026-07-30 for system/Figma appearance) — both are token-declaration zones, same
-    // as :root structurally — plus CSS comments (the light block's own doc comment
-    // quotes hex values in prose, same reason the sibling check below uses `chrome`),
-    // then assert no #RRGGBB / #RGB survives in the chrome/markup.
-    const withoutRoot = html.replace(THEME_BLOCK_RE, "").replace(/\/\*[\s\S]*?\*\//g, "");
-    expect(withoutRoot).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
-  });
-});
-
-describe("the plugin panel — states, a11y live regions, motion", () => {
-  it("consumes the P1 connection state machine via statusSentence — every branch has copy", () => {
-    // IA v2 (phase 02): stateView/troubleshootHint/compactMeta are gone, replaced by ONE
-    // pure function, statusSentence(state, ageMs, hadConnection), covering 6 branches
-    // (connected / probing<10s / probing>=10s / handshake / disconnected-never /
-    // disconnected-was). Assert the export exists and every branch's copy is verbatim —
-    // these are the owner-approved problem-and-next-action sentences (§2).
-    expect(model).toContain("export function statusSentence");
-    // Owner addendum 2026-07-30: shortened — success states are minimal (the tone dot
-    // already signals state), problem states keep problem + next action trimmed of filler.
-    for (const sentence of [
-      "Connected",
-      "Looking for the broker",
-      "Broker not running — run figma-agent status.",
-      "Connecting",
-      "Not connected — your first command starts the broker.",
-      "Connection lost — reconnecting.",
-    ]) {
-      expect(model, `missing sentence: ${sentence}`).toContain(sentence);
-    }
-  });
-
-  it("wires an activity record shape of {id, tool, ok, ms, at}", () => {
-    for (const field of ["id:", "tool:", "ok:", "ms:", "at:"]) {
-      expect(feed, `missing ${field}`).toContain(field);
-    }
-  });
-
-  it("keeps a row's intent label and its outcome — the feed says what ran, not just which cmd", () => {
-    // `cmd` alone is opaque (EXEC_JS is injected code), so the record carries the
-    // CLI's intent label and the plugin-derived result line. Without either, the feed
-    // regresses to "exec js · 1.2s", which is what this whole module exists to fix.
-    expect(feed).toContain("label?:");
-    expect(feed).toContain("result?:");
-    expect(feed).toContain("pending:");
-    expect(summary).toContain("summarizeResult");
-    expect(summary).toContain("summarizeError");
-    // IA v2: the label/result split alone is not the whole story any more — each row
-    // renders ONE sentence via activity-sentence.ts. Without this assertion, the OLD
-    // label+meta split would still satisfy every check above.
-    expect(sentenceSrc).toContain("export function activitySentence");
-  });
-
-  it("marks status + activity as aria-live polite regions", () => {
-    const live = html.match(/aria-live="polite"/g) ?? [];
-    expect(live.length, "aria-live regions").toBeGreaterThanOrEqual(2);
-  });
-
-  it("guards every animation behind prefers-reduced-motion", () => {
-    expect(html).toContain("@keyframes");
-    expect(html).toContain("prefers-reduced-motion");
-  });
-
-  it("shows the onboarding verify command", () => {
-    // The Docs link is cut entirely in IA v2 (§2 CUT list) — figma-agent status is the
-    // one command the onboarding card still points at.
-    expect(html).toContain("figma-agent status");
-  });
-});
-
-// Both blocks share one helper — comments must be stripped before any selector/declaration
-// scan, or a sentence like `/* …the ~300px panel… */` or a comment above `.status-dot`
-// poisons the match.
-/** The chrome, with :root blocks (+ the html.figma-light theme block) and CSS comments
- *  removed — the only safe scan surface. */
-const chrome = html
-  .replace(THEME_BLOCK_RE, "")
-  .replace(/\/\*[\s\S]*?\*\//g, "");
-/** [selectorList, declarations] for every rule in the chrome. */
-const rules: [string, string][] = [...chrome.matchAll(/([^{}]+)\{([^}]*)\}/g)]
-  .map((m): [string, string] => [(m[1] ?? "").trim(), m[2] ?? ""]);
-/** The declarations of the first rule whose selector list contains `sel`. */
-const declsFor = (sel: string): string =>
-  rules.filter(([s]) => s.split(",").some((one) => one.trim() === sel)).map(([, d]) => d).join(";");
-
-describe("the plugin panel — the dark skin layer", () => {
-  // The skin is only real if it is (a) declared in a :root block, (b) the LAST such block, and
-  // (c) actually what the chrome paints with. String-presence alone passes for a dead token.
-  const rootBlocks = [...html.matchAll(/:root\s*\{([\s\S]*?)\}/g)].map((m) => m[1]);
-
-  it("declares the skin tokens inside the LAST :root block", () => {
-    const last = rootBlocks.at(-1) ?? "";
-    for (const t of ["--fga-body", "--fga-surface", "--fga-divider", "--fga-text", "--fga-radius"]) {
-      expect(last, `${t} must be declared in the final :root block`).toContain(t);
-    }
-    // …and that block must come after the compiled DS block, so it wins the cascade.
-    expect(html.lastIndexOf("--fga-body")).toBeGreaterThan(html.indexOf("--color-primary"));
-  });
-
-  it("has no dead skin tokens, and no reference to a token that was never declared", () => {
-    const declared = [...(rootBlocks.at(-1) ?? "").matchAll(/(--fga-[a-z0-9-]+)\s*:/g)].map((m) => m[1]);
-    expect(declared.length, "skin tokens declared").toBeGreaterThan(8);
-    const unused = declared.filter((t) => !chrome.includes(`var(${t})`));
-    expect(unused, `unused skin tokens: ${unused.join(", ")}`).toEqual([]);
-    // The mirror check: a var(--fga-…) the block never declares is an invalid declaration the
-    // browser drops silently (this is how --fga-surface-raised nearly shipped).
-    const referenced = [...chrome.matchAll(/var\((--fga-[a-z0-9-]+)/g)].map((m) => m[1]);
-    const undeclared = [...new Set(referenced)].filter((t) => !declared.includes(t));
-    expect(undeclared, `undeclared tokens referenced: ${undeclared.join(", ")}`).toEqual([]);
-  });
-
-  it("uses the reference's dotted section rule and drops the 2px ink rules", () => {
-    expect(chrome).toMatch(/border-(top|bottom):\s*1px\s+dotted\s+var\(--fga-divider\)/);
-    expect(html).not.toContain("2px solid var(--color-foreground)");
-  });
-
-  it("paints the chrome only through vars (no hex, no bare custom-property values)", () => {
-    expect(chrome).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);            // mirrors the existing rule
-    expect(chrome).toContain("var(--fga-surface)");
-    // A declaration like `border: 1px solid --fga-border` is silently dropped by the browser;
-    // every --fga-* reference outside :root must be wrapped in var().
-    expect(chrome.match(/(?<!var\()--fga-[a-z0-9-]+(?!\s*:)/g) ?? []).toEqual([]);
-  });
-});
-// (Note the hex assertion now runs on the comment-stripped `chrome`, so the sampling
-// coordinates in the `:root` provenance comment cannot trip it.)
-
-describe("the plugin panel — system/Figma appearance (html.figma-light theme override)", () => {
-  // Radii, spacing, and type tokens are theme-invariant by design (owner-locked) — only
-  // COLOR tokens are expected to repeat in the light override.
-  const THEME_INVARIANT = new Set([
-    "--fga-radius", "--fga-radius-sm", "--fga-divider-gap",
-    "--fga-font-title", "--fga-font-body", "--fga-font-caption",
-    "--fga-track-title", "--fga-track-body", "--fga-track-caption",
-    "--fga-lh-title", "--fga-lh-body", "--fga-lh-caption",
-    "--fga-motion", "--fga-ease",
-  ]);
-  const rootBlocks = [...html.matchAll(/:root\s*\{([\s\S]*?)\}/g)].map((m) => m[1]);
-  const darkBlock = rootBlocks.at(-1) ?? "";
-  const lightBlock = /html\.figma-light\s*\{([\s\S]*?)\}/.exec(html)?.[1] ?? "";
-  const tokensOf = (block: string): string[] => [...block.matchAll(/(--fga-[a-z0-9-]+)\s*:/g)].map((m) => m[1] ?? "");
-
-  it("declares the html.figma-light override block, after the dark skin block", () => {
-    expect(lightBlock, "html.figma-light block must exist").not.toBe("");
-    // Anchor on the ACTUAL rule opening (`html.figma-light {`), not a bare substring
-    // match — the dark block's own doc comment mentions "html.figma-light" in prose,
-    // which sits BEFORE the dark block's last declaration and would otherwise poison
-    // a plain indexOf/lastIndexOf comparison either direction.
-    const lightRuleIndex = /html\.figma-light\s*\{/.exec(html)?.index ?? -1;
-    expect(lightRuleIndex).toBeGreaterThan(-1);
-    expect(lightRuleIndex).toBeGreaterThan(html.lastIndexOf("--fga-chrome: #2C2C2C"));
-  });
-
-  it("covers the SAME set of color tokens as the dark block — no token left dark-only", () => {
-    const darkColorTokens = tokensOf(darkBlock).filter((t) => !THEME_INVARIANT.has(t));
-    const lightTokens = new Set(tokensOf(lightBlock));
-    const missing = darkColorTokens.filter((t) => !lightTokens.has(t));
-    expect(missing, `color tokens missing from html.figma-light: ${missing.join(", ")}`).toEqual([]);
-  });
-
-  it("declares no theme-invariant (radius/spacing/type) token in the light override", () => {
-    const leaked = tokensOf(lightBlock).filter((t) => THEME_INVARIANT.has(t));
-    expect(leaked, `theme-invariant tokens should not repeat in html.figma-light: ${leaked.join(", ")}`).toEqual([]);
-  });
-
-  it("uses only var()-wrapped hex inside the light block itself — no undeclared or dead token", () => {
-    // The light block's OWN declared tokens must be exactly the dark color-token set
-    // (already asserted above); this guards the inverse — nothing declared in light that
-    // dark never declared (a typo'd token name would otherwise silently do nothing).
-    const darkTokenSet = new Set(tokensOf(darkBlock));
-    const extra = tokensOf(lightBlock).filter((t) => !darkTokenSet.has(t));
-    expect(extra, `html.figma-light declares a token the dark block never does: ${extra.join(", ")}`).toEqual([]);
-  });
-});
-
-describe("the plugin panel — typography contract (owner-locked)", () => {
-  it("uses exactly one font family, through the single body var", () => {
-    const families = [...chrome.matchAll(/font-family:\s*([^;]+);/g)].map((m) => (m[1] ?? "").trim());
-    expect([...new Set(families)]).toEqual(["var(--font-family-body)"]);
-  });
-
-  it("declares exactly three panel font sizes and uses no other size source", () => {
-    const skin = [...html.matchAll(/:root\s*\{([\s\S]*?)\}/g)].at(-1)?.[1] ?? "";
-    const declared = [...skin.matchAll(/(--fga-font-[a-z]+)\s*:/g)].map((m) => m[1]).sort();
-    expect(declared).toEqual(["--fga-font-body", "--fga-font-caption", "--fga-font-title"]);
-    const sizes = [...chrome.matchAll(/font-size:\s*([^;]+);/g)].map((m) => (m[1] ?? "").trim());
-    const bad = sizes.filter((v) => !/^var\(--fga-font-(title|body|caption)\)$/.test(v));
-    expect(bad, `font-size values outside the three tokens: ${bad.join(" | ")}`).toEqual([]);
-  });
-
-  it("draws every mark as an SVG — no text glyphs in markup or CSS content", () => {
-    const GLYPHS = /[✗✓⟳•✕×↻●○◆▪…]/u;
-    expect(GLYPHS.test(chrome), "glyph in CSS/markup").toBe(false);
-    const contents = [...chrome.matchAll(/content:\s*(["'])(.*?)\1/g)].map((m) => m[2] ?? "");
-    expect(contents.filter((c) => c.trim() !== ""), "content: must stay decorative-empty").toEqual([]);
-  });
-
-  it("draws every mark as an SVG — no text glyphs in markup, CSS, or the panel scripts", () => {
-    // A panel.html-only regex catches neither offender that actually shipped the old glyphs:
-    // `panel-ui.ts` wrote `dot.textContent = state === 'failed' ? '✗' : ''` and
-    // `panel-model.ts`'s `syncResultLabel` wrote `Synced ✓ — …` — both are JS, not markup.
-    // The ellipsis (…) joined the ban post-judge-review: literal `…` had crept into the
-    // status/activity sentences (`statusSentence`, `activitySentence`, the sync/running
-    // captions) — a text glyph exactly like the others, just easier to miss.
-    const GLYPHS = /[✗✓⟳•✕×↻●○◆▪…]/u;
-    for (const [name, src] of [["panel.html", chrome], ["panel-ui.ts", panelUi], ["panel-model.ts", model]] as const) {
-      expect(GLYPHS.test(src), `glyph in ${name}`).toBe(false);
-    }
-  });
-});
-
-describe("the plugin panel — IA v2 structure", () => {
-  it("ships exactly three blocks, in order, plus the sync prompt", () => {
-    const order = ["fga-status", "fga-context", "fga-activity-block", "fga-sync"]
-      .map((id) => html.indexOf(`id="${id}"`));
-    expect(order.every((i) => i >= 0), `a block container is missing: ${order.join()}`).toBe(true);
-    expect(order, "blocks must appear in IA order").toEqual([...order].sort((a, b) => a - b));
-    // exactly three block sections — a fourth means the IA drifted
-    expect((html.match(/class="[^"]*\bfga-block\b/g) ?? []).length).toBe(3);
-  });
-
-  it("keeps every id the panel script resolves, and the live regions", () => {
-    for (const id of ["fga-panel", "fga-status", "fga-dot", "fga-sentence", "fga-onboarding",
-                      "fga-ctx-file", "fga-ctx-file-note", "fga-ctx-page", "fga-ctx-selection",
-                      "fga-activity", "fga-sync", "fga-sync-msg", "fga-sync-now", "fga-sync-later",
-                      "fga-version"]) {
-      expect(html, `missing #${id}`).toContain(`id="${id}"`);
-    }
+  it('keeps context, activity, sync, onboarding, recovery, and version information', () => {
+    for (const id of [
+      'fga-sentence', 'fga-onboarding', 'fga-ctx-file', 'fga-ctx-file-note',
+      'fga-ctx-page', 'fga-ctx-selection', 'fga-target-btn', 'fga-activity',
+      'fga-sync', 'fga-sync-msg', 'fga-sync-now', 'fga-sync-later', 'fga-version',
+    ]) expect(html, `missing #${id}`).toContain(`id="${id}"`);
     expect((html.match(/aria-live="polite"/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(html).toContain('aria-atomic="true"');
+  });
+});
+
+describe('Lucide and control accessibility', () => {
+  it('vendors an attributed Lucide descriptor set with no runtime dependency', () => {
+    expect(icons).toContain('Lucide Contributors');
+    expect(icons).toContain('ISC License');
+    expect(icons).toContain("viewBox', '0 0 24 24'");
+    expect(icons).toContain("stroke-width', '2'");
+    expect(icons).not.toContain('innerHTML');
+    expect(activityView).toContain("from './lucide-icons'");
+    expect(`${panelUi}${activityView}${icons}`).not.toContain('Phosphor');
   });
 
-  it("has dropped the debug controls entirely — markup AND their dead CSS", () => {
-    for (const gone of ["fga-docs", "fga-copy", "fga-toggle", "fga-toggle-label", "fga-expanded",
-                        "fga-pill", "fga-meta", "fga-hint",
-                        "fga-d-port", "fga-d-proto", "fga-d-heartbeat", "fga-d-attempts",
-                        "fga-d-file", "fga-d-page"]) {
-      expect(html, `${gone} must be gone`).not.toContain(gone);
+  it('gives every icon-only rail control a title, accessible name, and native button', () => {
+    for (const id of ['fga-connection-btn', 'fga-target-rail-btn', 'fga-sync-rail-btn', 'fga-toggle-btn']) {
+      const button = new RegExp(`<button[^>]*id="${id}"[^>]*>`, 's').exec(html)?.[0] ?? '';
+      expect(button, `${id} must be a button`).toContain('<button');
+      expect(button, `${id} missing title`).toContain('title=');
+      expect(button, `${id} missing aria-label`).toContain('aria-label=');
+      expect(button, `${id} missing type`).toContain('type="button"');
     }
+    expect(declarationsFor('.rail-control')).toMatch(/(?:width|min-width):\s*32px/);
+    expect(declarationsFor('.rail-control')).toMatch(/height:\s*32px/);
+    expect(declarationsFor('.fga-icon')).toMatch(/width:\s*16px/);
+    expect(declarationsFor('.fga-icon')).toMatch(/height:\s*16px/);
+    expect(declarationsFor('.rail-control:focus-visible')).toMatch(/outline:\s*2px/);
   });
 
-  it("has no inset left-bar box-shadow — the owner vetoed the treatment entirely (2026-07-29)", () => {
-    // The reference's "active nav item" left-accent-bar signature was tried here (an inset
-    // box-shadow on the sync prompt, the onboarding card, and the newest activity row) and
-    // rejected outright by the owner on sight — not a color note, the TREATMENT itself. This
-    // encodes that taste call as a gate so it cannot silently return in a later pass.
+  it('implements keyboard tabs, Escape collapse, and focus restoration', () => {
+    for (const key of ['ArrowRight', 'ArrowLeft', 'Home', 'End', 'Escape']) {
+      expect(panelUi, `missing ${key} keyboard handling`).toContain(`'${key}'`);
+    }
+    expect(panelUi).toContain('toggleBtn.focus()');
+    expect(panelUi).toContain("setAttribute('aria-selected'");
+    expect(panelUi).toContain('tabIndex = selected ? 0 : -1');
+  });
+});
+
+describe('disclosure, authority, and motion', () => {
+  it('keeps target conditional and PEERS-authoritative', () => {
+    expect(html).toMatch(/id="fga-target-rail-btn"[^>]*hidden/);
+    expect(panelUi).toContain('targetRailBtn.hidden = peersCount <= 1');
+    expect(panelUi).toContain("peersPinned ? 'figma-agent:clear-target' : 'figma-agent:set-target'");
+    expect(panelUi).toContain('targetRailBtn.onclick = toggleTarget');
+    expect(panelUi).toContain('targetBtn.onclick = toggleTarget');
+    expect(panelUi).not.toContain('peersPinned = !peersPinned');
+  });
+
+  it('keeps sync conditional and failure retry semantics intact', () => {
+    expect(html).toMatch(/id="fga-sync-rail-btn"[^>]*hidden/);
+    expect(panelUi).toContain('pendingSyncCount');
+    expect(panelUi).toContain('shouldClearPendingCount(ok)');
+    expect(panelUi).toContain('syncNowLabel(unbound)');
+    expect(panelUi).toContain('SYNC_STUCK_TIMEOUT_MS');
+  });
+
+  it('dedupes forced expansion while leaving unresolved state on the rail', () => {
+    expect(panelUi).toContain('const disclosed = new BoundedKeySet()');
+    expect(panelUi).toContain('forceOnce');
+    expect(panelUi).toContain('activityView.failures.unresolvedCount > 0');
+    expect(viewState).toContain('records.find((record) => record.pending)');
+    expect(html).toContain('id="fga-failure-count"');
+    expect(panelUi).toContain('activityView.acknowledgeFailures()');
+    expect(panelUi).toContain("if (tab === 'activity') acknowledgeActivity()");
+    expect(activityView).toContain('failures.unresolvedCount');
+  });
+
+  it('uses named transitions and honors reduced motion', () => {
+    expect(chrome).not.toMatch(/transition[^;]*:\s*[^;]*\ball\b/);
+    expect(html).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(html).toContain('.is-spinning');
+  });
+
+  it('retains theme provenance and no-left-accent owner decision', () => {
+    expect(html).toContain('kinetic-swiss-punk');
+    expect(html).toContain('html.figma-light');
+    expect(chrome).not.toMatch(/#[0-9a-fA-F]{3,8}\b/);
     expect(chrome).not.toMatch(/box-shadow:\s*inset\b/);
-  });
-});
-
-describe("the plugin panel — responsive contract (240px → 640px+)", () => {
-  // Decorative squares are the ONLY fixed sizes allowed. Matched per INDIVIDUAL selector, after
-  // comment stripping — a comment above a rule used to end up inside the "selector".
-  // IA v2: the feed's status mark moved from `.log-dot` (a CSS-drawn shape) to
-  // `.log-icon-wrap` (a fixed-size SVG wrapper); the toggle's caret icon
-  // (`.footer-icon`) is gone with the toggle itself.
-  // Phase 03 §1: sizing moved onto the shared `.fga-icon` rule (14px icon grid).
-  // Phase 03 §6: the thin scrollbar thumb is a fixed 8px width, decorative chrome.
-  const SIZE_WHITELIST = ["\\.status-dot", "\\.log-icon-wrap", "\\.identity-dot",
-                          "\\.fga-icon", "::-webkit-scrollbar"];
-  const whitelisted = (selList: string): boolean =>
-    selList.split(",").every((s) => SIZE_WHITELIST.some((w) => new RegExp(w).test(s)));
-  // width | min-width | inline-size | min-inline-size | flex-basis, in px — however it is spelled.
-  const FIXED = /(?:^|;|\s)(?:min-)?(?:width|inline-size)\s*:\s*(?:calc\()?\s*\d+px|flex-basis\s*:\s*\d+px/;
-
-  it("declares no fixed width on any layout element", () => {
-    const offenders = rules
-      .filter(([sel, decls]) => FIXED.test(decls) && !whitelisted(sel))
-      .map(([sel]) => sel);
-    expect(offenders, `fixed widths outside the whitelist: ${offenders.join(" | ")}`).toEqual([]);
-  });
-
-  it("scrolls vertically on the panel and never horizontally", () => {
-    // Selector-scoped: "somewhere in the file" would pass with the rule on an unrelated element.
-    expect(declsFor(".panel")).toMatch(/overflow-y:\s*auto/);
-    expect(declsFor(".panel")).toMatch(/overflow-x:\s*hidden/);
-    expect(declsFor(".panel")).not.toMatch(FIXED);
-  });
-
-  it("keeps the STATUS HEADER sticky", () => {
-    expect(declsFor(".status-hero")).toMatch(/position:\s*sticky/);
-    expect(declsFor(".status-hero")).toMatch(/top:\s*0/);
-  });
-
-  it("sizes the DETAIL GRID fluidly — no fixed column track", () => {
-    const g = declsFor(".detail-grid");
-    expect(g).toMatch(/grid-template-columns:\s*repeat\(auto-fit,\s*minmax\(\s*\d+px\s*,\s*1fr\s*\)/);
-  });
-
-  it("wraps every button/link row", () => {
-    // IA v2 (§5): `.footer-actions` (Details/Docs/Copy) is cut with the row it held —
-    // `.sync-actions` and `.identity-row` are the surviving wrap-flexed rows.
-    for (const sel of [".sync-actions", ".identity-row"]) {
-      expect(declsFor(sel), `${sel} must wrap`).toMatch(/flex-wrap:\s*wrap/);
-    }
-  });
-
-  it("pairs every ellipsis with its overflow + white-space guards", () => {
-    const bad = rules
-      .filter(([, d]) => /text-overflow:\s*ellipsis/.test(d)
-        && !(/overflow:\s*hidden/.test(d) && /white-space:\s*nowrap/.test(d)))
-      .map(([sel]) => sel);
-    expect(bad, `ellipsis without overflow:hidden + white-space:nowrap: ${bad.join(" | ")}`).toEqual([]);
-  });
-
-  it("uses no width breakpoint — the layout is fluid across the whole range", () => {
-    expect(chrome).not.toMatch(/@media[^{]*\(\s*(?:min|max)-width/);
-  });
-});
-
-describe("the plugin panel — craft floor (phase 03)", () => {
-  // A. 4px rhythm — the shared taste linter only sees Tailwind utilities, so this is OUR check.
-  // NOTE the calc branch: `calc\([^)]*\)` cannot match the NESTED parens in
-  // `calc((1.5em - 14px) / 2)` — the optical-centring rule this very phase introduces would be
-  // reported as off-grid. Match calc() permissively instead.
-  it("lands every spacing value on the 4px grid", () => {
-    const ALLOWED = /^(0|var\(--space-(hair|1|2|3)\)|var\(--fga-divider-gap\)|auto|calc\(.*\))$/;
-    const offenders: string[] = [];
-    for (const [sel, decls] of rules) {
-      for (const m of decls.matchAll(/(?:^|;)\s*(padding|margin|gap|row-gap|column-gap|padding-block|padding-inline)\s*:\s*([^;]+)/g)) {
-        for (const part of (m[2] ?? "").trim().split(/\s+(?![^(]*\))/)) {
-          if (ALLOWED.test(part)) continue;
-          const px = /^(\d+)px$/.exec(part);
-          if (px && Number(px[1]) % 4 === 0) continue;      // a literal multiple of 4 is fine
-          offenders.push(`${sel} { ${m[1]}: ${part} }`);
-        }
-      }
-    }
-    expect(offenders, `off-grid spacing: ${offenders.join(" | ")}`).toEqual([]);
-  });
-
-  // B. Two size families and no third: icons 14px, dots 8px — asserted on the RULES, and on
-  // actual usage of the class (a rule alone would be dead CSS). `fga-row` is applied both in
-  // the static markup (`.status-row`) and dynamically (`panel-ui.ts`'s activity rows); `fga-icon`
-  // is applied ONLY dynamically (every icon in this panel is a JS-injected SVG, never a static
-  // one) — so "actually applied" is checked across panel.html AND panel-ui.ts, not html alone,
-  // or this assertion would fail despite the class being live on every real activity row.
-  it("sizes every icon on the 14px grid and every dot at 8px", () => {
-    const sizesOf = (sel: string) => [...declsFor(sel).matchAll(/(?:width|height):\s*([^;]+)/g)]
-      .map((d) => (d[1] ?? "").trim());
-    expect([...new Set(sizesOf(".fga-icon"))]).toEqual(["14px"]);
-    expect([...new Set([...sizesOf(".status-dot"), ...sizesOf(".identity-dot")])]).toEqual(["8px"]);
-    const iconApplied = /class="[^"]*\bfga-icon\b/.test(html)
-      || /className\s*=\s*['"][^'"]*\bfga-icon\b/.test(panelUi);
-    expect(iconApplied, "the icon class must actually be applied (markup or panel-ui.ts)").toBe(true);
-    const rowApplied = /class="[^"]*\bfga-row\b/.test(html)
-      || /className\s*=\s*['"][^'"]*\bfga-row\b/.test(panelUi);
-    expect(rowApplied, "the row class must actually be applied (markup or panel-ui.ts)").toBe(true);
-  });
-
-  // C. The vetoed left bar can never come back, in any spelling. (The blanket
-  // `box-shadow: inset` ban already lives above — kept; this adds the other two spellings
-  // and retires the dead token.)
-  it("has no left accent bar", () => {
     expect(chrome).not.toMatch(/border-left:\s*(?!0)/);
-    expect(chrome).not.toContain("--fga-accent");
-  });
-
-  // D. Depth is alpha BORDERS, never an alpha background. taste-lint's mode-invisible-surface does
-  // NOT resolve custom properties, so `background: var(--fga-hairline)` would slip past it — this
-  // assertion is the only enforcement, and it therefore checks the token names too.
-  it("uses low-alpha white only on borders, never on a surface", () => {
-    // The phase's own given regex here (`/background(?:-color)?:\s*(rgba\(|var\((--fga-(hairline
-    // |topedge))/`) has an unbalanced group — a missing closing paren — and throws
-    // "Invalid regular expression" as written. Fixed to the clearly-intended, balanced check:
-    // a literal `rgba(` background is caught by the first branch; ANY of the three alpha
-    // tokens used as a background (not just hairline/topedge) is caught by the second, which
-    // already covers hairline-soft too, so nothing from the original intent is lost.
-    const ALPHA_TOKENS = ["--fga-hairline", "--fga-hairline-soft", "--fga-topedge"];
-    const bgAlpha = rules
-      .filter(([sel]) => !sel.includes("::selection"))            // a text highlight, not a surface
-      .filter(([, d]) => /background(?:-color)?:\s*rgba\(/.test(d)
-        || ALPHA_TOKENS.some((t) => new RegExp(`background(?:-color)?:\\s*var\\(${t}\\)`).test(d)))
-      .map(([s]) => s);
-    expect(bgAlpha, `alpha background on: ${bgAlpha.join(" | ")}`).toEqual([]);
-    expect(chrome).toMatch(/border:\s*1px\s+solid\s+var\(--fga-hairline\)/);
-    expect(chrome).toMatch(/border-top-color:\s*var\(--fga-topedge\)/);
-  });
-
-  // E. Focus is visible on every interactive control.
-  it("gives both interactive controls a focus-visible ring", () => {
-    for (const sel of [".sync-btn:focus-visible", ".inline-link:focus-visible"]) {
-      expect(declsFor(sel), `${sel} needs an outline`).toMatch(/outline:\s*2px/);
-      expect(declsFor(sel)).toMatch(/outline-offset:/);
-    }
-  });
-
-  // F. Motion: named properties only, and everything guarded.
-  it("names its transitions and guards every one under reduced-motion", () => {
-    expect(chrome).not.toMatch(/transition[^;]*:\s*(?:[^;]*\s)?all\b/);
-    expect(chrome).not.toMatch(/transition[^;]*:[^;]*\blinear\b/);
-    const guard = /@media\s*\(prefers-reduced-motion[^{]*\{([\s\S]*?)\}\s*\}/.exec(html)?.[1] ?? "";
-    for (const sel of [".activity-row", ".sync-prompt", ".status-dot"]) {
-      expect(guard, `${sel} must be inside the reduced-motion guard`).toContain(sel);
-    }
-  });
-
-  // Backlog 4.7 — the activity row's entrance animation must be scoped to `.is-new`
-  // ONLY, never the bare `.activity-row` class every row carries: panel-ui.ts rebuilds
-  // every row's DOM node on each render (including the 1s heartbeat tick), so an
-  // animation on the base class replays on every tick for every row, worst when a
-  // failing command keeps re-rendering the same rows. This is the paired gate for that
-  // fix — it fails if a future change moves the animation back onto the base selector.
-  it("scopes the activity row's entrance animation to .is-new, not every row", () => {
-    expect(declsFor(".activity-row")).not.toMatch(/animation:/);
-    expect(declsFor(".activity-row.is-new")).toMatch(/animation:\s*fga-row-in/);
-    // The reduced-motion guard must match (or exceed) that selector's specificity, or
-    // its `animation: none` loses the cascade to `.is-new`'s own animation declaration.
-    const guard = /@media\s*\(prefers-reduced-motion[^{]*\{([\s\S]*?)\}\s*\}/.exec(html)?.[1] ?? "";
-    expect(guard, "the guard must target .activity-row.is-new specifically").toContain(".activity-row.is-new");
-  });
-
-  // G. Type micro-craft is tokenized, not sprinkled — BOTH axes. Raw line-heights currently
-  // survive at panel.html:309, :343, :398, :600; they must move to the tokens too, or "deliberate
-  // line-heights" is a claim with nothing enforcing it.
-  it("declares tracking + line-height per size and uses neither raw", () => {
-    for (const t of ["--fga-track-title", "--fga-track-body", "--fga-track-caption",
-                     "--fga-lh-title", "--fga-lh-body", "--fga-lh-caption"]) {
-      expect(html, `missing ${t}`).toContain(t);
-    }
-    const rawTrack = [...chrome.matchAll(/letter-spacing:\s*([^;]+)/g)]
-      .map((m) => (m[1] ?? "").trim()).filter((v) => !v.startsWith("var(--fga-track-"));
-    expect(rawTrack, `raw letter-spacing: ${rawTrack.join(" | ")}`).toEqual([]);
-    const rawLh = [...chrome.matchAll(/(?:^|;)\s*line-height:\s*([^;]+)/g)]
-      .map((m) => (m[1] ?? "").trim()).filter((v) => !v.startsWith("var(--fga-lh-"));
-    expect(rawLh, `raw line-height: ${rawLh.join(" | ")}`).toEqual([]);
   });
 });

--- a/tests/panel-craft-regression.test.ts
+++ b/tests/panel-craft-regression.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const read = (path: string): string => readFileSync(`${ROOT}/${path}`, 'utf8');
+const html = read('plugin/src/ui/panel.html');
+const activityView = read('plugin/src/ui/panel-activity-view.ts');
+const blocks = /(?::root|html\.figma-light)\s*\{[\s\S]*?\}/g;
+const chrome = html.replace(blocks, '').replace(/\/\*[\s\S]*?\*\//g, '');
+const rules: [string, string][] = [...chrome.matchAll(/([^{}]+)\{([^}]*)\}/g)]
+  .map((match) => [(match[1] ?? '').trim(), match[2] ?? '']);
+const declarationsFor = (selector: string): string => rules
+  .filter(([selectors]) => selectors.split(',').some((item) => item.trim() === selector))
+  .map(([, declarations]) => declarations).join(';');
+
+describe('panel visual regression contract', () => {
+  const roots = [...html.matchAll(/:root\s*\{([\s\S]*?)\}/g)].map((match) => match[1] ?? '');
+  const dark = roots.at(-1) ?? '';
+  const light = /html\.figma-light\s*\{([\s\S]*?)\}/.exec(html)?.[1] ?? '';
+  const tokens = (block: string): string[] => [...block.replace(/\/\*[\s\S]*?\*\//g, '')
+    .matchAll(/(--fga-[a-z0-9-]+)\s*:/g)].map((match) => match[1] ?? '');
+  const invariant = new Set([
+    '--fga-radius', '--fga-radius-sm', '--fga-divider-gap', '--fga-font-title',
+    '--fga-font-body', '--fga-font-caption', '--fga-track-title', '--fga-track-body',
+    '--fga-track-caption', '--fga-lh-title', '--fga-lh-body', '--fga-lh-caption',
+    '--fga-motion', '--fga-ease',
+  ]);
+
+  it('keeps dark tokens live and light color-token parity exact', () => {
+    const declared = tokens(dark);
+    const referenced = [...chrome.matchAll(/var\((--fga-[a-z0-9-]+)/g)].map((match) => match[1] ?? '');
+    expect(declared.filter((token) => !chrome.includes(`var(${token})`))).toEqual([]);
+    expect([...new Set(referenced)].filter((token) => !declared.includes(token))).toEqual([]);
+    expect(tokens(light).sort()).toEqual(declared.filter((token) => !invariant.has(token)).sort());
+    expect(tokens(light).filter((token) => invariant.has(token))).toEqual([]);
+  });
+
+  it('tokenizes typography sizes, tracking, and line-height', () => {
+    expect([...dark.matchAll(/(--fga-font-[a-z]+)\s*:/g)].map((match) => match[1]).sort())
+      .toEqual(['--fga-font-body', '--fga-font-caption', '--fga-font-title']);
+    expect([...new Set([...chrome.matchAll(/font-family:\s*([^;]+);/g)].map((match) => match[1]?.trim()))])
+      .toEqual(['var(--font-family-body)']);
+    expect([...chrome.matchAll(/font-size:\s*([^;]+);/g)].map((match) => match[1]?.trim())
+      .filter((value) => !/^var\(--fga-font-(title|body|caption)\)$/.test(value ?? ''))).toEqual([]);
+    expect([...chrome.matchAll(/letter-spacing:\s*([^;]+)/g)].map((match) => match[1]?.trim())
+      .filter((value) => !value?.startsWith('var(--fga-track-'))).toEqual([]);
+    expect([...chrome.matchAll(/(?:^|;)\s*line-height:\s*([^;]+)/g)].map((match) => match[1]?.trim())
+      .filter((value) => !value?.startsWith('var(--fga-lh-'))).toEqual([]);
+  });
+
+  it('preserves vertical-only overflow and every ellipsis guard', () => {
+    expect(declarationsFor('.inspector-content')).toMatch(/overflow-y:\s*auto/);
+    expect(declarationsFor('.inspector-content')).toMatch(/overflow-x:\s*hidden/);
+    expect(rules.filter(([, value]) => /text-overflow:\s*ellipsis/.test(value)
+      && !(/overflow:\s*hidden/.test(value) && /white-space:\s*nowrap/.test(value)))).toEqual([]);
+    expect(chrome).not.toMatch(/@media[^{]*\(\s*(?:min|max)-width/);
+  });
+
+  it('keeps spacing, depth, focus, and applied 16px Lucide classes intentional', () => {
+    const offGrid: string[] = [];
+    for (const [selector, value] of rules) {
+      for (const match of value.matchAll(/(?:^|;)\s*(padding|margin|gap|row-gap|column-gap)\s*:\s*([^;]+)/g)) {
+        for (const part of (match[2] ?? '').trim().split(/\s+(?![^(]*\))/)) {
+          if (/^(0|auto|var\(--space-(hair|1|2|3)\)|var\(--fga-divider-gap\)|calc\(.*\))$/.test(part)) continue;
+          const pixels = /^(\d+)px$/.exec(part);
+          if (!pixels || Number(pixels[1]) % 4 !== 0) offGrid.push(`${selector}:${part}`);
+        }
+      }
+    }
+    expect(offGrid).toEqual([]);
+    expect(declarationsFor('.fga-icon')).toMatch(/width:\s*16px/);
+    expect(activityView).toContain("icon.classList.add('is-spinning')");
+    expect(activityView).toContain("iconWrap.className = 'log-icon-wrap'");
+    expect(chrome).not.toMatch(/background(?:-color)?:\s*var\(--fga-(hairline|hairline-soft|topedge)\)/);
+    expect(chrome).not.toMatch(/box-shadow:\s*inset|border-left:\s*(?!0)/);
+    for (const selector of ['.rail-control:focus-visible', '.tab-button:focus-visible', '.sync-btn:focus-visible', '.inline-link:focus-visible']) expect(declarationsFor(selector)).toMatch(/outline:\s*2px/);
+  });
+
+  it('uses exact reduced-motion coverage and no stale icon selectors', () => {
+    expect(chrome).not.toMatch(/transition[^;]*:\s*[^;]*\ball\b|transition[^;]*:[^;]*\blinear\b/);
+    const guards = [...html.matchAll(/@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{([\s\S]*?)\n\}/g)]
+      .map((match) => match[1] ?? '').join('\n');
+    for (const selector of ['.is-spinning', '.activity-row.is-new', '.rail-control']) expect(guards).toContain(selector);
+    expect(declarationsFor('.activity-row')).not.toMatch(/animation:/);
+    expect(declarationsFor('.activity-row.is-new')).toMatch(/animation:\s*fga-row-in/);
+    expect(html).not.toMatch(/#fga-dot|\.log-icon(?:\s|\{|\[|:)/);
+    expect(html).toContain('.log-icon-wrap[data-state="failed"]  .fga-icon');
+    expect(html).toContain('.activity-row.is-stale .fga-icon');
+  });
+});

--- a/tests/panel-model.test.ts
+++ b/tests/panel-model.test.ts
@@ -1,19 +1,13 @@
-// Panel view-model — the pure layer under the DOM controller (panel-ui.ts).
-// IA v2: statusSentence (Block 1) replaces stateView/troubleshootHint/compactMeta;
-// fileNote (Block 2) is new. The activity feed's own model lives in activity-feed.ts,
-// and its SENTENCE mapping in activity-sentence.ts — see their own test files.
 import { describe, it, expect } from 'vitest';
 import {
-  statusSentence, formatAge, showOnboarding, fileNote, PANEL_WIDTH, PANEL_HEIGHT,
+  statusSentence, formatAge, showOnboarding, fileNote,
+  RAIL_WIDTH, RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT,
+  viewportFor, shouldForceInspector,
   syncPromptLabel, syncResultLabel, syncNowLabel, shouldClearPendingCount,
   syncStartSentence, syncResultSentence, syncStuckSentence, syncSupersededSentence, SYNC_STUCK_TIMEOUT_MS,
   targetButtonLabel,
 } from '../plugin/src/ui/panel-model.ts';
-
 describe('statusSentence — Block 1: the problem and the next action, six branches', () => {
-  // Owner addendum 2026-07-30: success states are minimal (the tone dot already signals
-  // state); problem states keep problem + next action, trimmed to the shortest honest
-  // sentence, no filler words, no text glyphs (the … ban covers "Connecting…" too).
   it('connected — success tone, minimal (the dot already signals it)', () => {
     expect(statusSentence('connected', 0, true)).toEqual({
       text: 'Connected', tone: 'success',
@@ -43,7 +37,6 @@ describe('statusSentence — Block 1: the problem and the next action, six branc
     });
   });
 });
-
 describe('formatAge', () => {
   it('formatAge steps just-now → seconds → minutes → hours', () => {
     expect(formatAge(0)).toBe('just now');
@@ -54,7 +47,6 @@ describe('formatAge', () => {
     expect(formatAge(Number.NaN)).toBe('—');
   });
 });
-
 describe('showOnboarding — first-run only (survives the IA v2 cut, priority-1 content)', () => {
   it('shows while waiting and never connected', () => {
     expect(showOnboarding('disconnected', false)).toBe(true);
@@ -66,7 +58,6 @@ describe('showOnboarding — first-run only (survives the IA v2 cut, priority-1 
     expect(showOnboarding('handshake', false)).toBe(false);
   });
 });
-
 describe('fileNote — Block 2: honest answer to "which file will my command hit?"', () => {
   it('single file, this one is the target → "command target"', () => {
     expect(fileNote(1, true)).toBe('command target');
@@ -83,9 +74,6 @@ describe('fileNote — Block 2: honest answer to "which file will my command hit
     expect(fileNote(2, false)).toBe('1 other file — commands go elsewhere');
   });
 });
-
-// #35 P2 — `pinned` distinguishes "target because pinned" from "target because
-// most-recent"; omitted/false reproduces the pre-pin wording exactly (proven above).
 describe('fileNote — pinned distinction (#35 P2)', () => {
   it('single file, pinned target → "pinned target" (never "command target")', () => {
     expect(fileNote(1, true, true)).toBe('pinned target');
@@ -101,7 +89,6 @@ describe('fileNote — pinned distinction (#35 P2)', () => {
     expect(fileNote(1, true)).toBe('command target');
   });
 });
-
 describe('targetButtonLabel — the "Target this plugin" toggle (#35 P2)', () => {
   it('unpinned → invites the click', () => {
     expect(targetButtonLabel(false)).toBe('Target this plugin');
@@ -111,14 +98,22 @@ describe('targetButtonLabel — the "Target this plugin" toggle (#35 P2)', () =>
     expect(targetButtonLabel(true)).not.toBe(targetButtonLabel(false));
   });
 });
-
-describe('panel geometry (IA v2 — one opening size, no compact/expanded split)', () => {
-  it('the iframe opens 300×420', () => {
-    expect(PANEL_WIDTH).toBe(300);
-    expect(PANEL_HEIGHT).toBe(420);
+describe('adaptive panel geometry', () => {
+  it('maps named viewport modes to the only accepted dimensions', () => {
+    expect(viewportFor('rail')).toEqual({ width: 240, height: 44 });
+    expect(viewportFor('inspector')).toEqual({ width: 288, height: 280 });
+    expect([RAIL_WIDTH, RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT])
+      .toEqual([240, 44, 288, 280]);
+  });
+  it('forces text-bearing recovery only when it is actionable', () => {
+    expect(shouldForceInspector('disconnected', 0, false)).toBe(true);
+    expect(shouldForceInspector('probing', 9_000, false)).toBe(true);
+    expect(shouldForceInspector('probing', 10_000, true)).toBe(true);
+    expect(shouldForceInspector('disconnected', 0, true)).toBe(true);
+    expect(shouldForceInspector('handshake', 0, false)).toBe(false);
+    expect(shouldForceInspector('connected', 0, true)).toBe(false);
   });
 });
-
 describe('idle-commit prompt labels (spec 004 P4)', () => {
   it('syncPromptLabel pluralizes and floors count at 1', () => {
     expect(syncPromptLabel(1)).toBe('1 change ready');
@@ -134,27 +129,17 @@ describe('idle-commit prompt labels (spec 004 P4)', () => {
     expect(syncResultLabel(true, '')).toBe('Synced — done'); // empty summary → sane default
     expect(syncResultLabel(false, '   ')).toBe('Sync failed — failed');
   });
-
   it('syncResultLabel — unbound renders the bind command bare, not under a failure verdict', () => {
     const summary = 'No project bound for "VSF - PCP" — run: figma-agent bind --file "VSF - PCP" --dir <project>';
     expect(syncResultLabel(false, summary, true, true)).toBe(summary);
-    // ok=false is what the broker actually sends for an unbound refusal — proves `unbound`
-    // takes precedence over the "Sync failed" branch rather than being unreachable dead code.
     expect(syncResultLabel(false, summary, true, true)).not.toContain('Sync failed');
   });
-
   it('syncNowLabel — swaps to the bind hint on E_UNBOUND, reverts once bound (fix round, finding 2)', () => {
     expect(syncNowLabel(false)).toBe('Sync now');
     expect(syncNowLabel(true)).toBe('Bind & retry');
     expect(syncNowLabel(true)).not.toBe(syncNowLabel(false)); // the state machine's two branches
   });
 });
-
-// Owner addendum (task #145) — the Activity feed's OWN long-form sync sentences. These
-// bypass activitySentence()'s generic tool/count/name mapper entirely (that mapper is
-// exactly what collapsed a sync row to the bare word "Synced" — see ActivityRecord.sentence's
-// own doc). Three required cases per the review ruling: success with the kernel summary,
-// failure with the reason, and the unbound passthrough.
 describe('syncStartSentence — the pending Activity row (task #145)', () => {
   it('manual click names the file and what is about to happen', () => {
     expect(syncStartSentence('manual', 'VSF - PCP')).toBe('Sync started — checking VSF - PCP for pending Figma changes to apply');
@@ -164,25 +149,21 @@ describe('syncStartSentence — the pending Activity row (task #145)', () => {
     expect(syncStartSentence('auto', 'X')).not.toBe(syncStartSentence('manual', 'X'));
   });
 });
-
 describe('syncResultSentence — the resolved Activity row, three required cases (task #145)', () => {
   it('success carries the KERNEL SUMMARY verbatim, never collapsing to a bare "Synced"', () => {
     const s = syncResultSentence(true, '3 added, 1 updated, 2 deprecated', true, false, 'VSF - PCP');
     expect(s).toBe('Synced VSF - PCP — 3 added, 1 updated, 2 deprecated');
     expect(s).not.toBe('Synced'); // the exact regression this field exists to stop
   });
-
   it('success with nothing landed says so, distinct from a real sync', () => {
     expect(syncResultSentence(true, 'every new component still pending re-ingest', false, false, 'VSF - PCP'))
       .toBe('Nothing synced for VSF - PCP — every new component still pending re-ingest');
   });
-
   it('failure carries the REASON, never collapsing to a bare "Reconcile failed"', () => {
     const s = syncResultSentence(false, 'ui not runnable', true, false, 'VSF - PCP');
     expect(s).toBe('Sync failed for VSF - PCP — ui not runnable');
     expect(s).not.toBe('Reconcile failed');
   });
-
   it('unbound passes syncResultLabel\'s own bare message through UNWRAPPED (never "Sync failed for…")', () => {
     const summary = 'No project bound for "VSF - PCP" — run: figma-agent bind --file "VSF - PCP" --dir <project>';
     const s = syncResultSentence(false, summary, true, true, 'VSF - PCP');
@@ -190,7 +171,6 @@ describe('syncResultSentence — the resolved Activity row, three required cases
     expect(s).not.toContain('Sync failed');
   });
 });
-
 describe('syncStuckSentence — the bounded-timeout fallback (live-observed broker-restart gap)', () => {
   it('names the cause and the recovery action, never implies the sync itself is broken', () => {
     expect(syncStuckSentence()).toBe('Sync did not answer — the broker restarted mid-run; press Sync again');
@@ -200,20 +180,15 @@ describe('syncStuckSentence — the bounded-timeout fallback (live-observed brok
     expect(SYNC_STUCK_TIMEOUT_MS).toBeLessThan(120_000);
   });
 });
-
 describe('syncSupersededSentence — a second click resolves the first row (stage-4 fix round, minor 9)', () => {
   it('names the fact plainly — never implies the first sync itself failed', () => {
     expect(syncSupersededSentence()).toBe('Superseded by a newer sync');
     expect(syncSupersededSentence()).not.toContain('failed');
   });
 });
-
 describe('shouldClearPendingCount', () => {
   it('ONLY a genuine success clears the pending counter (closing round, defect #2)', () => {
     expect(shouldClearPendingCount(true)).toBe(true);
-    // false covers BOTH a real reconcile failure AND an E_UNBOUND refusal — either way,
-    // nothing applied, so retry must stay possible (the bug: it used to clear on any
-    // non-unbound outcome, including "a sync is already running").
     expect(shouldClearPendingCount(false)).toBe(false);
   });
 });

--- a/tests/panel-view-state.test.ts
+++ b/tests/panel-view-state.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BoundedKeySet, VIEW_KEY_LIMIT, applyActivityOutcome, connectionForce,
+  currentActivity, landTerminalActivity, unresolvedActivityCount,
+} from '../plugin/src/ui/panel-view-state.ts';
+import { renderFailureBadge } from '../plugin/src/ui/panel-activity-view.ts';
+import type { ActivityRecord } from '../plugin/src/ui/activity-feed.ts';
+
+const record = (id: string, pending: boolean, ok: boolean, at: number): ActivityRecord => ({
+  id, tool: 'EXEC_JS', pending, ok, ms: 0, at,
+});
+
+describe('keyed unresolved activity failures', () => {
+  it('does not let an unrelated success clear a failed request', () => {
+    let records = [record('A', true, true, 2), record('B', true, true, 1)];
+    const failures = new BoundedKeySet();
+    applyActivityOutcome(failures, 'B', false);
+    records = records.map((item) => item.id === 'B' ? { ...item, pending: false, ok: false } : item);
+    expect(currentActivity(records)?.id).toBe('A');
+    expect(unresolvedActivityCount(failures)).toBe(1);
+
+    applyActivityOutcome(failures, 'A', true);
+    records = records.map((item) => item.id === 'A' ? { ...item, pending: false, ok: true } : item);
+    expect(currentActivity(records)?.id).toBe('A');
+    expect(unresolvedActivityCount(failures)).toBe(1);
+    expect(failures.values()).toEqual(['B']);
+  });
+
+  it('clears only the matching request and bounds retained keys', () => {
+    const failures = new BoundedKeySet();
+    for (let index = 0; index < VIEW_KEY_LIMIT + 5; index += 1) failures.add(`request-${index}`);
+    expect(failures.size).toBe(VIEW_KEY_LIMIT);
+    expect(failures.has('request-0')).toBe(false);
+    applyActivityOutcome(failures, `request-${VIEW_KEY_LIMIT + 4}`, true);
+    expect(failures.size).toBe(VIEW_KEY_LIMIT - 1);
+  });
+
+  it('accounts for the 65th failure until Activity acknowledges the aggregate', () => {
+    const failures = new BoundedKeySet();
+    for (let index = 0; index < VIEW_KEY_LIMIT + 1; index += 1) failures.add(`failure-${index}`);
+    expect(failures.size).toBe(VIEW_KEY_LIMIT);
+    expect(failures.overflowCount).toBe(1);
+    expect(unresolvedActivityCount(failures)).toBe(65);
+    failures.acknowledge();
+    expect(unresolvedActivityCount(failures)).toBe(0);
+    expect(failures.overflowCount).toBe(0);
+  });
+
+  it('synthesizes a readable failure row for a terminal result after eviction', () => {
+    const records = Array.from({ length: 50 }, (_, index) => record(`new-${index}`, false, true, 100 - index));
+    const landed = landTerminalActivity(records, {
+      id: 'evicted-request', ok: false, ms: 42, result: 'Node no longer exists', code: 'E_NOT_FOUND',
+    }, 200);
+    expect(landed).toHaveLength(50);
+    expect(landed[0]).toMatchObject({ id: 'evicted-request', pending: false, ok: false, at: 200 });
+    expect(landed[0]?.sentence).toContain('Node no longer exists');
+  });
+
+  it('updates the visible and accessible failure badge on acknowledge', () => {
+    const attributes = new Map<string, string>();
+    const badge = { hidden: true, textContent: '', setAttribute: (name: string, value: string) => attributes.set(name, value) };
+    renderFailureBadge(badge, 65);
+    expect(badge).toMatchObject({ hidden: false, textContent: '65' });
+    expect(attributes.get('aria-label')).toBe('65 unresolved failures');
+    renderFailureBadge(badge, 0);
+    expect(badge).toMatchObject({ hidden: true, textContent: '' });
+    expect(attributes.get('aria-label')).toBe('0 unresolved failures');
+  });
+});
+
+describe('semantic connection force keys', () => {
+  it('reopens at the probe timeout after onboarding was already disclosed', () => {
+    expect(connectionForce('probing', 9_999, false, 7)).toEqual({
+      key: 'onboarding:7', kind: 'onboarding',
+    });
+    expect(connectionForce('probing', 10_000, false, 7)).toEqual({
+      key: 'probe-timeout:7', kind: 'probe-timeout',
+    });
+  });
+
+  it('distinguishes connection loss from first-run setup', () => {
+    expect(connectionForce('disconnected', 0, true, 8)).toEqual({
+      key: 'connection-lost:8', kind: 'connection-lost',
+    });
+    expect(connectionForce('connected', 0, true, 8)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Problem

The fixed plugin panel covered too much of the canvas on small screens and kept secondary diagnostics visible during normal work.

## Outcome

- Open as a minimal 240×44 agent rail with connection health and current work.
- Expand only on demand to a bounded 288×280 Activity, Context, or Details inspector.
- Use locally vendored Lucide SVGs with accessible labels, tooltips, focus states, and 32px targets.
- Keep concurrent failures visible by request, reopen actionable recovery states once, and preserve retryable sync state until genuine success.
- Keep viewport requests constrained to named rail and inspector modes.

## Tests

- `npm run typecheck`
- `npm run build`
- `npm test`
- `npm run lint:comments`
- Focused panel model, view-state, and craft regression coverage

## Acceptance status

Code and automated gates are complete. Live smoke in Figma is still pending, so the tracking issue remains open.

Refs #77
