### PR TITLE
build(lint): replace kernel submodule with package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          submodules: recursive
           persist-credentials: false
 
       - name: Set up Node.js

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "kernel/design-os"]
-	path = kernel/design-os
-	url = https://github.com/jangtrinh/design-os.git
-	shallow = true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ GitHub issue = one Sonnet-ready task. The standard lifecycle, using installed ak
 ## Gates (all must pass before any PR)
 
 - `npm run typecheck` · `npm run build` · `npm test` (includes the panel gate,
-  `tests/figma-plugin-panel.test.ts`, which needs `git submodule update --init --depth 1`).
+  `tests/figma-plugin-panel.test.ts`, backed by the exact dev dependency `ease-design@0.5.0`).
 - `npm run lint:comments` — fails on a NEW ephemeral work-tracking ref (a GH issue/PR
   number, a dated plan-dir slug, or a bare finding/audit label) in a tracked comment or
   test name under `plugin/src`, `cli/src`, `shared`, `tests`. It deliberately ALLOWS this
@@ -35,8 +35,8 @@ GitHub issue = one Sonnet-ready task. The standard lifecycle, using installed ak
   — including one added right next to an existing one — still fails. Run
   `npm run lint:comments:update-baseline` only when deliberately retiring an old citation by
   restating its invariant directly (never to launder a new one through).
