### PR TITLE
feat(plugin): map orb to command semantics

### DIFF
--- a/plugin/src/ui/orb-command-state.ts
+++ b/plugin/src/ui/orb-command-state.ts
@@ -1,0 +1,43 @@
+import type { OrbState } from 'thinking-orbs/engine';
+
+export interface CommandOrbPresentation {
+  state: OrbState;
+  status: string;
+}
+
+const COMMANDS_BY_STATE = {
+  searching: new Set([
+    'STATUS', 'GET_SELECTION', 'SCAN_DESIGN_SYSTEM', 'GET_CORRECTION_MEMORY',
+    'LIST_CONNECTIONS', 'SHADER_GRADIENT_PROBE',
+  ]),
+  solving: new Set(['AUDIT_DS', 'VERIFY_CONNECTIONS']),
+  composing: new Set([
+    'CREATE_FRAME', 'CREATE_INSTANCE', 'CREATE_VARIABLE', 'SET_TEXT', 'HTML_TO_FIGMA',
+    'IMPORT_PAYLOAD', 'SHADER_GRADIENT', 'IMPORT_GRADIENT', 'EXPORT_PNG',
+  ]),
+  shaping: new Set([
+    'SET_VARIANT', 'BIND_VARIABLE', 'SET_AUTOLAYOUT', 'SET_CONSTRAINTS', 'CLONE_TRAITS',
+  ]),
+  weaving: new Set(['BATCH', 'CONNECT', 'DISCONNECT', 'REROUTE', 'RECONCILE']),
+  working: new Set(['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB']),
+  listening: new Set(['COWORK']),
+} satisfies Partial<Record<OrbState, ReadonlySet<string>>>;
+
+const STATUS_BY_STATE = {
+  searching: 'Searching',
+  solving: 'Analyzing',
+  composing: 'Composing',
+  shaping: 'Shaping',
+  weaving: 'Coordinating',
+  listening: 'Listening',
+  working: 'Processing',
+} satisfies Partial<Record<OrbState, string>>;
+
+export function commandOrbPresentation(command: string): CommandOrbPresentation {
+  for (const state of Object.keys(COMMANDS_BY_STATE) as Array<keyof typeof COMMANDS_BY_STATE>) {
+    if (COMMANDS_BY_STATE[state].has(command)) {
+      return { state, status: STATUS_BY_STATE[state] };
+    }
+  }
+  return { state: 'working', status: STATUS_BY_STATE.working };
+}

