### PR TITLE
fix(connectors): choose annotation anchors from edge gaps

### DIFF
--- a/plugin/code.js
+++ b/plugin/code.js
@@ -4557,6 +4557,21 @@
     const sourceSide = horizontal ? dx >= 0 ? "RIGHT" : "LEFT" : dy >= 0 ? "BOTTOM" : "TOP";
     return { source: anchorOn(source, sourceSide), target: anchorOn(target, OPPOSITE[sourceSide]) };
   }
+  function edgeGap(aStart, aEnd, bStart, bEnd) {
+    if (aEnd < bStart) return bStart - aEnd;
+    if (bEnd < aStart) return aStart - bEnd;
+    return 0;
+  }
+  function resolveAnnotationAnchors(source, target) {
+    const horizontalGap = edgeGap(source.x, source.x + source.width, target.x, target.x + target.width);
+    const verticalGap = edgeGap(source.y, source.y + source.height, target.y, target.y + target.height);
+    if (horizontalGap === 0 && verticalGap === 0) return resolveAnchors(source, target);
+    const from = centre(source);
+    const to = centre(target);
+    const vertical = verticalGap > 0 && (horizontalGap === 0 || verticalGap <= horizontalGap);
+    const sourceSide = vertical ? to.y >= from.y ? "BOTTOM" : "TOP" : to.x >= from.x ? "RIGHT" : "LEFT";
+    return { source: anchorOn(source, sourceSide), target: anchorOn(target, OPPOSITE[sourceSide]) };
+  }
 
   // shared/connector-route.ts
   var DEFAULT_CLEARANCE = 24;
@@ -4627,7 +4642,7 @@
     return [source.point, exit, { x: exit.x, y }, { x: entry.x, y }, entry, target.point];
   }
   function route(input) {
-    const anchors = resolveAnchors(input.source, input.target);
+    const anchors = input.intent === "annotation" ? resolveAnnotationAnchors(input.source, input.target) : resolveAnchors(input.source, input.target);
     const clearance = input.clearance ?? DEFAULT_CLEARANCE;
     let raw;
     if (input.intent === "annotation") {
@@ -4642,7 +4657,7 @@
   }
 
   // shared/connector-types.ts
-  var ROUTER_VERSION = 1;
+  var ROUTER_VERSION = 2;
 
   // shared/connector-geometry.ts
   function round2(value) {

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -2651,7 +2651,7 @@ body { overflow: hidden; }
     }, 4e3);
     render();
   });
