### PR TITLE
fix(broker): prevent cross-process request id collisions

### DIFF
--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -2,6 +2,7 @@
 // RequestMsg → await id-correlated ReplyMsg (reassembling chunked replies).
 // Throws CliError {code,message}; timeouts come from shared COMMAND_TIMEOUTS.
 import { unlinkSync } from 'node:fs';
+import { randomBytes } from 'node:crypto';
 import WebSocket from 'ws';
 import {
   BROKER_FILE,
@@ -40,6 +41,7 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 let requestCounter = 0;
+const requestNamespace = randomBytes(8).toString('hex');
 
 let expectedFile: string | undefined;
 let expectedInstance: string | undefined;
@@ -129,7 +131,7 @@ export function exchange(
   readOnly?: boolean,
 ): Promise<unknown> {
   return new Promise((resolve, reject) => {
-    const id = makeRequestId(++requestCounter);
+    const id = makeRequestId(++requestCounter, requestNamespace);
     const assembler = new ChunkAssembler();
     let settled = false;
     // Concurrency & jobs (backlog 1.1+2.6+4.3) — the LAST JOB_STATE seen before the reply

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -187,10 +187,10 @@ interface BrokerState {
   jobs: JobTable;
   queues: Map<string, QueueState>;
   // Buffered chunk frames for a CLI-originated request not yet fully admitted — keyed by
-  // CONNECTION first, then by wire request id (stage-4 fix round, minor 6): request ids
-  // (`c_<counter>_<ts>`) are unique only WITHIN one CLI process, so two simultaneous CLI
-  // processes could mint the same id — a flat `Map<string, ...>` would let their frames
-  // merge into one garbled reassembly. Concurrency & jobs §4: a request whose `cmd`/
+  // CONNECTION first, then by wire request id (stage-4 fix round, minor 6). Current ids
+  // carry a random client namespace, but partially assembled frames are still untrusted:
+  // a legacy or malformed client can reuse an id, and a flat `Map<string, ...>` would let
+  // their frames merge into one garbled reassembly. Concurrency & jobs §4: a request whose `cmd`/
   // `readOnly` live inside the not-yet-reassembled JSON must not be labelled with a
   // synthetic pseudo-command; it is buffered until `last`, then reassembled and admitted
   // with its REAL envelope. `lastFrameAt` is the abandoned-entry bound (stage-4 fold,
@@ -946,6 +946,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     from: WebSocket, id: string, rawText: string, cmd?: string, expectedFile?: string,
     expectedInstance?: string, readOnly = false, projectDir?: string, activity?: string,
   ): void => {
+    const duplicateJob = st.jobs.byRequestId(id);
+    const duplicateWaiting = st.waiting.some((request) => request.id === id);
+    if (duplicateJob || duplicateWaiting) {
+      sendReplyErr(from, id, 'E_INVALID_ARGS',
+        `duplicate request id "${id}" is already owned by another request — retry with a fresh client-generated id`);
+      log(`refused duplicate request id ${id}${duplicateJob ? ` (job ${duplicateJob.jobId})` : ' (parked)'}`);
+      return;
+    }
     // #35 P2: the standing runtime pin is consulted BEFORE `resolveRouteFilter` — a
     // per-request `--instance`/`--file` still bypasses it entirely (route-filter.ts's own
     // precedence), but a no-flag command with a pin set must never silently fall through
@@ -1067,9 +1075,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // A chunk belonging to an ALREADY-admitted job (running or queued) is a continuation
     // of a request already fully classified — never re-admitted as a fresh request. The
     // `existing.from === from` check (stage-4 fix round, minor 6) guards the theoretical
-    // collision: a request id minted by a DIFFERENT connection must never be treated as a
-    // continuation of this job — it is a fresh, still-unadmitted request on its own
-    // per-connection buffer instead.
+    // collision or replay: an id received from a DIFFERENT connection must never be
+    // treated as a continuation of this job — it is a fresh, still-unadmitted request on
+    // its own per-connection buffer, where admission can refuse the duplicate safely.
     const existing = st.jobs.byRequestId(id);
     if (existing !== undefined && existing.from === from) {
       if (existing.state === 'running') {
@@ -1146,11 +1154,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    * against the job's pinned `targetInstanceId` (backlog 2.10 audit) before anything
    * below is allowed to touch `pending`/job state. Pre-fix, this function took only
    * `(id, rawText, final)` and routed on `id` alone: any OTHER connected plugin
-   * instance sending a reply carrying the SAME id (reachable via a CLI-side request-id
-   * collision — ids are minted `c_<counter>_<ts>` per CLI PROCESS, so two concurrent
-   * CLI invocations can collide within the same millisecond) was accepted and forwarded
-   * to whichever CLI was waiting on that id, with no signal it came from the wrong
-   * plugin. A mismatched sender is now discarded outright — same shape as the
+   * instance sending a reply carrying the SAME id was accepted and forwarded to whichever
+   * CLI was waiting on that id, with no signal it came from the wrong plugin. Request ids
+   * now carry a per-process random namespace and admission refuses duplicates, while this
+   * sender check remains defense-in-depth. A mismatched sender is discarded outright — same shape as the
    * already-terminal-job discard below (count + log, never mutate `replyFrames` or
    * `pending`), so the REAL dispatched plugin's reply (or the watchdog timeout) is
    * still what resolves the job.

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -50,10 +50,10 @@ export function isHealthyRunningJob(
  * accept a reply keyed on `id` alone: it never checked which socket sent it against
  * `job.targetInstanceId` (pinned at admission — see `JobRecord.targetInstanceId`'s own
  * doc). Any OTHER currently-connected plugin instance sending a reply carrying the same
- * `id` — reachable via a request-id collision (ids are minted CLI-process-side as
- * `c_<counter>_<ts>`; two concurrent CLI invocations can collide within the same
- * millisecond) — was routed to the waiting CLI as though it were the real dispatched
- * plugin's answer, with zero signal that it wasn't.
+ * `id` — reachable when a legacy or malformed client reuses another request id — was
+ * routed to the waiting CLI as though it were the real dispatched plugin's answer, with
+ * zero signal that it wasn't. Current clients use a random per-process namespace, and
+ * broker admission independently refuses any duplicate id it has already observed.
  *
  * Deliberately identity-based (instanceId), never raw WebSocket-reference-based: a
  * plugin's own reconnect (Figma iframe reload) replaces its socket in the registry
@@ -167,9 +167,8 @@ export class JobTable {
 
   private mint(): string {
     if (this.mintId) return this.mintId();
-    // Request ids are per-process (`c_<counter>_<ts>`) and CAN collide across processes —
-    // a job id is polled LATER, by a possibly DIFFERENT process, so it must be
-    // broker-unique, not merely process-unique.
+    // Request ids carry a random per-process namespace, but a job id is polled LATER by
+    // a possibly DIFFERENT process, so it must still be broker-minted and broker-unique.
     return `j_${++this.counter}_${this.now()}`;
   }
 

--- a/cli/src/transport/protocol-helpers.ts
+++ b/cli/src/transport/protocol-helpers.ts
@@ -164,10 +164,10 @@ export function abandonedChunkIds(
 
 /**
  * Stage-4 fix round (minor 6) — chunk buffering keyed per CONNECTION (the socket in
- * hand), not by the process-unique request id alone. Request ids are `c_<counter>_<ts>`,
- * unique only WITHIN one CLI process — two simultaneous CLI processes could in principle
- * mint the same id, and a flat `Map<string, ...>` keyed by that id alone would let their
- * chunk payloads merge into one garbled reassembly. `Conn` is a type param (a real
+ * hand), not by request id alone. Current ids include a random per-process namespace, but
+ * the broker does not trust an unassembled frame to honour that contract: legacy or
+ * malformed clients can still reuse an id, and a flat map would let their chunk payloads
+ * merge into one garbled reassembly. `Conn` is a type param (a real
  * WebSocket in the broker, anything with reference identity in a test) so this stays
  * pure and testable without a socket.
  */

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -94,7 +94,7 @@ export type CommandName = (typeof COMMANDS)[number];
 
 // ── Envelopes ───────────────────────────────────────────────────────
 export interface RequestMsg {
-  id: string; // `c_<counter>_<ts>` (CLI-generated)
+  id: string; // `c_<random-client-namespace>_<counter>_<ts>` (CLI-generated)
   cmd: CommandName;
   params: unknown;
   v: number; // PROTOCOL_VERSION
@@ -449,8 +449,8 @@ export const RECONNECT_JITTER = 0.25;
 // timeout never fires first. STATUS is exempt (it must report "disconnected" fast).
 export const PLUGIN_WAIT_MS = 12_000;
 
-export function makeRequestId(counter: number): string {
-  return `c_${counter}_${Date.now()}`;
+export function makeRequestId(counter: number, clientNamespace: string, now = Date.now()): string {
+  return `c_${clientNamespace}_${counter}_${now}`;
 }
 
 /**

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -297,6 +297,38 @@ describe('daemon harness — process listeners belong to one daemon lifetime', (
   });
 });
 
+describe('daemon harness — duplicate request ids never overwrite reply ownership', () => {
+  it('refuses the second socket and delivers the plugin reply only to the first', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-duplicate-id', 'Duplicate Id File');
+    const pluginFrames = collectFrames(plugin);
+    const first = await connectSocket(port);
+    const second = await connectSocket(port);
+    const secondFrames = collectFrames(second);
+    const id = 'c_duplicate_1_1000';
+    const request = JSON.stringify(makeRequestFrame(id, 'SET_TEXT', { nodeId: '1:1', text: 'first' }));
+
+    first.send(request);
+    await nextFrame<EventMsg>(first, (msg) => (msg as EventMsg).type === 'JOB_STATE');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === id));
+
+    second.send(request);
+    await waitFor(() => secondFrames.frames.length > 0);
+    expect(secondFrames.frames[0]).toMatchObject({
+      id,
+      ok: false,
+      error: { code: 'E_INVALID_ARGS', message: expect.stringContaining('duplicate request id') },
+    });
+
+    const firstReplyPending = nextFrame<ReplyOk>(first, (msg) => (msg as ReplyOk).id === id);
+    plugin.send(JSON.stringify({ id, ok: true, result: { owner: 'first' } } satisfies ReplyOk));
+    const firstReply = await firstReplyPending;
+    expect(firstReply).toMatchObject({ id, ok: true, result: { owner: 'first' } });
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === id)).toHaveLength(1);
+  });
+});
+
 describe('daemon harness — cancel-then-complete never dispatches the cancelled job (BLOCKER 1)', () => {
   it('a QUEUED job cancelled via `job --cancel` is never resurrected when the running job finishes', async () => {
     const port = await startTestBroker();

--- a/tests/request-id.test.ts
+++ b/tests/request-id.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { makeRequestId } from '../shared/protocol.ts';
+
+describe('request ids — unique across CLI processes', () => {
+  it('does not collide when two client namespaces mint counter one in the same millisecond', () => {
+    expect(makeRequestId(1, 'client-a', 1_787_651_128_422))
+      .not.toBe(makeRequestId(1, 'client-b', 1_787_651_128_422));
+  });
+
+  it('stays deterministic for one namespace, counter, and clock value', () => {
+    expect(makeRequestId(7, 'client-a', 1_000)).toBe('c_client-a_7_1000');
+  });
+});


### PR DESCRIPTION
## What changed
- namespace every CLI request id with 64 bits of process-local cryptographic randomness
- refuse any duplicate request id already parked or owned by a broker job before routing state can be overwritten
- preserve per-connection chunk continuation and protocol version 1 compatibility
- update request-id contract comments for current and legacy clients

## Live failure closed
Two parallel final-smoke commands minted the same legacy id. One caller received the other result, a duplicate job blocked the file queue, and force-release was required. Issue #96 records the job IDs and recovery evidence.

## Verification
- red-first client namespace tests and duplicate-socket broker harness
- 3 focused tests passed; 32 unrelated harness cases skipped by filter
- full traced suite: 136 files, 1,713 tests passed
- npm run typecheck
- npm run build
- npm run lint:comments
- git diff --check
- independent ownership and compatibility review: no blockers
- worker browser timing flake observed separately and tracked in #97

Closes #96