### PR TITLE
fix(plugin): polish rail with status orb

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,25 @@
+# Third-Party Notices
+
+## thinking-orbs 0.3.1
+
+Source: https://github.com/Jakubantalik/thinking-orbs
+License: MIT
+Copyright (c) 2026 Jakub Antalik
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@types/ws": "^8.5.10",
         "esbuild": "^0.24.0",
         "playwright-core": "^1.62.1",
+        "thinking-orbs": "0.3.1",
         "typescript": "^5.6.0",
         "vitest": "^4.1.7"
       },
@@ -1702,6 +1703,17 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rolldown": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.1.tgz",
@@ -1798,6 +1810,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/thinking-orbs": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/thinking-orbs/-/thinking-orbs-0.3.1.tgz",
+      "integrity": "sha512-3BG1aeB1RUTxItCml/BBuIz5JRM4kZqGuyx+vouv0fXTtcR9ZNoKjWGneHPx94y74GxgArwJZ1qbJR5dt54kSw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0"
       }
     },
     "node_modules/tinybench": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "@types/ws": "^8.5.10",
     "esbuild": "^0.24.0",
     "playwright-core": "^1.62.1",
+    "thinking-orbs": "0.3.1",
     "typescript": "^5.6.0",
     "vitest": "^4.1.7"
   },

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -5338,12 +5338,16 @@
   }
 
   // plugin/src/ui/panel-model.ts
-  var RAIL_WIDTH = 240;
+  var RAIL_COMPACT_WIDTH = 200;
+  var RAIL_ONE_ACTION_WIDTH = 220;
+  var RAIL_TWO_ACTIONS_WIDTH = 240;
   var RAIL_HEIGHT = 44;
   var INSPECTOR_WIDTH = 288;
   var INSPECTOR_HEIGHT = 280;
   function viewportFor(mode) {
-    return mode === "inspector" ? { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT } : { width: RAIL_WIDTH, height: RAIL_HEIGHT };
+    if (mode === "inspector") return { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT };
+    const width = mode === "rail-compact" ? RAIL_COMPACT_WIDTH : mode === "rail-one-action" ? RAIL_ONE_ACTION_WIDTH : RAIL_TWO_ACTIONS_WIDTH;
+    return { width, height: RAIL_HEIGHT };
   }
 
   // plugin/src/main/readonly-guard.ts
