### PR TITLE
fix(broker): remove daemon process listeners on shutdown

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -661,6 +661,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   let advertiseRefreshInterval: ReturnType<typeof setInterval> | null = null;
   let idleCheckInterval: ReturnType<typeof setInterval> | null = null;
 
+  function onSigterm(): void { shutdown(0, 'SIGTERM'); }
+  function onSigint(): void { shutdown(0, 'SIGINT'); }
+  function onUncaughtException(err: Error): void {
+    log(`uncaughtException: ${err.stack ?? err.message}`);
+  }
+
   const shutdown = (code: number, reason: string): never => {
     log(`shutdown (${reason})`);
     // Drop ownership BEFORE unlinking — a refresh-interval tick racing this shutdown
@@ -687,6 +693,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (watchdogInterval) clearInterval(watchdogInterval);
     if (advertiseRefreshInterval) clearInterval(advertiseRefreshInterval);
     if (idleCheckInterval) clearInterval(idleCheckInterval);
+    process.off('SIGTERM', onSigterm);
+    process.off('SIGINT', onSigint);
+    process.off('uncaughtException', onUncaughtException);
     try {
       // Only remove the advertisement if it is still ours (a newer broker may own it).
       const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as BrokerAdvertisement;
@@ -1894,7 +1903,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     else if (Date.now() - st.lastBusyAt > IDLE_SHUTDOWN_MS) shutdown(0, `idle for ${IDLE_SHUTDOWN_MS}ms`);
   }, IDLE_CHECK_MS);
 
-  process.on('SIGTERM', () => shutdown(0, 'SIGTERM'));
-  process.on('SIGINT', () => shutdown(0, 'SIGINT'));
-  process.on('uncaughtException', (err) => log(`uncaughtException: ${err.stack ?? err.message}`));
+  process.on('SIGTERM', onSigterm);
+  process.on('SIGINT', onSigint);
+  process.on('uncaughtException', onUncaughtException);
 }

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -281,6 +281,22 @@ afterEach(async () => {
   rmSync(scratchDir, { recursive: true, force: true });
 });
 
+describe('daemon harness — process listeners belong to one daemon lifetime', () => {
+  it('restores signal and exception listener counts after BROKER_SHUTDOWN_REQUEST', async () => {
+    const events = ['SIGTERM', 'SIGINT', 'uncaughtException'] as const;
+    const baseline = Object.fromEntries(events.map((event) => [event, process.listenerCount(event)]));
+    const port = await startTestBroker();
+
+    for (const event of events) expect(process.listenerCount(event)).toBe(baseline[event] + 1);
+
+    const cli = await connectSocket(port);
+    cli.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' }));
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    for (const event of events) expect(process.listenerCount(event)).toBe(baseline[event]);
+  });
+});
+
 describe('daemon harness — cancel-then-complete never dispatches the cancelled job (BLOCKER 1)', () => {
   it('a QUEUED job cancelled via `job --cancel` is never resurrected when the running job finishes', async () => {
     const port = await startTestBroker();


### PR DESCRIPTION
## What changed
- give each broker daemon invocation named SIGTERM, SIGINT, and uncaughtException handlers
- unregister exactly those handlers during the existing shutdown path
- add an in-process regression measuring listener counts before startup, after startup, and after BROKER_SHUTDOWN_REQUEST

## Why
The harness starts many in-process daemons. Anonymous process handlers survived shutdown, accumulated past the Node listener limit, and emitted warnings even though all tests passed.

## Verification
- red-first regression failed with one leaked listener per event
- focused regression passed after the fix
- exact reproduction: NODE_OPTIONS=--trace-warnings npm test
- full suite: 135 files, 1,710 tests passed; zero MaxListenersExceededWarning
- npm run typecheck
- npm run build
- npm run lint:comments
- git diff --check
- independent lifecycle review: no blockers

Closes #93