-  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "e7bf3f1" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "c2bd0ef" : "dev"}`;
   replaceIcon(targetRailBtn, "files");
   replaceIcon(syncRailBtn, "refresh-cw");
   replaceIcon(toggleBtn, "chevron-down");

--- a/shared/connector-anchor.ts
+++ b/shared/connector-anchor.ts
@@ -57,3 +57,34 @@ export function resolveAnchors(source: Rect, target: Rect): { source: Anchor; ta
 
   return { source: anchorOn(source, sourceSide), target: anchorOn(target, OPPOSITE[sourceSide]) };
 }
+
+function edgeGap(aStart: number, aEnd: number, bStart: number, bEnd: number): number {
+  if (aEnd < bStart) return bStart - aEnd;
+  if (bEnd < aStart) return aStart - bEnd;
+  return 0;
+}
+
+/**
+ * Pick annotation anchors from the shortest positive gap between the boxes' edges.
+ *
+ * Centre distance is the right signal for relationship flows, where the overall layout
+ * direction matters. A straight annotation pointer instead reads best when it crosses the
+ * nearest whitespace between the note and its subject. If the boxes overlap on both axes,
+ * there is no edge gap to compare, so the stable centre-based rule remains the fallback.
+ * Equal positive gaps resolve vertically to keep the tie deterministic.
+ */
+export function resolveAnnotationAnchors(source: Rect, target: Rect): { source: Anchor; target: Anchor } {
+  const horizontalGap = edgeGap(source.x, source.x + source.width, target.x, target.x + target.width);
+  const verticalGap = edgeGap(source.y, source.y + source.height, target.y, target.y + target.height);
+
+  if (horizontalGap === 0 && verticalGap === 0) return resolveAnchors(source, target);
+
+  const from = centre(source);
+  const to = centre(target);
+  const vertical = verticalGap > 0 && (horizontalGap === 0 || verticalGap <= horizontalGap);
+  const sourceSide: Side = vertical
+    ? (to.y >= from.y ? 'BOTTOM' : 'TOP')
+    : (to.x >= from.x ? 'RIGHT' : 'LEFT');
+
+  return { source: anchorOn(source, sourceSide), target: anchorOn(target, OPPOSITE[sourceSide]) };
+}

--- a/shared/connector-route.ts
+++ b/shared/connector-route.ts
@@ -6,7 +6,7 @@
 // drawn as a straight line runs through every screen between its two ends. That case gets a
 // rule, not a search: it bows below the row, which is what a flow diagram does anyway.
 
-import { resolveAnchors } from './connector-anchor';
+import { resolveAnchors, resolveAnnotationAnchors } from './connector-anchor';
 import type { Anchor, ConnectorIntent, Point, Rect } from './connector-types';
 
 /** Half a 48px grid step — far enough to read as a deliberate exit, short enough to stay tidy. */
@@ -142,7 +142,9 @@ export interface RouteInput {
  * a relationship rather than as "this label is about that thing".
  */
 export function route(input: RouteInput): Point[] {
-  const anchors = resolveAnchors(input.source, input.target);
+  const anchors = input.intent === 'annotation'
+    ? resolveAnnotationAnchors(input.source, input.target)
+    : resolveAnchors(input.source, input.target);
   const clearance = input.clearance ?? DEFAULT_CLEARANCE;
   let raw: Point[];
   if (input.intent === 'annotation') {

--- a/shared/connector-types.ts
+++ b/shared/connector-types.ts
@@ -48,7 +48,7 @@ export interface VectorNetworkSpec {
  * linter reports a record behind the current version as stale so a redraw can repair it,
  * rather than reporting every older connector as drifted geometry.
  */
-export const ROUTER_VERSION = 1;
+export const ROUTER_VERSION = 2;
 
 /**
  * One connector, as persisted. `flow` is the provenance that makes the canvas a PROJECTION

--- a/tests/connector-route.test.ts
+++ b/tests/connector-route.test.ts
@@ -20,6 +20,44 @@ describe('annotation intent — a straight pointer', () => {
   it('stays two points even on a diagonal, where an elbow would have jogged', () => {
     expect(route({ source: box(0, 0), target: box(400, 300), intent: 'annotation' })).toHaveLength(2);
   });
+
+  it('uses the smaller edge gap when centre distance would choose the wrong axis', () => {
+    const source = box(250, 0);
+    const target = box(0, 200);
+
+    expect(route({ source, target, intent: 'annotation' })).toEqual([
+      { x: 300, y: 100 },
+      { x: 50, y: 200 },
+    ]);
+  });
+
+  it('points vertically above and below when the boxes overlap horizontally', () => {
+    expect(route({ source: box(0, 0), target: box(50, 200), intent: 'annotation' })).toEqual([
+      { x: 50, y: 100 },
+      { x: 100, y: 200 },
+    ]);
+    expect(route({ source: box(50, 200), target: box(0, 0), intent: 'annotation' })).toEqual([
+      { x: 100, y: 200 },
+      { x: 50, y: 100 },
+    ]);
+  });
+
+  it('resolves equal positive edge gaps vertically and keeps the result deterministic', () => {
+    const input = { source: box(0, 0), target: box(200, 200), intent: 'annotation' as const };
+    const expected = [{ x: 50, y: 100 }, { x: 250, y: 200 }];
+
+    expect(route(input)).toEqual(expected);
+    expect(route(input)).toEqual(expected);
+  });
+
+  it('does not change flow routing for the annotation regression geometry', () => {
+    expect(route({ source: box(250, 0), target: box(0, 200), intent: 'flow' })).toEqual([
+      { x: 250, y: 50 },
+      { x: 175, y: 50 },
+      { x: 175, y: 250 },
+      { x: 100, y: 250 },
+    ]);
+  });
 });
 
 describe('flow intent — an orthogonal elbow', () => {


### PR DESCRIPTION
## What changed
- choose annotation anchor axes from the shortest positive gap between rectangle edges
- preserve the existing centre-axis resolver for flow routes and overlapping annotation boxes
- make equal positive annotation gaps resolve vertically and bump the stored router version to 2
- regenerate the loadable plugin bundles

## Verification
- red-first regression reproduced the side-anchor defect from #92
- 48 focused connector tests passed
- full suite: 135 files, 1,709 tests passed
- npm run typecheck
- npm run build
- npm run lint:comments
- independent differential review: 16,384 flow routes byte-identical; no blockers
- live VSF-PCP smoke: rendered source-bottom to target-top pointer; exported and inspected PNG; temporary node removed and fresh-call verified absent

## Known separate issue
The full suite still emits the process-listener warnings tracked by #93; no test failed.

Closes #92