@@ -5366,7 +5370,7 @@
   // plugin/src/main/main.ts
   figma.showUI(__html__, {
     visible: true,
-    width: RAIL_WIDTH,
+    width: RAIL_COMPACT_WIDTH,
     height: RAIL_HEIGHT,
     title: "design:os by JANG",
     themeColors: true
@@ -5588,7 +5592,7 @@
   });
   figma.ui.onmessage = async (msg) => {
     const chrome = msg;
-    if (chrome && chrome.type === "PANEL_VIEWPORT" && (chrome.mode === "rail" || chrome.mode === "inspector")) {
+    if (chrome && chrome.type === "PANEL_VIEWPORT" && (chrome.mode === "rail-compact" || chrome.mode === "rail-one-action" || chrome.mode === "rail-two-actions" || chrome.mode === "inspector")) {
       const viewport = viewportFor(chrome.mode);
       figma.ui.resize(viewport.width, viewport.height);
       return;

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -47,13 +47,13 @@ import {
   writeEdgeCorrections,
 } from './correction-edge-store';
 import type { CorrectionEvent } from '../../../shared/supervised-memory';
-import { RAIL_WIDTH, RAIL_HEIGHT, viewportFor } from '../ui/panel-model';
+import { RAIL_COMPACT_WIDTH, RAIL_HEIGHT, viewportFor } from '../ui/panel-model';
 import {
   createReadOnlyGuardState, isReadOnlyExecJs, recordDocumentChangeBatch,
   snapshotChangeEvents, violatedSinceSnapshot,
 } from './readonly-guard';
 
-// The adaptive panel opens as a rail. The iframe can request one of two named modes;
+// The adaptive panel opens as its smallest rail. The iframe can request only named modes;
 // main owns the dimensions and never trusts arbitrary width/height input.
 //
 // Owner decree 2026-07-30: the plugin window's own (host-drawn) title bar cannot be
@@ -68,7 +68,7 @@ import {
 // `html.figma-light { ... }` override block (a sibling of the default dark :root) is
 // what actually repaints every color token; this flag is what makes that class exist.
 figma.showUI(__html__, {
-  visible: true, width: RAIL_WIDTH, height: RAIL_HEIGHT, title: 'design:os by JANG', themeColors: true,
+  visible: true, width: RAIL_COMPACT_WIDTH, height: RAIL_HEIGHT, title: 'design:os by JANG', themeColors: true,
 });
 
 // Absorption phase-03 (FigJam) — which design-only boot capabilities this session
@@ -495,7 +495,8 @@ interface UiRequest {
 figma.ui.onmessage = async (msg: unknown) => {
   const chrome = msg as { type?: unknown; mode?: unknown; data?: unknown } | null;
   if (chrome && chrome.type === 'PANEL_VIEWPORT'
-      && (chrome.mode === 'rail' || chrome.mode === 'inspector')) {
+      && (chrome.mode === 'rail-compact' || chrome.mode === 'rail-one-action'
+        || chrome.mode === 'rail-two-actions' || chrome.mode === 'inspector')) {
     const viewport = viewportFor(chrome.mode);
     figma.ui.resize(viewport.width, viewport.height);
     return;

--- a/plugin/src/ui/panel-activity-view.ts
+++ b/plugin/src/ui/panel-activity-view.ts
@@ -25,6 +25,8 @@ export interface FailureBadgeTarget {
   setAttribute(name: string, value: string): void;
 }
 
+export type ActivityRailPhase = 'idle' | 'pending' | 'complete' | 'failed';
+
 export function renderFailureBadge(target: FailureBadgeTarget, count: number): void {
   target.hidden = count === 0;
   target.textContent = count === 0 ? '' : String(count);
@@ -90,6 +92,11 @@ export class ActivityView {
 
   acknowledgeFailures(): void { this.failures.acknowledge(); }
 
+  railPhase(): ActivityRailPhase {
+    const current = currentActivity(this.records);
+    return !current ? 'idle' : current.pending ? 'pending' : current.ok ? 'complete' : 'failed';
+  }
+
   render(now = Date.now()): void {
     const shown = this.records.slice(0, 20);
     if (shown.length === 0) {
@@ -115,16 +122,14 @@ export class ActivityView {
     renderFailureBadge(this.failureCount, count);
     const suffix = count === 0 ? '' : `. ${count} unresolved failure${count === 1 ? '' : 's'}`;
     if (!current) {
-      replaceIcon(this.currentButton, 'activity');
       this.currentLabel.textContent = 'Idle';
       this.currentButton.className = `rail-control current-control${count ? ' tone-danger' : ''}`;
       labelControl(this.currentButton, `Current activity: Idle${suffix}`);
       return;
     }
     const state = current.pending ? 'running' : current.ok ? 'complete' : 'failed';
-    replaceIcon(this.currentButton, current.pending ? 'loader-circle' : current.ok ? 'circle-check' : 'circle-x', current.pending);
     this.currentLabel.textContent = sentence(current);
-    this.currentButton.className = `rail-control current-control tone-${count ? 'danger' : current.pending ? 'warning' : current.ok ? 'success' : 'danger'}`;
+    this.currentButton.className = `rail-control current-control${count ? ' tone-danger' : ''}`;
     labelControl(this.currentButton, `Current activity ${state}: ${sentence(current)}${suffix}`);
   }
 }

--- a/plugin/src/ui/panel-model.ts
+++ b/plugin/src/ui/panel-model.ts
@@ -1,12 +1,15 @@
 import type { ConnectionState } from '../../../shared/protocol';
 
 export type Tone = 'success' | 'warning' | 'info' | 'muted';
-export const RAIL_WIDTH = 240;
+export const RAIL_COMPACT_WIDTH = 200;
+export const RAIL_ONE_ACTION_WIDTH = 220;
+export const RAIL_TWO_ACTIONS_WIDTH = 240;
 export const RAIL_HEIGHT = 44;
 export const INSPECTOR_WIDTH = 288;
 export const INSPECTOR_HEIGHT = 280;
 export const SYNC_STUCK_TIMEOUT_MS = 30_000;
-export type ViewportMode = 'rail' | 'inspector';
+export type RailViewportMode = 'rail-compact' | 'rail-one-action' | 'rail-two-actions';
+export type ViewportMode = RailViewportMode | 'inspector';
 export type SyncSource = 'manual' | 'auto';
 
 export function statusSentence(state: ConnectionState, ageMs: number, hadConnection: boolean): { text: string; tone: Tone } {
@@ -34,8 +37,17 @@ export function showOnboarding(state: ConnectionState, hadConnection: boolean): 
   return !hadConnection && (state === 'disconnected' || state === 'probing');
 }
 
+export function railViewportMode(targetVisible: boolean, syncVisible: boolean): RailViewportMode {
+  const actions = Number(targetVisible) + Number(syncVisible);
+  return actions === 0 ? 'rail-compact' : actions === 1 ? 'rail-one-action' : 'rail-two-actions';
+}
+
 export function viewportFor(mode: ViewportMode): { width: number; height: number } {
-  return mode === 'inspector' ? { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT } : { width: RAIL_WIDTH, height: RAIL_HEIGHT };
+  if (mode === 'inspector') return { width: INSPECTOR_WIDTH, height: INSPECTOR_HEIGHT };
+  const width = mode === 'rail-compact'
+    ? RAIL_COMPACT_WIDTH
+    : mode === 'rail-one-action' ? RAIL_ONE_ACTION_WIDTH : RAIL_TWO_ACTIONS_WIDTH;
+  return { width, height: RAIL_HEIGHT };
 }
 
 export function shouldForceInspector(state: ConnectionState, ageMs: number, hadConnection: boolean): boolean {

--- a/plugin/src/ui/panel-ui.ts
+++ b/plugin/src/ui/panel-ui.ts
@@ -6,9 +6,10 @@ import {
   fileNote, showOnboarding, statusSentence, syncNowLabel, syncPromptLabel,
   syncResultLabel, syncResultSentence, syncStartSentence, syncStuckSentence,
   syncSupersededSentence, targetButtonLabel, shouldClearPendingCount,
-  SYNC_STUCK_TIMEOUT_MS, type ViewportMode,
+  railViewportMode, SYNC_STUCK_TIMEOUT_MS, type ViewportMode,
 } from './panel-model';
 import { BoundedKeySet, connectionForce } from './panel-view-state';
+import { mountThinkingOrb, orbPresentation } from './thinking-orb';
 
 declare const __BUILD_ID__: string;
 const el = (id: string): HTMLElement => document.getElementById(id) as HTMLElement;
@@ -28,6 +29,7 @@ const syncMsg = el('fga-sync-msg');
 const syncNowBtn = btn('fga-sync-now');
 const targetBtn = btn('fga-target-btn');
 const activityView = new ActivityView(el('fga-activity'), currentBtn, el('fga-current-label'), el('fga-failure-count'));
+const thinkingOrb = mountThinkingOrb(connectionBtn);
 type Tab = 'activity' | 'context' | 'details';
 const tabNames: Tab[] = ['activity', 'context', 'details'];
 const tabs = Object.fromEntries(tabNames.map((name) => [name, btn(`fga-tab-${name}`)])) as Record<Tab, HTMLButtonElement>;
@@ -40,9 +42,18 @@ let peersCount = 1, peersIsActiveTarget = true, peersPinned = false, pendingSync
 let selectedTab: Tab = 'activity', inspectorOpen = false, userExpanded = false, forcedOnly = false;
 let connectionFailure = false, syncFailure = false, connectionTransition = 0;
 let previousConnectionState: ConnectionState | null = null;
+let lastViewportMode: ViewportMode = 'rail-compact';
 const disclosed = new BoundedKeySet();
 
-function viewport(mode: ViewportMode): void { parent.postMessage({ pluginMessage: { type: 'PANEL_VIEWPORT', mode } }, '*'); }
+function viewport(mode: ViewportMode): void {
+  if (lastViewportMode === mode) return;
+  lastViewportMode = mode;
+  parent.postMessage({ pluginMessage: { type: 'PANEL_VIEWPORT', mode } }, '*');
+}
+function syncViewport(): void {
+  const railMode = railViewportMode(!targetRailBtn.hidden, !syncRailBtn.hidden);
+  viewport(inspectorOpen ? 'inspector' : railMode);
+}
 function selectTab(tab: Tab, focus = false): void {
   selectedTab = tab;
   for (const name of tabNames) {
@@ -62,7 +73,7 @@ function setInspector(open: boolean, tab = selectedTab, intent = false): void {
   labelControl(toggleBtn, open ? 'Close inspector' : 'Open inspector');
   replaceIcon(toggleBtn, open ? 'chevron-up' : 'chevron-down');
   if (open) selectTab(tab);
-  viewport(open ? 'inspector' : 'rail');
+  syncViewport();
 }
 function forceOnce(key: string, tab: Tab): void {
   if (disclosed.has(key)) return;
@@ -72,7 +83,18 @@ function forceOnce(key: string, tab: Tab): void {
 }
 function unresolved(): boolean { return connectionFailure || syncFailure || activityView.failures.unresolvedCount > 0; }
 function updateSignal(): void { panel.dataset.unresolved = String(unresolved()); }
-function acknowledgeActivity(): void { activityView.acknowledgeFailures(); updateSignal(); activityView.render(); }
+function renderOrb(): void {
+  const orb = orbPresentation({
+    connection: payload?.state ?? 'disconnected', connectionFailure, syncFailure,
+    activityFailure: activityView.failures.unresolvedCount > 0,
+    activityPending: activityView.railPhase() === 'pending',
+    syncPending: pendingSyncCount > 0,
+  });
+  thinkingOrb.update(orb);
+  connectionBtn.className = 'rail-control';
+  labelControl(connectionBtn, `${orb.status}. Open details`);
+}
+function acknowledgeActivity(): void { activityView.acknowledgeFailures(); updateSignal(); activityView.render(); renderOrb(); }
 function openUser(tab: Tab): void { if (tab === 'activity') acknowledgeActivity(); setInspector(true, tab, true); }
 function context(): void {
   el('fga-ctx-file').textContent = sceneFile || '—'; el('fga-ctx-file').title = sceneFile;
@@ -86,21 +108,23 @@ function context(): void {
     replaceIcon(targetRailBtn, peersPinned ? 'pin' : 'files');
     targetRailBtn.classList.toggle('tone-info', peersIsActiveTarget);
   }
+  syncViewport();
 }
 function render(): void {
   const now = Date.now(), state: ConnectionState = payload?.state ?? 'disconnected', age = payload ? now - payload.since : 0;
   const view = statusSentence(state, age, hadConnection);
   sentence.textContent = view.text; sentence.dataset.tone = view.tone;
   onboarding.hidden = !showOnboarding(state, hadConnection);
-  replaceIcon(connectionBtn, state === 'connected' ? 'circle-check' : state === 'probing' || state === 'handshake' ? 'loader-circle' : 'circle-off', state === 'probing' || state === 'handshake');
-  connectionBtn.className = `rail-control tone-${view.tone}`; labelControl(connectionBtn, view.text);
   context(); activityView.render(now);
   const showSync = pendingSyncCount > 0 || syncFailure;
   syncRailBtn.hidden = !showSync;
   if (showSync) { syncBadge.textContent = String(Math.max(1, pendingSyncCount)); replaceIcon(syncRailBtn, syncFailure ? 'circle-x' : 'refresh-cw'); syncRailBtn.className = `rail-control tone-${syncFailure ? 'danger' : 'warning'}`; labelControl(syncRailBtn, syncFailure ? `${syncMsg.textContent || 'Sync failed'}. Open sync actions` : `${syncPromptLabel(pendingSyncCount)}. Open sync actions`); }
+  syncViewport();
   const force = connectionForce(state, age, hadConnection, connectionTransition);
   connectionFailure = force?.kind === 'probe-timeout' || force?.kind === 'connection-lost';
-  updateSignal(); if (force) forceOnce(force.key, 'details');
+  updateSignal();
+  renderOrb();
+  if (force) forceOnce(force.key, 'details');
   if (state === 'connected' && forcedOnly && !userExpanded && !unresolved()) { forcedOnly = false; setInspector(false); }
 }
 
@@ -115,6 +139,7 @@ for (const tab of tabNames) {
   tabs[tab].onkeydown = (event) => { const index = tabNames.indexOf(tab); const target = event.key === 'ArrowRight' ? tabNames[(index + 1) % 3] : event.key === 'ArrowLeft' ? tabNames[(index + 2) % 3] : event.key === 'Home' ? tabNames[0] : event.key === 'End' ? tabNames[2] : null; if (target) { event.preventDefault(); if (target === 'activity') acknowledgeActivity(); selectTab(target, true); } };
 }
 document.addEventListener('keydown', (event) => { if (event.key === 'Escape' && inspectorOpen) { event.preventDefault(); setInspector(false, selectedTab, true); toggleBtn.focus(); } });
+window.addEventListener('pagehide', () => thinkingOrb.dispose(), { once: true });
 window.addEventListener('figma-agent:conn-state', (event) => { const next = (event as CustomEvent).detail as ConnectionStatePayload | undefined; if (!next || typeof next.state !== 'string') return; if (next.state !== previousConnectionState) connectionTransition += 1; previousConnectionState = next.state; if (next.state === 'connected') hadConnection = true; payload = next; render(); });
 window.addEventListener('figma-agent:activity', (event) => { const detail = (event as CustomEvent).detail as { phase?: unknown } | undefined; if (detail?.phase === 'done') { const patch = toActivityResult(detail); if (!patch) return; activityView.resolve(patch); if (!patch.ok) forceOnce(`activity-failure:${patch.id}`, 'activity'); } else { const record = toActivityRecord(detail); if (!record) return; activityView.push(record); } updateSignal(); render(); });
 window.addEventListener('figma-agent:peers', (event) => { const data = (event as CustomEvent).detail as { count?: unknown; isActiveTarget?: unknown; pinned?: unknown } | undefined; if (typeof data?.count === 'number' && Number.isFinite(data.count)) peersCount = data.count; if (typeof data?.isActiveTarget === 'boolean') peersIsActiveTarget = data.isActiveTarget; peersPinned = data?.pinned === true; context(); });

--- a/plugin/src/ui/panel.html
+++ b/plugin/src/ui/panel.html
@@ -821,21 +821,21 @@ code {
   .inline-link, .sync-prompt, .status-sentence, .activity-row { transition: none; }
 }
 
-/* Adaptive Agent Rail. The host viewport owns the two exact sizes; this document owns
+/* Adaptive Agent Rail. The host viewport owns the named sizes; this document owns
    disclosure within them. Existing theme tokens remain the color source of truth. */
 body { overflow: hidden; }
 .panel { height: 100%; overflow: hidden; }
 .agent-rail {
   height: 44px;
   padding: 0 var(--space-1);
-  display: grid;
-  grid-template-columns: 32px minmax(32px, 1fr) auto auto 32px;
+  display: flex;
   gap: var(--space-hair);
   align-items: center;
   background: var(--fga-chrome);
 }
 .rail-control {
   position: relative;
+  flex: 0 0 32px;
   width: 32px;
   min-width: 32px;
   height: 32px;
@@ -857,8 +857,10 @@ body { overflow: hidden; }
   outline: 2px solid var(--fga-focus);
   outline-offset: 1px;
 }
-.current-control { width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
+.current-control { flex: 1 1 auto; width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
 .current-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.thinking-orb { display: block; width: 20px; height: 20px; }
+.thinking-orb[data-dimmed="true"] { opacity: 0.5; }
 .failure-count {
   min-width: 14px;
   padding: 0 var(--space-hair);

--- a/plugin/src/ui/thinking-orb.ts
+++ b/plugin/src/ui/thinking-orb.ts
@@ -1,0 +1,133 @@
+import type { ConnectionState } from '../../../shared/protocol';
+import { MODE_DRAWS, resolvePreset, type OrbState } from 'thinking-orbs/engine';
+
+const ORB_SIZE = 20;
+const STATIC_TIME = 0.75;
+
+export interface OrbSignals {
+  connection: ConnectionState;
+  connectionFailure: boolean;
+  syncFailure: boolean;
+  activityFailure: boolean;
+  activityPending: boolean;
+  syncPending: boolean;
+}
+
+export interface OrbPresentation {
+  state: OrbState;
+  paused: boolean;
+  dimmed: boolean;
+  status: 'Connected' | 'Processing' | 'Connecting' | 'Disconnected' | 'Needs attention';
+}
+
+export function orbPresentation(signals: OrbSignals): OrbPresentation {
+  if (signals.connectionFailure || signals.syncFailure || signals.activityFailure) {
+    return { state: 'shaping', paused: true, dimmed: false, status: 'Needs attention' };
+  }
+  if (signals.connection === 'probing' || signals.connection === 'handshake') {
+    return { state: 'connecting', paused: false, dimmed: false, status: 'Connecting' };
+  }
+  if (signals.connection === 'disconnected') {
+    return { state: 'connecting', paused: true, dimmed: true, status: 'Disconnected' };
+  }
+  if (signals.activityPending || signals.syncPending) {
+    return { state: 'working', paused: false, dimmed: false, status: 'Processing' };
+  }
+  return { state: 'breathing', paused: false, dimmed: false, status: 'Connected' };
+}
+
+export interface ThinkingOrbController {
+  update(presentation: OrbPresentation): void;
+  dispose(): void;
+}
+
+export function mountThinkingOrb(target: HTMLElement): ThinkingOrbController {
+  const canvas = document.createElement('canvas');
+  canvas.className = 'thinking-orb';
+  canvas.setAttribute('aria-hidden', 'true');
+  target.append(canvas);
+
+  const context = canvas.getContext('2d');
+  if (!context) {
+    canvas.remove();
+    return { update: () => {}, dispose: () => {} };
+  }
+  const drawingContext: CanvasRenderingContext2D = context;
+
+  const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
+  let presentation = orbPresentation({
+    connection: 'disconnected', connectionFailure: false, syncFailure: false,
+    activityFailure: false, activityPending: false, syncPending: false,
+  });
+  canvas.dataset.dimmed = String(presentation.dimmed);
+  let frameId: number | null = null;
+  let disposed = false;
+
+  const isDark = (): boolean => !document.documentElement.classList.contains('figma-light');
+  const isAnimated = (): boolean => !presentation.paused && !reducedMotion.matches && !document.hidden;
+
+  function prepareCanvas(): void {
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const pixels = Math.round(ORB_SIZE * dpr);
+    if (canvas.width !== pixels || canvas.height !== pixels) {
+      canvas.width = pixels;
+      canvas.height = pixels;
+    }
+    drawingContext.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+
+  function paint(now: number): void {
+    prepareCanvas();
+    drawingContext.clearRect(0, 0, ORB_SIZE, ORB_SIZE);
+    const preset = resolvePreset(presentation.state, ORB_SIZE);
+    const time = isAnimated() ? now / 1000 * preset.speed : STATIC_TIME * preset.speed;
+    MODE_DRAWS[preset.mode](drawingContext, ORB_SIZE, time, isDark(), preset.opts);
+  }
+
+  function stop(): void {
+    if (frameId === null) return;
+    cancelAnimationFrame(frameId);
+    frameId = null;
+  }
+
+  function schedule(): void {
+    if (disposed || !isAnimated() || frameId !== null) return;
+    frameId = requestAnimationFrame((now) => {
+      frameId = null;
+      paint(now);
+      schedule();
+    });
+  }
+
+  function refresh(): void {
+    stop();
+    paint(performance.now());
+    schedule();
+  }
+
+  const onVisibilityChange = (): void => refresh();
+  const onMotionChange = (): void => refresh();
+  document.addEventListener('visibilitychange', onVisibilityChange);
+  reducedMotion.addEventListener('change', onMotionChange);
+  const themeObserver = new MutationObserver(refresh);
+  themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+
+  refresh();
+  return {
+    update(next): void {
+      if (next.state === presentation.state && next.paused === presentation.paused
+          && next.dimmed === presentation.dimmed && next.status === presentation.status) return;
+      presentation = next;
+      canvas.dataset.dimmed = String(next.dimmed);
+      refresh();
+    },
+    dispose(): void {
+      disposed = true;
+      stop();
+      document.removeEventListener('visibilitychange', onVisibilityChange);
+      reducedMotion.removeEventListener('change', onMotionChange);
+      themeObserver.disconnect();
+      canvas.remove();
+    },
+  };
+}

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -821,21 +821,21 @@ code {
   .inline-link, .sync-prompt, .status-sentence, .activity-row { transition: none; }
 }
 
-/* Adaptive Agent Rail. The host viewport owns the two exact sizes; this document owns
+/* Adaptive Agent Rail. The host viewport owns the named sizes; this document owns
    disclosure within them. Existing theme tokens remain the color source of truth. */
 body { overflow: hidden; }
 .panel { height: 100%; overflow: hidden; }
 .agent-rail {
   height: 44px;
   padding: 0 var(--space-1);
-  display: grid;
-  grid-template-columns: 32px minmax(32px, 1fr) auto auto 32px;
+  display: flex;
   gap: var(--space-hair);
   align-items: center;
   background: var(--fga-chrome);
 }
 .rail-control {
   position: relative;
+  flex: 0 0 32px;
   width: 32px;
   min-width: 32px;
   height: 32px;
@@ -857,8 +857,10 @@ body { overflow: hidden; }
   outline: 2px solid var(--fga-focus);
   outline-offset: 1px;
 }
-.current-control { width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
+.current-control { flex: 1 1 auto; width: auto; min-width: 32px; justify-content: flex-start; padding: 0 var(--space-1); }
 .current-label { min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.thinking-orb { display: block; width: 20px; height: 20px; }
+.thinking-orb[data-dimmed="true"] { opacity: 0.5; }
 .failure-count {
   min-width: 14px;
   padding: 0 var(--space-hair);
@@ -1401,6 +1403,10 @@ body { overflow: hidden; }
     acknowledgeFailures() {
       this.failures.acknowledge();
     }
+    railPhase() {
+      const current = currentActivity(this.records);
+      return !current ? "idle" : current.pending ? "pending" : current.ok ? "complete" : "failed";
+    }
     render(now = Date.now()) {
       const shown = this.records.slice(0, 20);
       if (shown.length === 0) {
@@ -1425,16 +1431,14 @@ body { overflow: hidden; }
       renderFailureBadge(this.failureCount, count);
       const suffix = count === 0 ? "" : `. ${count} unresolved failure${count === 1 ? "" : "s"}`;
       if (!current) {
-        replaceIcon(this.currentButton, "activity");
         this.currentLabel.textContent = "Idle";
         this.currentButton.className = `rail-control current-control${count ? " tone-danger" : ""}`;
         labelControl(this.currentButton, `Current activity: Idle${suffix}`);
         return;
       }
       const state = current.pending ? "running" : current.ok ? "complete" : "failed";
-      replaceIcon(this.currentButton, current.pending ? "loader-circle" : current.ok ? "circle-check" : "circle-x", current.pending);
       this.currentLabel.textContent = sentence(current);
-      this.currentButton.className = `rail-control current-control tone-${count ? "danger" : current.pending ? "warning" : current.ok ? "success" : "danger"}`;
+      this.currentButton.className = `rail-control current-control${count ? " tone-danger" : ""}`;
       labelControl(this.currentButton, `Current activity ${state}: ${sentence(current)}${suffix}`);
     }
   };
@@ -1449,6 +1453,10 @@ body { overflow: hidden; }
   }
   function showOnboarding(state, hadConnection2) {
     return !hadConnection2 && (state === "disconnected" || state === "probing");
+  }
+  function railViewportMode(targetVisible, syncVisible) {
+    const actions = Number(targetVisible) + Number(syncVisible);
+    return actions === 0 ? "rail-compact" : actions === 1 ? "rail-one-action" : "rail-two-actions";
   }
   function fileNote(count, active, pinned = false) {
     if (count <= 1) return active ? pinned ? "pinned target" : "command target" : "";
@@ -1492,6 +1500,677 @@ body { overflow: hidden; }
     return ok === true;
   }
 
+  // node_modules/thinking-orbs/dist/engine.es.js
+  function U(n, s, t) {
+    return n + (s - n) * t;
+  }
+  function nt(n) {
+    return n - Math.floor(n);
+  }
+  function G(n, s) {
+    const t = Math.floor(n), r = Math.floor(s);
+    let a = n - t, o = s - r;
+    a = a * a * (3 - 2 * a), o = o * o * (3 - 2 * o);
+    const c = E(t, r), M = E(t + 1, r), h = E(t, r + 1), m = E(t + 1, r + 1);
+    return c + (M - c) * a + (h - c) * o + (c - M - h + m) * a * o;
+  }
+  function E(n, s) {
+    const t = Math.sin(n * 12.9898 + s * 78.233) * 43758.5453;
+    return t - Math.floor(t);
+  }
+  function J(n, s) {
+    const t = Math.PI * (3 - Math.sqrt(5)), r = 1 - 2 * (n + 0.5) / s, a = Math.sqrt(1 - r * r), o = n * t;
+    return [a * Math.cos(o), r, a * Math.sin(o)];
+  }
+  function et(n, s) {
+    return Math.atan2(Math.sin(n - s), Math.cos(n - s));
+  }
+  function _(n, s, t, r, a) {
+    const o = Math.sin(s), c = Math.cos(s), M = Math.sin(n), h = Math.cos(n);
+    return (m, D, p) => {
+      const e = m * h + p * M, l = -m * M + p * h, R = D * c - l * o, w = D * o + l * c;
+      return [t + e * a, r - R * a, w];
+    };
+  }
+  function rt(n, s, t, r = 0.3) {
+    for (const a of s) {
+      const o = a.a ?? 1, c = Math.min(1, Math.max(0, a.white)), M = Math.round((t ? 1 - c : c) * 255);
+      n.fillStyle = `rgba(${M},${M},${M},${o})`, n.beginPath(), n.arc(a.x, a.y, a.r, 0, Math.PI * 2), n.fill();
+    }
+  }
+  function it(n, s, t) {
+    for (const r of s) {
+      const a = r.a ?? 1, o = Math.min(1, Math.max(0, r.white)), c = Math.round((t ? 1 - o : o) * 255);
+      n.strokeStyle = `rgba(${c},${c},${c},${a})`, n.lineWidth = r.w, n.beginPath(), n.moveTo(r.x1, r.y1), n.lineTo(r.x2, r.y2), n.stroke();
+    }
+  }
+  function L(n, s, t = 0.3) {
+    const r = [];
+    for (const a of n)
+      (a.a ?? 1) < 0.02 || (a.r = Math.max(t, a.r), r.push(a));
+    return r.sort((a, o) => a.z - o.z), { dots: r, lines: s.filter((a) => (a.a ?? 1) >= 0.02) };
+  }
+  function ht(n, s, t) {
+    s.lines.length && it(n, s.lines, t), rt(n, s.dots, t);
+  }
+  function $(n, s) {
+    return (n / 300) ** s;
+  }
+  var Mt = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.76, c = _(s * 0.4, 0.3, r, a, 1), M = $(n, t.rsPow ?? 0.6), h = [], m = t.ghostN ?? 150;
+    for (let e = 0; e < m; e++) {
+      const l = J(e, m), [R, w, i] = c(l[0] * o, l[1] * o, l[2] * o), u = (i / o + 1) / 2;
+      h.push({ x: R, y: w, z: i, r: 0.8 * M, white: 0.78, a: 0.1 + 0.22 * u });
+    }
+    const D = t.strandN ?? 52, p = t.turns ?? 3;
+    for (let e = 0; e < 3; e++) {
+      const l = e / 3 * 2 * Math.PI;
+      for (let R = 0; R < D; R++) {
+        const w = (nt(R / D + s * 0.045) * 2 - 1) * 0.96, i = Math.sqrt(Math.max(0, 1 - w * w)), u = Math.min(1, (1 - Math.abs(w)) / 0.1), y = w * Math.PI * p + l, b = 1 + 0.075 * Math.sin(w * Math.PI * p * 2 + l * 2 + s * 0.8), f = i * o * b, [P, x, g] = c(Math.cos(y) * f, w * o * b, Math.sin(y) * f), d = (g / o + 1) / 2;
+        h.push({
+          x: P,
+          y: x,
+          z: g,
+          r: ((t.rBase ?? 1.2) + (t.rDepth ?? 1.8) * d) * M,
+          white: 0.55 - 0.45 * d,
+          a: u * (0.45 + 0.55 * d)
+        });
+      }
+    }
+    return L(h, [], t.rMin);
+  };
+  function lt(n, s, t, r) {
+    const a = 2 * s * t + r, o = n % a, c = new Array(s).fill(0);
+    let M = -1;
+    if (o < 2 * s * t) {
+      const h = Math.floor(o / t), m = (o - h * t) / t, p = 1 - (1 - Math.min(1, m / 0.7)) ** 3;
+      if (h < s) {
+        for (let e = 0; e < h; e++) c[e] = 1;
+        c[h] = p, M = h;
+      } else {
+        const e = 2 * s - 1 - h;
+        for (let l = 0; l < e; l++) c[l] = 1;
+        c[e] = 1 - p, M = e;
+      }
+    }
+    return { amount: c, active: M };
+  }
+  function pt(n, s, t) {
+    let [r, a, o] = n, c = false;
+    for (let M = 0; M < s.length; M++) {
+      if (t.amount[M] <= 0) continue;
+      const h = s[M], m = h.axis === 0 ? r : h.axis === 1 ? a : o;
+      if (m < h.lo || m >= h.hi) continue;
+      M === t.active && (c = true);
+      const D = h.ang * t.amount[M], p = Math.cos(D), e = Math.sin(D);
+      if (h.axis === 0) {
+        const l = a * p - o * e;
+        o = a * e + o * p, a = l;
+      } else if (h.axis === 1) {
+        const l = r * p + o * e;
+        o = -r * e + o * p, r = l;
+      } else {
+        const l = r * p - a * e;
+        a = r * e + a * p, r = l;
+      }
+    }
+    return [r, a, o, c];
+  }
+  function ut(n) {
+    const s = [];
+    for (let t = 0; t < n; t++) {
+      const r = Math.min(2, Math.floor(E(t, 2.3) * 3)), a = -1 + 0.5 * Math.min(3, Math.floor(E(t, 5.9) * 4)), o = E(t, 7.7) < 0.5 ? 1 : -1;
+      s.push({ axis: r, lo: a, hi: a + 0.5, ang: o * Math.PI / 2 });
+    }
+    return s;
+  }
+  var ft = (n, s, t) => {
+    const a = n / 2, o = n / 2, c = n / 2 * 0.82, M = 0.4 + 0.06 * Math.sin(s * 0.35), h = _(s * 0.5, M, a, o, c), m = s * (0.5 + (1.7 - 0.5) * (t.scanMul ?? 1)), D = $(n, t.rsPow ?? 0.6), p = t.dimBase ?? 1, e = [], l = t.latRings ?? 17, R = t.lonDensity ?? 44;
+    for (let w = 0; w <= l; w++) {
+      const i = -Math.PI / 2 + w / l * Math.PI, u = Math.cos(i), y = Math.sin(i), b = Math.max(1, Math.round(Math.abs(u) * R));
+      for (let f = 0; f < b; f++) {
+        const P = f / b * 2 * Math.PI, [x, g, d] = h(u * Math.cos(P), y, u * Math.sin(P)), v = (d + 1) / 2, k = et(P + s * 0.5, m), N = Math.exp(-(k * k) / 0.18) * Math.max(0, d);
+        e.push({
+          x,
+          y: g,
+          z: d,
+          r: ((t.rBase ?? 0.6) + (t.rDepth ?? 1.7) * v + (t.rBoost ?? 1) * N) * D,
+          white: (t.inkFar ?? 0.62) - (t.inkSpan ?? 0.54) * v,
+          // dimBase < 1 fades un-scanned dots so the meridian reads clearly
+          a: p + (1 - p) * Math.min(1, N)
+        });
+      }
+    }
+    return L(e, [], t.rMin);
+  };
+  var dt = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.82, c = _(s * 0.55, 0.35 + 0.1 * Math.sin(s * 0.9), r, a, o), M = $(n, t.rsPow ?? 0.6), h = t.moveCount ?? 14, m = ut(h), D = lt(s, h, 0.42, 1.2), p = [], e = t.latRings ?? 15, l = t.lonDensity ?? 40;
+    for (let R = 0; R <= e; R++) {
+      const w = -Math.PI / 2 + R / e * Math.PI, i = Math.cos(w), u = Math.sin(w), y = Math.max(1, Math.round(Math.abs(i) * l));
+      for (let b = 0; b < y; b++) {
+        const f = b / y * 2 * Math.PI, [P, x, g, d] = pt([i * Math.cos(f), u, i * Math.sin(f)], m, D), [v, k, N] = c(P, x, g), z = (N + 1) / 2;
+        p.push({
+          x: v,
+          y: k,
+          z: N,
+          r: ((t.rBase ?? 0.6) + (t.rDepth ?? 1.7) * z + (d ? t.rActive ?? 0.3 : 0)) * M,
+          white: (t.inkFar ?? 0.62) - (t.inkSpan ?? 0.54) * z - (d ? 0.14 : 0)
+        });
+      }
+    }
+    return L(p, [], t.rMin);
+  };
+  var bt = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.874, c = _(s * 0.18, 0.38, r, a, 1), M = $(n, t.rsPow ?? 0.6), h = [], m = t.rings ?? 15, D = t.lonDensity ?? 40;
+    for (let p = 0; p <= m; p++) {
+      const e = -Math.PI / 2 + p / m * Math.PI, l = Math.cos(e), R = Math.sin(e), w = 0.62 * Math.sin(s * 2.1 - p * 0.52) + 0.38 * Math.sin(s * 1.27 + p * 0.83), i = o * (0.88 + 0.105 * w), u = Math.max(1, Math.round(Math.abs(l) * D));
+      for (let y = 0; y < u; y++) {
+        const b = y / u * 2 * Math.PI, [f, P, x] = c(l * Math.cos(b) * i, R * i, l * Math.sin(b) * i), g = (x / o + 1) / 2, d = Math.max(0, w);
+        h.push({
+          x: f,
+          y: P,
+          z: x,
+          r: ((t.rBase ?? 0.6) + (t.rDepth ?? 1.7) * g) * (1 + 0.4 * d) * M,
+          white: 0.66 - 0.56 * g - 0.1 * d
+        });
+      }
+    }
+    return L(h, [], t.rMin);
+  };
+  function xt(n) {
+    return n * n * (3 - 2 * n);
+  }
+  function st(n) {
+    const s = n.length, t = [];
+    let r = 0;
+    for (let a = 0; a < s; a++) {
+      const o = n[a], c = n[(a + 1) % s], M = Math.hypot(c[0] - o[0], c[1] - o[1]);
+      t.push(M), r += M;
+    }
+    return (a) => {
+      let o = a * r, c = 0;
+      for (; o > t[c] && c < s - 1; )
+        o -= t[c], c++;
+      const M = n[c], h = n[(c + 1) % s], m = t[c] ? Math.min(1, o / t[c]) : 0;
+      return [M[0] + (h[0] - M[0]) * m, M[1] + (h[1] - M[1]) * m];
+    };
+  }
+  var yt = (n) => {
+    const s = -Math.PI / 2 + n * 2 * Math.PI;
+    return [Math.cos(s) * 0.24, Math.sin(s) * 0.24];
+  };
+  var gt = st([
+    [0, -0.26],
+    [0.24, 0.16],
+    [-0.24, 0.16]
+  ]);
+  var mt = st([
+    [0, -0.2],
+    [0.2, -0.2],
+    [0.2, 0.2],
+    [-0.2, 0.2],
+    [-0.2, -0.2]
+  ]);
+  var H = [yt, gt, mt];
+  function wt(n) {
+    return Math.max(6, Math.round(34 * n));
+  }
+  var V = 1.4;
+  var ot = 0.9;
+  var Q = V + ot;
+  var Pt = (n, s, t) => {
+    const r = H.length, a = s % (Q * r), o = Math.floor(a / Q), c = a - o * Q, M = c > V ? xt((c - V) / ot) : 0, h = t.spread ?? 1, m = H[o], D = H[(o + 1) % r], p = 160, e = [];
+    for (let x = 0; x < p; x++) {
+      const g = x / p, d = m(g), v = D(g);
+      e.push([(d[0] + (v[0] - d[0]) * M) * h, (d[1] + (v[1] - d[1]) * M) * h]);
+    }
+    const l = [];
+    let R = 0;
+    for (let x = 0; x < p; x++) {
+      const g = e[x], d = e[(x + 1) % p], v = Math.hypot(d[0] - g[0], d[1] - g[1]);
+      l.push(v), R += v;
+    }
+    const w = wt(t.iconD ?? 1), i = (t.rDot ?? 0.021) * 1.35 * h, u = 1 + 0.02 * Math.sin(c * 3.1), y = [], b = n / 2;
+    let f = 0, P = 0;
+    for (let x = 0; x < w; x++) {
+      const g = x / w * R;
+      for (; P + l[f] < g && f < p - 1; )
+        P += l[f], f++;
+      const d = e[f], v = e[(f + 1) % p], k = l[f] ? Math.min(1, (g - P) / l[f]) : 0, N = (d[0] + (v[0] - d[0]) * k) * u, z = (d[1] + (v[1] - d[1]) * k) * u;
+      y.push({
+        x: b + N * n,
+        y: b + z * n,
+        z: 0,
+        r: Math.max(0.35, i * n),
+        white: 0.1
+      });
+    }
+    return L(y, [], t.rMin);
+  };
+  var Rt = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.82, c = _(s * 0.12, 0.3, r, a, 1), M = $(n, t.rsPow ?? 0.6), h = [], m = t.orbitN ?? 12, D = t.ghostN ?? 40, p = t.particles ?? 3;
+    for (let e = 0; e < m; e++) {
+      const l = E(e, 1.7), R = E(e, 5.2), w = E(e, 8.9), i = o * (0.45 + 0.52 * l), u = l * 2 * Math.PI, y = Math.acos(2 * R - 1), b = Math.sin(y) * Math.cos(u), f = Math.cos(y), P = Math.sin(y) * Math.sin(u);
+      let x = -f, g = b;
+      const d = 0, v = Math.max(1e-6, Math.sqrt(x * x + g * g));
+      x /= v, g /= v;
+      const k = f * d - P * g, N = P * x - b * d, z = b * g - f * x, O = (0.25 + 0.55 * w) * (w > 0.5 ? 1 : -1);
+      for (let B = 0; B < D; B++) {
+        const I = B / D * 2 * Math.PI, [S, A, T] = c(
+          (x * Math.cos(I) + k * Math.sin(I)) * i,
+          (g * Math.cos(I) + N * Math.sin(I)) * i,
+          (d * Math.cos(I) + z * Math.sin(I)) * i
+        ), C = (T / i + 1) / 2;
+        h.push({
+          x: S,
+          y: A,
+          z: T,
+          r: (t.ghostR ?? 0.9) * M,
+          white: 0.72,
+          a: (t.ghostA ?? 0.5) * (0.4 + 0.6 * C)
+        });
+      }
+      for (let B = 0; B < p; B++) {
+        const I = s * O + B / p * 2 * Math.PI + R * 6, [S, A, T] = c(
+          (x * Math.cos(I) + k * Math.sin(I)) * i,
+          (g * Math.cos(I) + N * Math.sin(I)) * i,
+          (d * Math.cos(I) + z * Math.sin(I)) * i
+        ), C = (T / i + 1) / 2;
+        h.push({
+          x: S,
+          y: A,
+          z: T,
+          r: ((t.partR ?? 1.2) + (t.partRDepth ?? 1.6) * C) * M,
+          white: 0.3 - 0.22 * C
+        });
+      }
+    }
+    return L(h, [], t.rMin);
+  };
+  var Z = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.78, c = t.spin ?? 1, M = 0.3, h = _(s * 0.1 * c, M, r, a, 1), m = $(n, t.rsPow ?? 0.6), D = [], p = t.ghostN ?? 150;
+    for (let z = 0; z < p; z++) {
+      const O = J(z, p), [B, I, S] = h(O[0] * o, O[1] * o, O[2] * o), A = (S / o + 1) / 2;
+      D.push({ x: B, y: I, z: S, r: 0.8 * m, white: 0.78, a: 0.1 + 0.22 * A });
+    }
+    const e = s * 0.24 * c, l = t.faceOn ? -M : 0.55 + 0.3 * Math.sin(s * 0.18) * c, R = Math.cos(e), w = 0, i = Math.sin(e), u = -i * Math.sin(l), y = Math.cos(l), b = R * Math.sin(l), f = w * b - i * y, P = i * u - R * b, x = R * y - w * u, g = 0.23 * (t.wobMul ?? 1), d = t.faceOn ? o / (1 + 0.85 * g) : o, v = t.lanes ?? 5, k = t.segs ?? 88, N = Math.max(1, Math.round(v * (t.bandMul ?? 1)));
+    for (let z = 0; z < N; z++) {
+      const O = (z - (N - 1) / 2) * 0.075, B = Math.abs(z - (N - 1) / 2) / Math.max(1, (N - 1) / 2);
+      for (let I = 0; I < k; I++) {
+        const S = I / k * 2 * Math.PI, A = (0.16 * Math.sin(S * 3 - s * 1.7 + z * 0.22) + 0.07 * Math.sin(S * 5 + s * 1.1)) * (t.wobMul ?? 1), T = t.faceOn ? 1 + A : 1, C = t.faceOn ? O : O + A, q = R * Math.cos(S) + u * Math.sin(S) + f * C, F = w * Math.cos(S) + y * Math.sin(S) + P * C, j = i * Math.cos(S) + b * Math.sin(S) + x * C, W = Math.sqrt(q * q + F * F + j * j), Y = d * T, [ct, at, X] = h(q / W * Y, F / W * Y, j / W * Y), K = (X / o + 1) / 2;
+        D.push({
+          x: ct,
+          y: at,
+          z: X,
+          r: ((t.rBase ?? 1.1) + (t.rDepth ?? 1.7) * K) * (1 - 0.25 * B) * m,
+          white: 0.52 - 0.44 * K + 0.18 * B,
+          a: 0.4 + 0.6 * K
+        });
+      }
+    }
+    return L(D, [], t.rMin);
+  };
+  var Dt = (n, s, t) => {
+    const r = n / 2, a = n / 2, o = n / 2 * 0.8 * (t.spread ?? 1), c = _(s * 0.12, 0.32, r, a, o), M = $(n, t.rsPow ?? 0.6), h = t.nodeN ?? 30, m = t.thr ?? 0.72, D = t.nodeR ?? 1.4, p = t.nodeRDepth ?? 1.8, e = [];
+    for (let i = 0; i < h; i++) {
+      const u = J(i, h), y = u[0] + 0.3 * (G(i * 0.31 + 9, s * 0.24) - 0.5) * 2, b = u[1] + 0.3 * (G(i * 0.53 + 27, s * 0.21) - 0.5) * 2, f = u[2] + 0.3 * (G(i * 0.77 + 55, s * 0.27) - 0.5) * 2, P = Math.sqrt(y * y + b * b + f * f);
+      e.push([y / P, b / P, f / P]);
+    }
+    const l = [], R = [];
+    for (let i = 0; i < h; i++)
+      for (let u = i + 1; u < h; u++) {
+        const y = e[i][0] - e[u][0], b = e[i][1] - e[u][1], f = e[i][2] - e[u][2], P = Math.sqrt(y * y + b * b + f * f);
+        if (P >= m) continue;
+        const [x, g, d] = c(e[i][0], e[i][1], e[i][2]), [v, k, N] = c(e[u][0], e[u][1], e[u][2]), z = ((d + N) / 2 + 1) / 2;
+        l.push({
+          x1: x,
+          y1: g,
+          x2: v,
+          y2: k,
+          white: 0.42,
+          a: (1 - P / m) * (0.3 + 0.55 * z),
+          w: Math.max(0.6, (t.lineW ?? 0.8) * M)
+        });
+      }
+    for (let i = 0; i < h; i++) {
+      const [u, y, b] = c(e[i][0], e[i][1], e[i][2]), f = (b + 1) / 2, P = 1 + 0.25 * Math.sin(s * 1.4 + i * 2.7);
+      R.push({
+        x: u,
+        y,
+        z: b,
+        r: (D + p * f) * P * M,
+        white: 0.55 - 0.45 * f
+      });
+    }
+    const w = t.signals ?? 5;
+    for (let i = 0; i < w; i++) {
+      const u = Math.floor(s * 0.55 + i * 7.31), y = Math.floor(E(u, i * 3.1 + 1.7) * h), b = Math.floor(E(u, i * 5.7 + 4.2) * h);
+      if (y === b) continue;
+      const f = nt(s * 0.55 + i * 7.31), P = U(e[y][0], e[b][0], f), x = U(e[y][1], e[b][1], f), g = U(e[y][2], e[b][2], f), d = Math.max(1e-6, Math.sqrt(P * P + x * x + g * g)), [v, k, N] = c(P / d, x / d, g / d), z = (N + 1) / 2;
+      R.push({
+        x: v,
+        y: k,
+        z: N,
+        r: (D * 1.5 + p * z) * M,
+        white: 0.05,
+        a: 0.5 + 0.5 * z
+      });
+    }
+    return L(R, l, t.rMin);
+  };
+  var vt = {
+    orbits: Rt,
+    globe: ft,
+    rubik: dt,
+    wave: bt,
+    web: Dt,
+    braid: Mt,
+    ribbon: Z,
+    // ring shares ribbon's geometry — the `faceOn` profile flag switches it
+    ring: Z,
+    morph: Pt
+  };
+  var Ct = Object.fromEntries(
+    Object.entries(vt).map(([n, s]) => [
+      n,
+      (t, r, a, o, c) => ht(t, s(r, a, c), o)
+    ])
+  );
+  var zt = [
+    ["latRings", "lonDensity"],
+    ["rings", "lonDensity"],
+    ["lanes", "segs"]
+  ];
+  var Nt = ["orbitN", "ghostN", "nodeN", "strandN", "signals"];
+  var It = ["iconD"];
+  var kt = [
+    "rBase",
+    "rDepth",
+    "rActive",
+    "rDot",
+    "ghostR",
+    "partR",
+    "partRDepth",
+    "nodeR",
+    "nodeRDepth"
+  ];
+  function St(n, s) {
+    const t = { ...n }, r = /* @__PURE__ */ new Set(), a = Math.sqrt(s);
+    for (const [o, c] of zt) {
+      const M = t[o], h = t[c];
+      M != null && h != null && !r.has(o) && !r.has(c) && (t[o] = Math.max(2, Math.round(M * a)), t[c] = Math.max(2, Math.round(h * a)), r.add(o), r.add(c));
+    }
+    for (const o of Nt) {
+      const c = t[o];
+      c != null && c !== 0 && !r.has(o) && (t[o] = Math.max(1, Math.round(c * s)));
+    }
+    for (const o of It) {
+      const c = t[o];
+      c != null && (t[o] = Math.max(0.02, c * s));
+    }
+    return t;
+  }
+  function Bt(n, s) {
+    const t = { ...n };
+    for (const r of kt) {
+      const a = t[r];
+      a != null && (t[r] = a * s);
+    }
+    return t.rSizeMul = (t.rSizeMul ?? 1) * s, t;
+  }
+  var Et = {
+    globe: {
+      latRings: 17,
+      lonDensity: 44,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rBoost: 1,
+      inkFar: 0.62,
+      inkSpan: 0.54,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    orbits: {
+      orbitN: 12,
+      ghostN: 40,
+      ghostR: 0.9,
+      ghostA: 0.5,
+      particles: 3,
+      partR: 1.2,
+      partRDepth: 1.6,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    rubik: {
+      latRings: 15,
+      lonDensity: 40,
+      moveCount: 14,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rActive: 0.3,
+      inkFar: 0.62,
+      inkSpan: 0.54,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    wave: {
+      rings: 15,
+      lonDensity: 40,
+      rBase: 0.6,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    web: {
+      nodeN: 30,
+      thr: 0.72,
+      signals: 5,
+      nodeR: 1.4,
+      nodeRDepth: 1.8,
+      lineW: 0.8,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    braid: {
+      strandN: 52,
+      turns: 3,
+      ghostN: 150,
+      rBase: 1.2,
+      rDepth: 1.8,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    ribbon: {
+      lanes: 5,
+      segs: 88,
+      ghostN: 150,
+      rBase: 1.1,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    // ring shares ribbon's painter; faceOn cancels the camera tilt and moves
+    // the undulation onto the radius, and there is no ghost sphere behind it
+    ring: {
+      lanes: 5,
+      segs: 88,
+      ghostN: 0,
+      faceOn: 1,
+      rBase: 1.1,
+      rDepth: 1.7,
+      rsPow: 0.6,
+      rMin: 0.3
+    },
+    morph: {
+      rDot: 0.021,
+      iconD: 1,
+      rMin: 0.25
+    }
+  };
+  var Ot = {
+    working: "orbits",
+    searching: "globe",
+    solving: "rubik",
+    listening: "wave",
+    connecting: "web",
+    weaving: "braid",
+    composing: "ribbon",
+    breathing: "ring",
+    shaping: "morph"
+  };
+  var At = {
+    orbits: {
+      64: { speed: 1.885, count: 1, size: 1 },
+      20: { speed: 3.9, count: 0.238, size: 2.4 }
+    },
+    globe: {
+      64: { speed: 2.015, count: 0.42, size: 1.15, extra: { scanMul: 4.08, dimBase: 0.45 } },
+      20: { speed: 2.665, count: 0.105, size: 1.75, extra: { scanMul: 4.335, dimBase: 0.45 } }
+    },
+    rubik: {
+      64: { speed: 1.82, count: 0.35, size: 1.05 },
+      20: { speed: 1.95, count: 0.088, size: 1.9 }
+    },
+    wave: {
+      64: { speed: 4.388, count: 0.341, size: 1 },
+      20: { speed: 3.998, count: 0.105, size: 1.6 }
+    },
+    web: {
+      64: { speed: 3.315, count: 1.35, size: 0.95 },
+      20: { speed: 6.63, count: 0.25, size: 1.52 }
+    },
+    braid: {
+      64: { speed: 1.625, count: 0.5, size: 1 },
+      20: { speed: 2.75, count: 0.1125, size: 1.36 }
+    },
+    ribbon: {
+      64: { speed: 2.34, count: 0.25, size: 0.85, extra: { spin: 0, bandMul: 3.9, wobMul: 1 } },
+      20: { speed: 3.12, count: 0.051, size: 1.073, extra: { spin: 0, bandMul: 4.94, wobMul: 1 } }
+    },
+    ring: {
+      64: { speed: 3.24, count: 0.25, size: 0.956, extra: { spin: 0, bandMul: 3.627, wobMul: 0.368 } },
+      20: { speed: 3.78, count: 0.028, size: 1.622, extra: { spin: 0, bandMul: 3.968, wobMul: 0.565 } }
+    },
+    morph: {
+      64: { speed: 2.405, count: 0.702, size: 0.395, extra: { spread: 1.45 } },
+      20: { speed: 2.08, count: 0.53, size: 1.011, extra: { spread: 1.45 } }
+    }
+  };
+  var tt = /* @__PURE__ */ new Map();
+  function Lt(n, s) {
+    const t = `${n}-${s}`, r = tt.get(t);
+    if (r) return r;
+    const a = Ot[n], o = At[a][s];
+    let c = { ...Et[a] };
+    o.count !== 1 && (c = St(c, o.count)), o.size !== 1 && (c = Bt(c, o.size)), o.extra && (c = { ...c, ...o.extra });
+    const M = { mode: a, speed: o.speed, opts: c };
+    return tt.set(t, M), M;
+  }
+
+  // plugin/src/ui/thinking-orb.ts
+  var ORB_SIZE = 20;
+  var STATIC_TIME = 0.75;
+  function orbPresentation(signals) {
+    if (signals.connectionFailure || signals.syncFailure || signals.activityFailure) {
+      return { state: "shaping", paused: true, dimmed: false, status: "Needs attention" };
+    }
+    if (signals.connection === "probing" || signals.connection === "handshake") {
+      return { state: "connecting", paused: false, dimmed: false, status: "Connecting" };
+    }
+    if (signals.connection === "disconnected") {
+      return { state: "connecting", paused: true, dimmed: true, status: "Disconnected" };
+    }
+    if (signals.activityPending || signals.syncPending) {
+      return { state: "working", paused: false, dimmed: false, status: "Processing" };
+    }
+    return { state: "breathing", paused: false, dimmed: false, status: "Connected" };
+  }
+  function mountThinkingOrb(target) {
+    const canvas = document.createElement("canvas");
+    canvas.className = "thinking-orb";
+    canvas.setAttribute("aria-hidden", "true");
+    target.append(canvas);
+    const context2 = canvas.getContext("2d");
+    if (!context2) {
+      canvas.remove();
+      return { update: () => {
+      }, dispose: () => {
+      } };
+    }
+    const drawingContext = context2;
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    let presentation = orbPresentation({
+      connection: "disconnected",
+      connectionFailure: false,
+      syncFailure: false,
+      activityFailure: false,
+      activityPending: false,
+      syncPending: false
+    });
+    canvas.dataset.dimmed = String(presentation.dimmed);
+    let frameId = null;
+    let disposed = false;
+    const isDark = () => !document.documentElement.classList.contains("figma-light");
+    const isAnimated = () => !presentation.paused && !reducedMotion.matches && !document.hidden;
+    function prepareCanvas() {
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      const pixels = Math.round(ORB_SIZE * dpr);
+      if (canvas.width !== pixels || canvas.height !== pixels) {
+        canvas.width = pixels;
+        canvas.height = pixels;
+      }
+      drawingContext.setTransform(dpr, 0, 0, dpr, 0, 0);
+    }
+    function paint(now) {
+      prepareCanvas();
+      drawingContext.clearRect(0, 0, ORB_SIZE, ORB_SIZE);
+      const preset = Lt(presentation.state, ORB_SIZE);
+      const time = isAnimated() ? now / 1e3 * preset.speed : STATIC_TIME * preset.speed;
+      Ct[preset.mode](drawingContext, ORB_SIZE, time, isDark(), preset.opts);
+    }
+    function stop() {
+      if (frameId === null) return;
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    function schedule() {
+      if (disposed || !isAnimated() || frameId !== null) return;
+      frameId = requestAnimationFrame((now) => {
+        frameId = null;
+        paint(now);
+        schedule();
+      });
+    }
+    function refresh() {
+      stop();
+      paint(performance.now());
+      schedule();
+    }
+    const onVisibilityChange = () => refresh();
+    const onMotionChange = () => refresh();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    reducedMotion.addEventListener("change", onMotionChange);
+    const themeObserver = new MutationObserver(refresh);
+    themeObserver.observe(document.documentElement, { attributes: true, attributeFilter: ["class"] });
+    refresh();
+    return {
+      update(next) {
+        if (next.state === presentation.state && next.paused === presentation.paused && next.dimmed === presentation.dimmed && next.status === presentation.status) return;
+        presentation = next;
+        canvas.dataset.dimmed = String(next.dimmed);
+        refresh();
+      },
+      dispose() {
+        disposed = true;
+        stop();
+        document.removeEventListener("visibilitychange", onVisibilityChange);
+        reducedMotion.removeEventListener("change", onMotionChange);
+        themeObserver.disconnect();
+        canvas.remove();
+      }
+    };
+  }
+
   // plugin/src/ui/panel-ui.ts
   var el = (id) => document.getElementById(id);
   var btn = (id) => el(id);
@@ -1510,6 +2189,7 @@ body { overflow: hidden; }
   var syncNowBtn = btn("fga-sync-now");
   var targetBtn = btn("fga-target-btn");
   var activityView = new ActivityView(el("fga-activity"), currentBtn, el("fga-current-label"), el("fga-failure-count"));
+  var thinkingOrb = mountThinkingOrb(connectionBtn);
   var tabNames = ["activity", "context", "details"];
   var tabs = Object.fromEntries(tabNames.map((name) => [name, btn(`fga-tab-${name}`)]));
   var tabPanels = Object.fromEntries(tabNames.map((name) => [name, el(`fga-panel-${name}`)]));
@@ -1531,9 +2211,16 @@ body { overflow: hidden; }
   var syncFailure = false;
   var connectionTransition = 0;
   var previousConnectionState = null;
+  var lastViewportMode = "rail-compact";
   var disclosed = new BoundedKeySet();
   function viewport(mode) {
+    if (lastViewportMode === mode) return;
+    lastViewportMode = mode;
     parent.postMessage({ pluginMessage: { type: "PANEL_VIEWPORT", mode } }, "*");
+  }
+  function syncViewport() {
+    const railMode = railViewportMode(!targetRailBtn.hidden, !syncRailBtn.hidden);
+    viewport(inspectorOpen ? "inspector" : railMode);
   }
   function selectTab(tab, focus = false) {
     selectedTab = tab;
@@ -1557,7 +2244,7 @@ body { overflow: hidden; }
     labelControl(toggleBtn, open ? "Close inspector" : "Open inspector");
     replaceIcon(toggleBtn, open ? "chevron-up" : "chevron-down");
     if (open) selectTab(tab);
-    viewport(open ? "inspector" : "rail");
+    syncViewport();
   }
   function forceOnce(key, tab) {
     if (disclosed.has(key)) return;
@@ -1571,10 +2258,24 @@ body { overflow: hidden; }
   function updateSignal() {
     panel.dataset.unresolved = String(unresolved());
   }
+  function renderOrb() {
+    const orb = orbPresentation({
+      connection: payload?.state ?? "disconnected",
+      connectionFailure,
+      syncFailure,
+      activityFailure: activityView.failures.unresolvedCount > 0,
+      activityPending: activityView.railPhase() === "pending",
+      syncPending: pendingSyncCount > 0
+    });
+    thinkingOrb.update(orb);
+    connectionBtn.className = "rail-control";
+    labelControl(connectionBtn, `${orb.status}. Open details`);
+  }
   function acknowledgeActivity() {
     activityView.acknowledgeFailures();
     updateSignal();
     activityView.render();
+    renderOrb();
   }
   function openUser(tab) {
     if (tab === "activity") acknowledgeActivity();
@@ -1594,6 +2295,7 @@ body { overflow: hidden; }
       replaceIcon(targetRailBtn, peersPinned ? "pin" : "files");
       targetRailBtn.classList.toggle("tone-info", peersIsActiveTarget);
     }
+    syncViewport();
   }
   function render() {
     const now = Date.now(), state = payload?.state ?? "disconnected", age = payload ? now - payload.since : 0;
@@ -1601,9 +2303,6 @@ body { overflow: hidden; }
     sentence2.textContent = view.text;
     sentence2.dataset.tone = view.tone;
     onboarding.hidden = !showOnboarding(state, hadConnection);
-    replaceIcon(connectionBtn, state === "connected" ? "circle-check" : state === "probing" || state === "handshake" ? "loader-circle" : "circle-off", state === "probing" || state === "handshake");
-    connectionBtn.className = `rail-control tone-${view.tone}`;
-    labelControl(connectionBtn, view.text);
     context();
     activityView.render(now);
     const showSync = pendingSyncCount > 0 || syncFailure;
@@ -1614,9 +2313,11 @@ body { overflow: hidden; }
       syncRailBtn.className = `rail-control tone-${syncFailure ? "danger" : "warning"}`;
       labelControl(syncRailBtn, syncFailure ? `${syncMsg.textContent || "Sync failed"}. Open sync actions` : `${syncPromptLabel(pendingSyncCount)}. Open sync actions`);
     }
+    syncViewport();
     const force = connectionForce(state, age, hadConnection, connectionTransition);
     connectionFailure = force?.kind === "probe-timeout" || force?.kind === "connection-lost";
     updateSignal();
+    renderOrb();
     if (force) forceOnce(force.key, "details");
     if (state === "connected" && forcedOnly && !userExpanded && !unresolved()) {
       forcedOnly = false;
@@ -1663,6 +2364,7 @@ body { overflow: hidden; }
       toggleBtn.focus();
     }
   });
+  window.addEventListener("pagehide", () => thinkingOrb.dispose(), { once: true });
   window.addEventListener("figma-agent:conn-state", (event) => {
     const next = event.detail;
     if (!next || typeof next.state !== "string") return;
@@ -1770,7 +2472,7 @@ body { overflow: hidden; }
     }, 4e3);
     render();
   });
-  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "15cb9e2" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "8e47266" : "dev"}`;
   replaceIcon(targetRailBtn, "files");
   replaceIcon(syncRailBtn, "refresh-cw");
   replaceIcon(toggleBtn, "chevron-down");
@@ -1992,10 +2694,10 @@ body { overflow: hidden; }
             const dec = childCs.textDecorationLine;
             if (dec === "underline") seg.textDecoration = "UNDERLINE";
             else if (dec === "line-through") seg.textDecoration = "STRIKETHROUGH";
-            const tt = childCs.textTransform;
-            if (tt === "uppercase") seg.textCase = "UPPER";
-            else if (tt === "lowercase") seg.textCase = "LOWER";
-            else if (tt === "capitalize") seg.textCase = "TITLE";
+            const tt2 = childCs.textTransform;
+            if (tt2 === "uppercase") seg.textCase = "UPPER";
+            else if (tt2 === "lowercase") seg.textCase = "LOWER";
+            else if (tt2 === "capitalize") seg.textCase = "TITLE";
             segments.push(seg);
             fullText += childText;
           }
@@ -2121,10 +2823,10 @@ body { overflow: hidden; }
       textAlignHorizontal: mapTextAlign(textCs.textAlign),
       textAutoResize: "WIDTH_AND_HEIGHT"
     };
-    const tt = textCs.textTransform;
-    if (tt === "uppercase") textNode.textCase = "UPPER";
-    else if (tt === "lowercase") textNode.textCase = "LOWER";
-    else if (tt === "capitalize") textNode.textCase = "TITLE";
+    const tt2 = textCs.textTransform;
+    if (tt2 === "uppercase") textNode.textCase = "UPPER";
+    else if (tt2 === "lowercase") textNode.textCase = "LOWER";
+    else if (tt2 === "capitalize") textNode.textCase = "TITLE";
     const td = textCs.textDecorationLine;
     if (td === "underline") textNode.textDecoration = "UNDERLINE";
     else if (td === "line-through") textNode.textDecoration = "STRIKETHROUGH";
@@ -2425,11 +3127,11 @@ body { overflow: hidden; }
         if (bestMargin > 0) node.itemSpacing = bestMargin;
       }
     }
-    const pt = parseFloat(cs.paddingTop) || 0;
+    const pt2 = parseFloat(cs.paddingTop) || 0;
     const pr = parseFloat(cs.paddingRight) || 0;
     const pb = parseFloat(cs.paddingBottom) || 0;
     const pl = parseFloat(cs.paddingLeft) || 0;
-    if (pt > 0) node.paddingTop = Math.round(pt);
+    if (pt2 > 0) node.paddingTop = Math.round(pt2);
     if (pr > 0) node.paddingRight = Math.round(pr);
     if (pb > 0) node.paddingBottom = Math.round(pb);
     if (pl > 0) node.paddingLeft = Math.round(pl);
@@ -2977,9 +3679,9 @@ body { overflow: hidden; }
         const name = spacingByValue.get(node.itemSpacing);
         if (name) refs.gap = name;
       }
-      const pt = node.paddingTop;
-      if (pt && pt > 0 && pt === node.paddingRight && pt === node.paddingBottom && pt === node.paddingLeft) {
-        const name = spacingByValue.get(pt);
+      const pt2 = node.paddingTop;
+      if (pt2 && pt2 > 0 && pt2 === node.paddingRight && pt2 === node.paddingBottom && pt2 === node.paddingLeft) {
+        const name = spacingByValue.get(pt2);
         if (name) refs.padding = name;
       }
       if (Object.keys(refs).length > 0) node.tokenRefs = refs;

--- a/tests/figma-plugin-panel.test.ts
+++ b/tests/figma-plugin-panel.test.ts
@@ -27,9 +27,14 @@ const html = read('plugin/src/ui/panel.html');
 const model = read('plugin/src/ui/panel-model.ts');
 const panelUi = read('plugin/src/ui/panel-ui.ts');
 const activityView = read('plugin/src/ui/panel-activity-view.ts');
+const thinkingOrb = existsSync(`${ROOT}/plugin/src/ui/thinking-orb.ts`) ? read('plugin/src/ui/thinking-orb.ts') : '';
 const viewState = read('plugin/src/ui/panel-view-state.ts');
 const main = read('plugin/src/main/main.ts');
 const icons = existsSync(`${ROOT}/plugin/src/ui/lucide-icons.ts`) ? read('plugin/src/ui/lucide-icons.ts') : '';
+const packageJson = JSON.parse(read('package.json')) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
 
 const THEME_BLOCK_RE = /(?::root|html\.figma-light)\s*\{[\s\S]*?\}/g;
 const chrome = html.replace(THEME_BLOCK_RE, '').replace(/\/\*[\s\S]*?\*\//g, '');
@@ -56,16 +61,23 @@ describe('adaptive panel source contract', () => {
   });
 
   it('opens as the exact rail and whitelists only named viewport modes', () => {
-    expect(model).toContain('RAIL_WIDTH = 240');
+    expect(model).toContain('RAIL_COMPACT_WIDTH = 200');
+    expect(model).toContain('RAIL_ONE_ACTION_WIDTH = 220');
+    expect(model).toContain('RAIL_TWO_ACTIONS_WIDTH = 240');
     expect(model).toContain('RAIL_HEIGHT = 44');
     expect(model).toContain('INSPECTOR_WIDTH = 288');
     expect(model).toContain('INSPECTOR_HEIGHT = 280');
-    expect(main).toMatch(/width:\s*RAIL_WIDTH,\s*height:\s*RAIL_HEIGHT/);
+    expect(main).toMatch(/width:\s*RAIL_COMPACT_WIDTH,\s*height:\s*RAIL_HEIGHT/);
     expect(main).toContain("chrome.type === 'PANEL_VIEWPORT'");
+    for (const mode of ['rail-compact', 'rail-one-action', 'rail-two-actions', 'inspector']) {
+      expect(main).toContain(`chrome.mode === '${mode}'`);
+    }
     expect(main).toContain("chrome.mode === 'inspector'");
     expect(main).toContain('viewportFor(chrome.mode)');
     expect(main).toContain('figma.ui.resize(viewport.width, viewport.height)');
     expect(main).not.toMatch(/chrome\.(?:width|height)/);
+    expect(panelUi).toContain('railViewportMode(!targetRailBtn.hidden, !syncRailBtn.hidden)');
+    expect(panelUi).toContain('if (lastViewportMode === mode) return');
   });
 
   it('owns a compact rail and a mounted three-view inspector', () => {
@@ -101,6 +113,30 @@ describe('Lucide and control accessibility', () => {
     expect(icons).not.toContain('innerHTML');
     expect(activityView).toContain("from './lucide-icons'");
     expect(`${panelUi}${activityView}${icons}`).not.toContain('Phosphor');
+  });
+
+  it('uses the exact engine package without pulling React into the panel', () => {
+    expect(packageJson.dependencies?.['thinking-orbs']).toBeUndefined();
+    expect(packageJson.devDependencies?.['thinking-orbs']).toBe('0.3.1');
+    expect(thinkingOrb).toContain("from 'thinking-orbs/engine'");
+    expect(thinkingOrb).not.toMatch(/from ['"]thinking-orbs['"]|from ['"]react['"]/);
+    expect(panelUi).toContain('mountThinkingOrb(connectionBtn)');
+  });
+
+  it('uses one aggregate canvas status and no current-activity outcome glyph', () => {
+    expect(thinkingOrb).toContain("document.createElement('canvas')");
+    expect((thinkingOrb.match(/document\.createElement\('canvas'\)/g) ?? []).length).toBe(1);
+    expect(panelUi).not.toContain('replaceIcon(connectionBtn');
+    expect(activityView).not.toContain('replaceIcon(this.currentButton');
+    expect(activityView).toContain('makeLucideIcon(record.pending');
+    expect(activityView).toContain('railPhase()');
+  });
+
+  it('recomputes aggregate orb status immediately when activity is acknowledged', () => {
+    expect(panelUi).toContain('function renderOrb()');
+    const acknowledge = /function acknowledgeActivity\(\): void \{([\s\S]*?)\}/.exec(panelUi)?.[1] ?? '';
+    expect(acknowledge).toContain('activityView.acknowledgeFailures()');
+    expect(acknowledge).toContain('renderOrb()');
   });
 
   it('gives every icon-only rail control a title, accessible name, and native button', () => {

--- a/tests/panel-craft-regression.test.ts
+++ b/tests/panel-craft-regression.test.ts
@@ -6,6 +6,7 @@ const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const read = (path: string): string => readFileSync(`${ROOT}/${path}`, 'utf8');
 const html = read('plugin/src/ui/panel.html');
 const activityView = read('plugin/src/ui/panel-activity-view.ts');
+const thinkingOrb = read('plugin/src/ui/thinking-orb.ts');
 const blocks = /(?::root|html\.figma-light)\s*\{[\s\S]*?\}/g;
 const chrome = html.replace(blocks, '').replace(/\/\*[\s\S]*?\*\//g, '');
 const rules: [string, string][] = [...chrome.matchAll(/([^{}]+)\{([^}]*)\}/g)]
@@ -57,6 +58,15 @@ describe('panel visual regression contract', () => {
     expect(chrome).not.toMatch(/@media[^{]*\(\s*(?:min|max)-width/);
   });
 
+  it('hugs the rail with flex while only the activity label may shrink', () => {
+    expect(declarationsFor('.agent-rail')).toMatch(/display:\s*flex/);
+    expect(declarationsFor('.agent-rail')).not.toMatch(/grid-template-columns|\b1fr\b/);
+    expect(declarationsFor('.rail-control')).toMatch(/flex:\s*0\s+0\s+32px/);
+    expect(declarationsFor('.current-control')).toMatch(/flex:\s*1\s+1\s+auto/);
+    expect(declarationsFor('.current-label')).toMatch(/min-width:\s*0/);
+    expect(declarationsFor('.current-label')).toMatch(/text-overflow:\s*ellipsis/);
+  });
+
   it('keeps spacing, depth, focus, and applied 16px Lucide classes intentional', () => {
     const offGrid: string[] = [];
     for (const [selector, value] of rules) {
@@ -75,6 +85,18 @@ describe('panel visual regression contract', () => {
     expect(chrome).not.toMatch(/background(?:-color)?:\s*var\(--fga-(hairline|hairline-soft|topedge)\)/);
     expect(chrome).not.toMatch(/box-shadow:\s*inset|border-left:\s*(?!0)/);
     for (const selector of ['.rail-control:focus-visible', '.tab-button:focus-visible', '.sync-btn:focus-visible', '.inline-link:focus-visible']) expect(declarationsFor(selector)).toMatch(/outline:\s*2px/);
+  });
+
+  it('keeps the aggregate orb inline, monochrome, and lifecycle-bounded', () => {
+    expect(declarationsFor('.thinking-orb')).toMatch(/width:\s*20px/);
+    expect(declarationsFor('.thinking-orb')).toMatch(/height:\s*20px/);
+    expect(thinkingOrb).toContain('Math.min(2, window.devicePixelRatio || 1)');
+    expect(thinkingOrb).toContain("matchMedia('(prefers-reduced-motion: reduce)')");
+    expect(thinkingOrb).toContain("document.addEventListener('visibilitychange'");
+    expect(thinkingOrb).toContain('document.hidden');
+    expect(thinkingOrb).toContain('requestAnimationFrame');
+    expect(thinkingOrb).toContain('cancelAnimationFrame');
+    expect(thinkingOrb).not.toContain('IntersectionObserver');
   });
 
   it('uses exact reduced-motion coverage and no stale icon selectors', () => {

--- a/tests/panel-model.test.ts
+++ b/tests/panel-model.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   statusSentence, formatAge, showOnboarding, fileNote,
-  RAIL_WIDTH, RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT,
-  viewportFor, shouldForceInspector,
+  RAIL_COMPACT_WIDTH, RAIL_ONE_ACTION_WIDTH, RAIL_TWO_ACTIONS_WIDTH,
+  RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT,
+  railViewportMode, viewportFor, shouldForceInspector,
   syncPromptLabel, syncResultLabel, syncNowLabel, shouldClearPendingCount,
   syncStartSentence, syncResultSentence, syncStuckSentence, syncSupersededSentence, SYNC_STUCK_TIMEOUT_MS,
   targetButtonLabel,
@@ -100,10 +101,20 @@ describe('targetButtonLabel — the "Target this plugin" toggle (#35 P2)', () =>
 });
 describe('adaptive panel geometry', () => {
   it('maps named viewport modes to the only accepted dimensions', () => {
-    expect(viewportFor('rail')).toEqual({ width: 240, height: 44 });
+    expect(viewportFor('rail-compact')).toEqual({ width: 200, height: 44 });
+    expect(viewportFor('rail-one-action')).toEqual({ width: 220, height: 44 });
+    expect(viewportFor('rail-two-actions')).toEqual({ width: 240, height: 44 });
     expect(viewportFor('inspector')).toEqual({ width: 288, height: 280 });
-    expect([RAIL_WIDTH, RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT])
-      .toEqual([240, 44, 288, 280]);
+    expect([
+      RAIL_COMPACT_WIDTH, RAIL_ONE_ACTION_WIDTH, RAIL_TWO_ACTIONS_WIDTH,
+      RAIL_HEIGHT, INSPECTOR_WIDTH, INSPECTOR_HEIGHT,
+    ]).toEqual([200, 220, 240, 44, 288, 280]);
+  });
+  it('selects the smallest safe rail from conditional control visibility', () => {
+    expect(railViewportMode(false, false)).toBe('rail-compact');
+    expect(railViewportMode(true, false)).toBe('rail-one-action');
+    expect(railViewportMode(false, true)).toBe('rail-one-action');
+    expect(railViewportMode(true, true)).toBe('rail-two-actions');
   });
   it('forces text-bearing recovery only when it is actionable', () => {
     expect(shouldForceInspector('disconnected', 0, false)).toBe(true);

--- a/tests/panel-rail-geometry.test.ts
+++ b/tests/panel-rail-geometry.test.ts
@@ -1,0 +1,46 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { Browser, Page } from 'playwright';
+import { chromium } from 'playwright';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const html = readFileSync(`${ROOT}/plugin/src/ui/panel.html`, 'utf8');
+let browser: Browser;
+let page: Page;
+
+beforeAll(async () => {
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch {
+    browser = await chromium.launch({ headless: true, channel: 'chrome' });
+  }
+  page = await browser.newPage({ viewport: { width: 200, height: 44 } });
+  await page.setContent(html);
+});
+
+afterAll(async () => { await browser?.close(); });
+
+describe('adaptive rail geometry in Chromium', () => {
+  for (const scenario of [
+    { width: 200, target: false, sync: false },
+    { width: 220, target: true, sync: false },
+    { width: 220, target: false, sync: true },
+    { width: 240, target: true, sync: true },
+  ]) {
+    it(`keeps the toggle 8px from the ${scenario.width}px rail edge`, async () => {
+      await page.setViewportSize({ width: scenario.width, height: 44 });
+      await page.evaluate(({ target, sync }) => {
+        (document.getElementById('fga-target-rail-btn') as HTMLButtonElement).hidden = !target;
+        (document.getElementById('fga-sync-rail-btn') as HTMLButtonElement).hidden = !sync;
+      }, scenario);
+      const geometry = await page.evaluate(() => {
+        const current = document.getElementById('fga-current-btn')!.getBoundingClientRect();
+        const toggle = document.getElementById('fga-toggle-btn')!.getBoundingClientRect();
+        return { currentRight: current.right, toggleLeft: toggle.left, toggleRight: toggle.right };
+      });
+      expect(geometry.toggleRight).toBe(scenario.width - 8);
+      expect(geometry.toggleLeft - geometry.currentRight).toBeGreaterThanOrEqual(4);
+    });
+  }
+});

--- a/tests/thinking-orb.test.ts
+++ b/tests/thinking-orb.test.ts
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mountThinkingOrb, orbPresentation } from '../plugin/src/ui/thinking-orb.ts';
+
+const healthy = {
+  connection: 'connected' as const,
+  connectionFailure: false,
+  syncFailure: false,
+  activityFailure: false,
+  activityPending: false,
+  syncPending: false,
+};
+
+describe('orbPresentation', () => {
+  it('makes unresolved failure the highest-priority aggregate state', () => {
+    for (const failure of ['connectionFailure', 'syncFailure', 'activityFailure'] as const) {
+      expect(orbPresentation({ ...healthy, [failure]: true })).toEqual({
+        state: 'shaping', paused: true, dimmed: false, status: 'Needs attention',
+      });
+    }
+  });
+
+  it('maps connection transitions and loss without fabricating health', () => {
+    expect(orbPresentation({ ...healthy, connection: 'probing' })).toEqual({
+      state: 'connecting', paused: false, dimmed: false, status: 'Connecting',
+    });
+    expect(orbPresentation({ ...healthy, connection: 'handshake' })).toEqual({
+      state: 'connecting', paused: false, dimmed: false, status: 'Connecting',
+    });
+    expect(orbPresentation({ ...healthy, connection: 'disconnected' })).toEqual({
+      state: 'connecting', paused: true, dimmed: true, status: 'Disconnected',
+    });
+  });
+
+  it('maps pending work and connected rest after connection health', () => {
+    expect(orbPresentation({ ...healthy, activityPending: true })).toEqual({
+      state: 'working', paused: false, dimmed: false, status: 'Processing',
+    });
+    expect(orbPresentation({ ...healthy, syncPending: true })).toEqual({
+      state: 'working', paused: false, dimmed: false, status: 'Processing',
+    });
+    expect(orbPresentation(healthy)).toEqual({
+      state: 'breathing', paused: false, dimmed: false, status: 'Connected',
+    });
+  });
+});
+
+interface OrbHarness {
+  target: { append(node: unknown): void };
+  canvas: { removed: boolean };
+  context: { clears: number };
+  media: { matches: boolean; emit(): void; listeners: Set<() => void> };
+  documentState: { hidden: boolean; emit(): void; listeners: Set<() => void> };
+  observer: { emit(): void; disconnected: boolean };
+  raf: Map<number, FrameRequestCallback>;
+  cancelled: number[];
+  runFrame(now?: number): void;
+}
+
+function orbHarness(hasContext = true): OrbHarness {
+  const context = {
+    clears: 0, fillStyle: '', strokeStyle: '', lineWidth: 0,
+    setTransform() {}, clearRect() { this.clears += 1; }, beginPath() {},
+    arc() {}, fill() {}, moveTo() {}, lineTo() {}, stroke() {},
+  };
+  const canvas = {
+    width: 0, height: 0, className: '', dataset: {} as Record<string, string>, removed: false,
+    setAttribute() {}, getContext: () => hasContext ? context : null, remove() { this.removed = true; },
+  };
+  const mediaListeners = new Set<() => void>();
+  const media = {
+    matches: false, listeners: mediaListeners,
+    addEventListener: (_: string, fn: () => void) => mediaListeners.add(fn),
+    removeEventListener: (_: string, fn: () => void) => mediaListeners.delete(fn),
+    emit: () => [...mediaListeners].forEach((fn) => fn()),
+  };
+  const visibilityListeners = new Set<() => void>();
+  const documentState = {
+    hidden: false, listeners: visibilityListeners,
+    documentElement: { classList: { contains: () => false } },
+    createElement: () => canvas,
+    addEventListener: (_: string, fn: () => void) => visibilityListeners.add(fn),
+    removeEventListener: (_: string, fn: () => void) => visibilityListeners.delete(fn),
+    emit: () => [...visibilityListeners].forEach((fn) => fn()),
+  };
+  let observerCallback: () => void = () => {};
+  const observer = { emit: () => observerCallback(), disconnected: false };
+  class FakeMutationObserver {
+    constructor(callback: () => void) { observerCallback = callback; }
+    observe() {}
+    disconnect() { observer.disconnected = true; }
+  }
+  const raf = new Map<number, FrameRequestCallback>();
+  const cancelled: number[] = [];
+  let nextFrame = 1;
+  vi.stubGlobal('document', documentState);
+  vi.stubGlobal('window', { devicePixelRatio: 3, matchMedia: () => media });
+  vi.stubGlobal('MutationObserver', FakeMutationObserver);
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+    const id = nextFrame++; raf.set(id, callback); return id;
+  });
+  vi.stubGlobal('cancelAnimationFrame', (id: number) => { cancelled.push(id); raf.delete(id); });
+  return {
+    target: { append: () => {} }, canvas, context, media, documentState, observer, raf, cancelled,
+    runFrame(now = 1000): void {
+      const entry = raf.entries().next().value as [number, FrameRequestCallback] | undefined;
+      if (!entry) throw new Error('No pending animation frame');
+      raf.delete(entry[0]); entry[1](now);
+    },
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe('Thinking Orb canvas lifecycle', () => {
+  it('fails soft when a 2D canvas context is unavailable', () => {
+    const harness = orbHarness(false);
+    const controller = mountThinkingOrb(harness.target as unknown as HTMLElement);
+    expect(harness.canvas.removed).toBe(true);
+    expect(harness.raf.size).toBe(0);
+    expect(() => controller.update(orbPresentation(healthy))).not.toThrow();
+    expect(() => controller.dispose()).not.toThrow();
+  });
+
+  it('keeps at most one RAF and makes same-presentation updates a no-op', () => {
+    const harness = orbHarness();
+    const controller = mountThinkingOrb(harness.target as unknown as HTMLElement);
+    expect(harness.raf.size).toBe(0);
+    controller.update(orbPresentation(healthy));
+    expect(harness.raf.size).toBe(1);
+    const clears = harness.context.clears;
+    controller.update(orbPresentation(healthy));
+    expect(harness.context.clears).toBe(clears);
+    expect(harness.raf.size).toBe(1);
+    harness.runFrame();
+    expect(harness.raf.size).toBe(1);
+  });
+
+  it('pauses for state, reduced motion, and document visibility', () => {
+    const harness = orbHarness();
+    const controller = mountThinkingOrb(harness.target as unknown as HTMLElement);
+    controller.update(orbPresentation(healthy));
+    controller.update(orbPresentation({ ...healthy, activityFailure: true }));
+    expect(harness.raf.size).toBe(0);
+    controller.update(orbPresentation(healthy));
+    harness.media.matches = true; harness.media.emit();
+    expect(harness.raf.size).toBe(0);
+    harness.media.matches = false; harness.media.emit();
+    harness.documentState.hidden = true; harness.documentState.emit();
+    expect(harness.raf.size).toBe(0);
+    expect(harness.context.clears).toBeGreaterThan(3);
+  });
+
+  it('refreshes on motion, visibility, and theme changes, then disposes everything', () => {
+    const harness = orbHarness();
+    const controller = mountThinkingOrb(harness.target as unknown as HTMLElement);
+    controller.update(orbPresentation(healthy));
+    const clears = harness.context.clears;
+    harness.media.emit(); harness.documentState.emit(); harness.observer.emit();
+    expect(harness.context.clears).toBe(clears + 3);
+    expect(harness.raf.size).toBe(1);
+    controller.dispose();
+    expect(harness.raf.size).toBe(0);
+    expect(harness.cancelled.length).toBeGreaterThan(0);
+    expect(harness.observer.disconnected).toBe(true);
+    expect(harness.media.listeners.size).toBe(0);
+    expect(harness.documentState.listeners.size).toBe(0);
+    expect(harness.canvas.removed).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- replace duplicate status glyphs with one thinking-orbs canvas for connected, processing, success, and error states
- hug the compact rail at deterministic 200/220/240 px modes without trailing empty space
- keep the activity label readable while preserving inspector and optional action behavior
- attribute the MIT-licensed ORB reference from orbs.jakubantalik.com in third-party notices

## Test plan
- [x] npm run typecheck
- [x] npm run build
- [x] npm test (1676/1676)
- [x] npm run lint:comments
- [x] focused panel/orb tests (69/69)
- [x] generated plugin artifacts reproduce cleanly
- [x] independent review: APPROVE

Relates #79

Live Figma visual smoke remains pending before issue closure.