-- The panel gate runs the kernel's own linters from the pinned `kernel/design-os` submodule —
-  a bridge until `ease-design/lint` is published (issue #9). Bump the pin deliberately.
+- The panel gate imports layout, accessibility, taste, and content linters directly from
+  `ease-design/lint`; keep the package pin exact so local and CI results share one boundary.
 
 ## House rules (carried from the design-os studio)
 
@@ -65,6 +65,5 @@ GitHub issue = one Sonnet-ready task. The standard lifecycle, using installed ak
 - `shared/` — protocol, edit-feed schema, mutating-command classification.
 - `tests/` — the full suite (900+); daemon-harness tests cover the broker seams pure unit
   tests cannot see.
-- `kernel/design-os` — pinned submodule (panel-gate linters only; see issue #9).
 
 The studio this belongs to: https://github.com/jangtrinh/design-os

--- a/README.md
+++ b/README.md
@@ -170,28 +170,11 @@ plugin/       Figma plugin: main-thread executor + a hidden-iframe HTML→Figma 
 shared/       wire-protocol types shared by cli/ and plugin/
 scripts/      esbuild build script + an optional probe/ suite (site recon, visual diff)
 tests/        vitest unit tests (pure-logic; run with `npm test`)
-kernel/       git submodule bridge to the design-os kernel (dev-only, see below)
 ```
 
-### Dev note: the `kernel/design-os` submodule (a bridge, not architecture)
-
-`tests/figma-plugin-panel.test.ts` (the panel's craft/taste/a11y gate) runs the SAME four
-linters every ease-design-generated artifact does. Those linters aren't part of the
-published `ease-design` npm package yet, and an npm git-dependency doesn't help either —
-npm applies the kernel's own publish `"files"` allowlist even to git-dependency installs,
-so the linter sources never land in `node_modules` regardless of what the pinned commit
-actually contains. `kernel/design-os` is a real git **submodule** instead (a raw checkout
-npm packing can't touch), pinned to one commit — one source of truth, no local fork of
-the linter subsystem.
-
-- First clone: `git submodule update --init --depth 1` before running `npm test`. The
-  panel test fails with that exact instruction if you forget.
-- Bumping the pin: `cd kernel/design-os && git fetch --depth 1 origin <ref> && git
-  checkout <ref>`, then commit the updated gitlink in this repo — a deliberate act, not
-  automatic drift.
-- This bridge is temporary: once the kernel publishes its linters as a real
-  `ease-design/lint` subpath export, this submodule goes away and the panel test imports
-  the published package directly instead.
+`tests/figma-plugin-panel.test.ts` runs the same layout, accessibility, taste, and content
+linters as ease-design-generated artifacts. They come from the exact dev dependency
+`ease-design@0.5.0`, so `npm ci` is sufficient to run the panel gate in a fresh clone.
 
 ## Supervised editing loop
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "@figma/plugin-typings": "^1.130.0",
         "@types/node": "^22.0.0",
         "@types/ws": "^8.5.10",
+        "ease-design": "0.5.0",
         "esbuild": "^0.24.0",
         "playwright-core": "^1.62.1",
         "thinking-orbs": "0.3.1",
@@ -1112,6 +1113,23 @@
       "integrity": "sha512-pGVkY3T/qXxAp2nFPodwYqOevk6ncNMSmvL8QfRCx5ZWGd6Vor7AFNmyaA8Zs6uJyP1QAfjuLandCgvSix1BNA==",
       "license": "BSD-3-Clause",
       "optional": true
+    },
+    "node_modules/ease-design": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/ease-design/-/ease-design-0.5.0.tgz",
+      "integrity": "sha512-gDl4/6pYFADPIEWlhJZhof4GzhNur9QjMqICU8bG1bllg+VeZjTxrwQsHDPqLKbbsKvsC8IMk3cyUpg++QWLaQ==",
+      "dev": true,
+      "license": "MIT",
+      "workspaces": [
+        "a11y",
+        "recall"
+      ],
+      "bin": {
+        "ui": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/emoji-regex": {
       "version": "10.6.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@figma/plugin-typings": "^1.130.0",
     "@types/node": "^22.0.0",
     "@types/ws": "^8.5.10",
+    "ease-design": "0.5.0",
     "esbuild": "^0.24.0",
     "playwright-core": "^1.62.1",
     "thinking-orbs": "0.3.1",

--- a/tests/figma-plugin-panel.test.ts
+++ b/tests/figma-plugin-panel.test.ts
@@ -1,26 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
+import { allContentChecks, lintA11y, lintLayout, lintTaste } from 'ease-design/lint';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
-const KERNEL_CORE = `${ROOT}/kernel/design-os/src/core/`;
-if (!existsSync(`${KERNEL_CORE}layout-lint.ts`)) {
-  throw new Error('kernel/design-os submodule is not checked out — run: git submodule update --init --depth 1');
-}
-
-// Dynamic imports keep the missing-submodule message above actionable.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type AnyLintModule = any;
-const layoutLintMod: AnyLintModule = await import(/* @vite-ignore */ `${KERNEL_CORE}layout-lint.ts`);
-const a11yLintMod: AnyLintModule = await import(/* @vite-ignore */ `${KERNEL_CORE}a11y-lint.ts`);
-const tasteLintMod: AnyLintModule = await import(/* @vite-ignore */ `${KERNEL_CORE}taste-lint.ts`);
-const contentChecksMod: AnyLintModule = await import(/* @vite-ignore */ `${KERNEL_CORE}content-checks.ts`);
-const { lintLayout } = layoutLintMod as { lintLayout: (html: string) => { errorCount: number } };
-const { lintA11y } = a11yLintMod as { lintA11y: (html: string) => { errorCount: number } };
-const { lintTaste } = tasteLintMod as { lintTaste: (html: string) => { errorCount: number } };
-const { allContentChecks } = contentChecksMod as {
-  allContentChecks: ReadonlyArray<(src: string) => ReadonlyArray<{ severity: string }>>;
-};
 
 const read = (path: string): string => readFileSync(`${ROOT}/${path}`, 'utf8');
 const html = read('plugin/src/ui/panel.html');
@@ -53,6 +36,11 @@ function contentErrors(source: string): number {
 }
 
 describe('adaptive panel source contract', () => {
+  it('loads panel linters from the exact dev-only ease-design package', () => {
+    expect(packageJson.dependencies?.['ease-design']).toBeUndefined();
+    expect(packageJson.devDependencies?.['ease-design']).toBe('0.5.0');
+  });
+
   it('passes the shared layout, accessibility, taste, and content linters', () => {
     expect(lintLayout(html).errorCount, 'layout errors').toBe(0);
     expect(lintA11y(html).errorCount, 'a11y errors').toBe(0);


### PR DESCRIPTION
## Summary

- consume the published ease-design/lint package export
- remove the temporary kernel submodule bridge
- keep panel contract checks on the packaged lint API

## Test plan

- [x] npm test (1700/1700)
- [x] npm run typecheck
- [x] npm run lint
- [x] npm run build
- [x] independent cold-clone verification

Closes #9