### PR TITLE
fix(ci): allow cold chromium startup

### DIFF
--- a/tests/panel-rail-geometry.test.ts
+++ b/tests/panel-rail-geometry.test.ts
@@ -6,6 +6,7 @@ import { chromium } from 'playwright';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
 const html = readFileSync(`${ROOT}/plugin/src/ui/panel.html`, 'utf8');
+const BROWSER_SETUP_TIMEOUT_MS = 30_000;
 let browser: Browser;
 let page: Page;
 
@@ -17,7 +18,7 @@ beforeAll(async () => {
   }
   page = await browser.newPage({ viewport: { width: 200, height: 44 } });
   await page.setContent(html);
-});
+}, BROWSER_SETUP_TIMEOUT_MS);
 
 afterAll(async () => { await browser?.close(); });
 


### PR DESCRIPTION
## Summary
- allow up to 30 seconds for Playwright to launch Chromium in the rail geometry suite
- keep geometry assertions and production behavior unchanged
- address the repeated cold-start timeout from main CI run https://github.com/jangtrinh/design-os-figma-plugin/actions/runs/32700463140

## Test plan
- [x] focused rail geometry tests (4/4)
- [x] npm test (133 files, 1676 tests)
- [x] npm run typecheck
- [x] npm run build
- [x] npm run lint:comments
- [x] git diff --check
- [x] independent review: APPROVE

Closes #81
Relates #79