--- a/plugin/src/ui/panel-activity-view.ts
+++ b/plugin/src/ui/panel-activity-view.ts
@@ -74,6 +74,7 @@ function row(record: ActivityRecord, now: number, stale: boolean, fresh: boolean
 export class ActivityView {
   private records: ActivityRecord[] = [];
   private previousKeys: string[] = [];
+  private readonly activeTools = new Map<string, string>();
   readonly failures = new BoundedKeySet();
 
   constructor(
@@ -83,10 +84,15 @@ export class ActivityView {
     private readonly failureCount: HTMLElement,
   ) {}
 
-  push(record: ActivityRecord): void { this.records = pushActivity(this.records, record); }
+  push(record: ActivityRecord): void {
+    this.records = pushActivity(this.records, record);
+    if (record.pending) this.activeTools.set(record.id, record.tool);
+    else this.activeTools.delete(record.id);
+  }
 
   resolve(patch: ActivityResult, trackFailure = true): void {
     this.records = landTerminalActivity(this.records, patch);
+    this.activeTools.delete(patch.id);
     if (trackFailure) applyActivityOutcome(this.failures, patch.id, patch.ok);
   }
 
@@ -95,6 +101,10 @@ export class ActivityView {
   railPhase(): ActivityRailPhase {
     const current = currentActivity(this.records);
     return !current ? 'idle' : current.pending ? 'pending' : current.ok ? 'complete' : 'failed';
+  }
+
+  pendingTools(): readonly string[] {
+    return [...this.activeTools.values()];
   }
 
   render(now = Date.now()): void {

--- a/plugin/src/ui/panel-ui.ts
+++ b/plugin/src/ui/panel-ui.ts
@@ -87,7 +87,7 @@ function renderOrb(): void {
   const orb = orbPresentation({
     connection: payload?.state ?? 'disconnected', connectionFailure, syncFailure,
     activityFailure: activityView.failures.unresolvedCount > 0,
-    activityPending: activityView.railPhase() === 'pending',
+    pendingTools: activityView.pendingTools(),
     syncPending: pendingSyncCount > 0,
   });
   thinkingOrb.update(orb);

--- a/plugin/src/ui/thinking-orb.ts
+++ b/plugin/src/ui/thinking-orb.ts
@@ -1,5 +1,6 @@
 import type { ConnectionState } from '../../../shared/protocol';
 import { MODE_DRAWS, resolvePreset, type OrbState } from 'thinking-orbs/engine';
+import { commandOrbPresentation } from './orb-command-state';
 
 const ORB_SIZE = 20;
 const STATIC_TIME = 0.75;
@@ -9,7 +10,7 @@ export interface OrbSignals {
   connectionFailure: boolean;
   syncFailure: boolean;
   activityFailure: boolean;
-  activityPending: boolean;
+  pendingTools: readonly string[];
   syncPending: boolean;
 }
 
@@ -17,7 +18,7 @@ export interface OrbPresentation {
   state: OrbState;
   paused: boolean;
   dimmed: boolean;
-  status: 'Connected' | 'Processing' | 'Connecting' | 'Disconnected' | 'Needs attention';
+  status: string;
 }
 
 export function orbPresentation(signals: OrbSignals): OrbPresentation {
@@ -30,8 +31,16 @@ export function orbPresentation(signals: OrbSignals): OrbPresentation {
   if (signals.connection === 'disconnected') {
     return { state: 'connecting', paused: true, dimmed: true, status: 'Disconnected' };
   }
-  if (signals.activityPending || signals.syncPending) {
-    return { state: 'working', paused: false, dimmed: false, status: 'Processing' };
+  const syncRepresented = signals.pendingTools.includes('RECONCILE');
+  const pendingCount = signals.pendingTools.length + (signals.syncPending && !syncRepresented ? 1 : 0);
+  if (pendingCount >= 2) {
+    return { state: 'weaving', paused: false, dimmed: false, status: `${pendingCount} tasks running` };
+  }
+  if (signals.syncPending) {
+    return { state: 'weaving', paused: false, dimmed: false, status: 'Syncing' };
+  }
+  if (signals.pendingTools.length === 1) {
+    return { ...commandOrbPresentation(signals.pendingTools[0] ?? ''), paused: false, dimmed: false };
   }
   return { state: 'breathing', paused: false, dimmed: false, status: 'Connected' };
 }
@@ -57,7 +66,7 @@ export function mountThinkingOrb(target: HTMLElement): ThinkingOrbController {
   const reducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)');
   let presentation = orbPresentation({
     connection: 'disconnected', connectionFailure: false, syncFailure: false,
-    activityFailure: false, activityPending: false, syncPending: false,
+    activityFailure: false, pendingTools: [], syncPending: false,
   });
   canvas.dataset.dimmed = String(presentation.dimmed);
   let frameId: number | null = null;

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1391,13 +1391,17 @@ body { overflow: hidden; }
       this.failureCount = failureCount;
       this.records = [];
       this.previousKeys = [];
+      this.activeTools = /* @__PURE__ */ new Map();
       this.failures = new BoundedKeySet();
     }
     push(record) {
       this.records = pushActivity(this.records, record);
+      if (record.pending) this.activeTools.set(record.id, record.tool);
+      else this.activeTools.delete(record.id);
     }
     resolve(patch, trackFailure = true) {
       this.records = landTerminalActivity(this.records, patch);
+      this.activeTools.delete(patch.id);
       if (trackFailure) applyActivityOutcome(this.failures, patch.id, patch.ok);
     }
     acknowledgeFailures() {
@@ -1406,6 +1410,9 @@ body { overflow: hidden; }
     railPhase() {
       const current = currentActivity(this.records);
       return !current ? "idle" : current.pending ? "pending" : current.ok ? "complete" : "failed";
+    }
+    pendingTools() {
+      return [...this.activeTools.values()];
     }
     render(now = Date.now()) {
       const shown = this.records.slice(0, 20);
@@ -2067,6 +2074,57 @@ body { overflow: hidden; }
     return tt.set(t, M), M;
   }
 
+  // plugin/src/ui/orb-command-state.ts
+  var COMMANDS_BY_STATE = {
+    searching: /* @__PURE__ */ new Set([
+      "STATUS",
+      "GET_SELECTION",
+      "SCAN_DESIGN_SYSTEM",
+      "GET_CORRECTION_MEMORY",
+      "LIST_CONNECTIONS",
+      "SHADER_GRADIENT_PROBE"
+    ]),
+    solving: /* @__PURE__ */ new Set(["AUDIT_DS", "VERIFY_CONNECTIONS"]),
+    composing: /* @__PURE__ */ new Set([
+      "CREATE_FRAME",
+      "CREATE_INSTANCE",
+      "CREATE_VARIABLE",
+      "SET_TEXT",
+      "HTML_TO_FIGMA",
+      "IMPORT_PAYLOAD",
+      "SHADER_GRADIENT",
+      "IMPORT_GRADIENT",
+      "EXPORT_PNG"
+    ]),
+    shaping: /* @__PURE__ */ new Set([
+      "SET_VARIANT",
+      "BIND_VARIABLE",
+      "SET_AUTOLAYOUT",
+      "SET_CONSTRAINTS",
+      "CLONE_TRAITS"
+    ]),
+    weaving: /* @__PURE__ */ new Set(["BATCH", "CONNECT", "DISCONNECT", "REROUTE", "RECONCILE"]),
+    working: /* @__PURE__ */ new Set(["EXEC_JS", "SET_CORRECTION_MEMORY", "PROJECT_BIND", "JOB"]),
+    listening: /* @__PURE__ */ new Set(["COWORK"])
+  };
+  var STATUS_BY_STATE = {
+    searching: "Searching",
+    solving: "Analyzing",
+    composing: "Composing",
+    shaping: "Shaping",
+    weaving: "Coordinating",
+    listening: "Listening",
+    working: "Processing"
+  };
+  function commandOrbPresentation(command) {
+    for (const state of Object.keys(COMMANDS_BY_STATE)) {
+      if (COMMANDS_BY_STATE[state].has(command)) {
+        return { state, status: STATUS_BY_STATE[state] };
+      }
+    }
+    return { state: "working", status: STATUS_BY_STATE.working };
+  }
+
   // plugin/src/ui/thinking-orb.ts
   var ORB_SIZE = 20;
   var STATIC_TIME = 0.75;
@@ -2080,8 +2138,16 @@ body { overflow: hidden; }
     if (signals.connection === "disconnected") {
       return { state: "connecting", paused: true, dimmed: true, status: "Disconnected" };
     }
-    if (signals.activityPending || signals.syncPending) {
-      return { state: "working", paused: false, dimmed: false, status: "Processing" };
+    const syncRepresented = signals.pendingTools.includes("RECONCILE");
+    const pendingCount = signals.pendingTools.length + (signals.syncPending && !syncRepresented ? 1 : 0);
+    if (pendingCount >= 2) {
+      return { state: "weaving", paused: false, dimmed: false, status: `${pendingCount} tasks running` };
+    }
+    if (signals.syncPending) {
+      return { state: "weaving", paused: false, dimmed: false, status: "Syncing" };
+    }
+    if (signals.pendingTools.length === 1) {
+      return { ...commandOrbPresentation(signals.pendingTools[0] ?? ""), paused: false, dimmed: false };
     }
     return { state: "breathing", paused: false, dimmed: false, status: "Connected" };
   }
@@ -2104,7 +2170,7 @@ body { overflow: hidden; }
       connectionFailure: false,
       syncFailure: false,
       activityFailure: false,
-      activityPending: false,
+      pendingTools: [],
       syncPending: false
     });
     canvas.dataset.dimmed = String(presentation.dimmed);
@@ -2264,7 +2330,7 @@ body { overflow: hidden; }
       connectionFailure,
       syncFailure,
       activityFailure: activityView.failures.unresolvedCount > 0,
-      activityPending: activityView.railPhase() === "pending",
+      pendingTools: activityView.pendingTools(),
       syncPending: pendingSyncCount > 0
     });
     thinkingOrb.update(orb);
@@ -2472,7 +2538,7 @@ body { overflow: hidden; }
     }, 4e3);
     render();
   });
-  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "8e47266" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "dcf064d" : "dev"}`;
   replaceIcon(targetRailBtn, "files");
   replaceIcon(syncRailBtn, "refresh-cw");
   replaceIcon(toggleBtn, "chevron-down");

--- a/tests/orb-command-state.test.ts
+++ b/tests/orb-command-state.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { COMMANDS } from '../shared/protocol.ts';
+import { commandOrbPresentation } from '../plugin/src/ui/orb-command-state.ts';
+import { orbPresentation } from '../plugin/src/ui/thinking-orb.ts';
+import { labelControl } from '../plugin/src/ui/panel-activity-view.ts';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+
+const groups = [
+  ['searching', 'Searching', ['STATUS', 'GET_SELECTION', 'SCAN_DESIGN_SYSTEM',
+    'GET_CORRECTION_MEMORY', 'LIST_CONNECTIONS', 'SHADER_GRADIENT_PROBE']],
+  ['solving', 'Analyzing', ['AUDIT_DS', 'VERIFY_CONNECTIONS']],
+  ['composing', 'Composing', ['CREATE_FRAME', 'CREATE_INSTANCE', 'CREATE_VARIABLE',
+    'SET_TEXT', 'HTML_TO_FIGMA', 'IMPORT_PAYLOAD', 'SHADER_GRADIENT',
+    'IMPORT_GRADIENT', 'EXPORT_PNG']],
+  ['shaping', 'Shaping', ['SET_VARIANT', 'BIND_VARIABLE', 'SET_AUTOLAYOUT',
+    'SET_CONSTRAINTS', 'CLONE_TRAITS']],
+  ['weaving', 'Coordinating', ['BATCH', 'CONNECT', 'DISCONNECT', 'REROUTE', 'RECONCILE']],
+  ['working', 'Processing', ['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB']],
+  ['listening', 'Listening', ['COWORK']],
+] as const;
+
+describe('commandOrbPresentation', () => {
+  it('covers every wire command exactly, plus only local RECONCILE', () => {
+    const mapped = groups.flatMap(([, , commands]) => [...commands]).sort();
+    expect(mapped).toEqual([...COMMANDS, 'RECONCILE'].sort());
+    expect(new Set(mapped).size).toBe(mapped.length);
+  });
+
+  it.each(groups)('maps %s commands from stable command identity', (state, status, commands) => {
+    for (const command of commands) {
+      expect(commandOrbPresentation(command), command).toEqual({ state, status });
+    }
+  });
+
+  it('uses working for unknown future commands', () => {
+    expect(commandOrbPresentation('FUTURE_COMMAND')).toEqual({
+      state: 'working', status: 'Processing',
+    });
+  });
+
+  it.each(groups)('carries %s through the one-task aggregate', (state, status, commands) => {
+    expect(orbPresentation({
+      connection: 'connected', connectionFailure: false, syncFailure: false,
+      activityFailure: false, pendingTools: [commands[0]], syncPending: false,
+    })).toMatchObject({ state, status, paused: false, dimmed: false });
+  });
+
+  it('keeps semantic status as the native connection button accessible label', () => {
+    const panelUi = readFileSync(`${ROOT}/plugin/src/ui/panel-ui.ts`, 'utf8');
+    expect(panelUi).toContain('labelControl(connectionBtn, `${orb.status}. Open details`)');
+    const labels = new Map<string, string>();
+    const target = {
+      title: '', setAttribute: (name: string, value: string) => labels.set(name, value),
+    } as unknown as HTMLButtonElement;
+    const orb = orbPresentation({
+      connection: 'connected', connectionFailure: false, syncFailure: false,
+      activityFailure: false, pendingTools: ['AUDIT_DS'], syncPending: false,
+    });
+    labelControl(target, `${orb.status}. Open details`);
+    expect(target.title).toBe('Analyzing. Open details');
+    expect(labels.get('aria-label')).toBe('Analyzing. Open details');
+  });
+});

--- a/tests/panel-view-state.test.ts
+++ b/tests/panel-view-state.test.ts
@@ -3,7 +3,7 @@ import {
   BoundedKeySet, VIEW_KEY_LIMIT, applyActivityOutcome, connectionForce,
   currentActivity, landTerminalActivity, unresolvedActivityCount,
 } from '../plugin/src/ui/panel-view-state.ts';
-import { renderFailureBadge } from '../plugin/src/ui/panel-activity-view.ts';
+import { ActivityView, renderFailureBadge } from '../plugin/src/ui/panel-activity-view.ts';
 import type { ActivityRecord } from '../plugin/src/ui/activity-feed.ts';
 
 const record = (id: string, pending: boolean, ok: boolean, at: number): ActivityRecord => ({
@@ -65,6 +65,57 @@ describe('keyed unresolved activity failures', () => {
     renderFailureBadge(badge, 0);
     expect(badge).toMatchObject({ hidden: true, textContent: '' });
     expect(attributes.get('aria-label')).toBe('0 unresolved failures');
+  });
+});
+
+describe('pending activity command snapshots', () => {
+  const view = (): ActivityView => new ActivityView(
+    {} as HTMLElement, {} as HTMLButtonElement, {} as HTMLElement, {} as HTMLElement,
+  );
+
+  it('includes every pending request without deduplicating command names', () => {
+    const activity = view();
+    activity.push(record('oldest', true, true, 1));
+    activity.push(record('newest', true, true, 2));
+    expect(activity.pendingTools()).toEqual(['EXEC_JS', 'EXEC_JS']);
+  });
+
+  it('keeps unrelated pending work through out-of-order completion', () => {
+    const activity = view();
+    activity.push({ ...record('oldest', true, true, 1), tool: 'AUDIT_DS' });
+    activity.push({ ...record('newest', true, true, 2), tool: 'SET_TEXT' });
+    activity.resolve({ id: 'newest', ok: true, ms: 1 });
+    expect(activity.pendingTools()).toEqual(['AUDIT_DS']);
+    activity.resolve({ id: 'oldest', ok: true, ms: 2 });
+    expect(activity.pendingTools()).toEqual([]);
+  });
+
+  it('keeps the newer request when the oldest request resolves first', () => {
+    const activity = view();
+    activity.push({ ...record('oldest', true, true, 1), tool: 'AUDIT_DS' });
+    activity.push({ ...record('newest', true, true, 2), tool: 'SET_TEXT' });
+    activity.resolve({ id: 'oldest', ok: true, ms: 1 });
+    expect(activity.pendingTools()).toEqual(['SET_TEXT']);
+  });
+
+  it('tracks every active request beyond the capped 50-row display history', () => {
+    const activity = view();
+    for (let index = 0; index < 65; index += 1) {
+      activity.push(record(`request-${index}`, true, true, index));
+    }
+    expect(activity.pendingTools()).toHaveLength(65);
+    activity.resolve({ id: 'request-0', ok: true, ms: 1 });
+    expect(activity.pendingTools()).toHaveLength(64);
+    activity.resolve({ id: 'request-64', ok: true, ms: 1 });
+    expect(activity.pendingTools()).toHaveLength(63);
+  });
+
+  it('returns a fresh snapshot that cannot mutate the activity buffer', () => {
+    const activity = view();
+    activity.push(record('request', true, true, 1));
+    const snapshot = activity.pendingTools() as string[];
+    snapshot.length = 0;
+    expect(activity.pendingTools()).toEqual(['EXEC_JS']);
   });
 });
 

--- a/tests/thinking-orb.test.ts
+++ b/tests/thinking-orb.test.ts
@@ -6,14 +6,18 @@ const healthy = {
   connectionFailure: false,
   syncFailure: false,
   activityFailure: false,
-  activityPending: false,
+  pendingTools: [] as string[],
   syncPending: false,
 };
 
 describe('orbPresentation', () => {
   it('makes unresolved failure the highest-priority aggregate state', () => {
+    const activeTransport = {
+      ...healthy, connection: 'handshake' as const,
+      pendingTools: ['SCAN_DESIGN_SYSTEM'], syncPending: true,
+    };
     for (const failure of ['connectionFailure', 'syncFailure', 'activityFailure'] as const) {
-      expect(orbPresentation({ ...healthy, [failure]: true })).toEqual({
+      expect(orbPresentation({ ...activeTransport, [failure]: true })).toEqual({
         state: 'shaping', paused: true, dimmed: false, status: 'Needs attention',
       });
     }
@@ -31,16 +35,36 @@ describe('orbPresentation', () => {
     });
   });
 
-  it('maps pending work and connected rest after connection health', () => {
-    expect(orbPresentation({ ...healthy, activityPending: true })).toEqual({
-      state: 'working', paused: false, dimmed: false, status: 'Processing',
+  it('maps one command, sync, concurrency, fallback, and connected rest', () => {
+    expect(orbPresentation({ ...healthy, pendingTools: ['SCAN_DESIGN_SYSTEM'] })).toEqual({
+      state: 'searching', paused: false, dimmed: false, status: 'Searching',
     });
     expect(orbPresentation({ ...healthy, syncPending: true })).toEqual({
+      state: 'weaving', paused: false, dimmed: false, status: 'Syncing',
+    });
+    expect(orbPresentation({ ...healthy, pendingTools: ['RECONCILE'], syncPending: true })).toEqual({
+      state: 'weaving', paused: false, dimmed: false, status: 'Syncing',
+    });
+    expect(orbPresentation({ ...healthy, pendingTools: ['SCAN_DESIGN_SYSTEM', 'RECONCILE'], syncPending: true }).status).toBe('2 tasks running');
+    expect(orbPresentation({ ...healthy, pendingTools: ['RECONCILE', 'RECONCILE'], syncPending: true }).status).toBe('2 tasks running');
+    expect(orbPresentation({ ...healthy, pendingTools: ['AUDIT_DS'], syncPending: true })).toEqual({
+      state: 'weaving', paused: false, dimmed: false, status: '2 tasks running',
+    });
+    expect(orbPresentation({ ...healthy, pendingTools: ['SET_TEXT', 'SET_TEXT'] })).toEqual({
+      state: 'weaving', paused: false, dimmed: false, status: '2 tasks running',
+    });
+    expect(orbPresentation({ ...healthy, pendingTools: ['FUTURE_COMMAND'] })).toEqual({
       state: 'working', paused: false, dimmed: false, status: 'Processing',
     });
     expect(orbPresentation(healthy)).toEqual({
       state: 'breathing', paused: false, dimmed: false, status: 'Connected',
     });
+  });
+
+  it('keeps failure and transport above semantic work', () => {
+    const working = { ...healthy, pendingTools: ['SCAN_DESIGN_SYSTEM'] };
+    expect(orbPresentation({ ...working, connection: 'handshake' }).status).toBe('Connecting');
+    expect(orbPresentation({ ...working, connection: 'disconnected' }).status).toBe('Disconnected');
   });
 });
 


### PR DESCRIPTION
## Summary
- Map every stable plugin command to an intentional Thinking Orb state.
- Preserve failure and transport priority while using weaving for concurrent work.
- Track all pending requests independently of the capped activity history.

## Verification
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` (1,699 tests)
- [x] `npm run lint:comments`
- [ ] Live Figma semantic-state smoke (pending)

Closes #83