### PR TITLE
test(plugin): make worker animation proof timing safe

### DIFF
--- a/tests/thinking-orb-worker-browser.test.ts
+++ b/tests/thinking-orb-worker-browser.test.ts
@@ -1,7 +1,7 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import type { Browser, Page } from 'playwright';
+import type { Browser, Locator, Page } from 'playwright';
 import { chromium } from 'playwright';
 
 const ROOT = fileURLToPath(new URL('..', import.meta.url));
@@ -9,6 +9,17 @@ const html = readFileSync(`${ROOT}/plugin/ui.html`, 'utf8');
 const BROWSER_SETUP_TIMEOUT_MS = 30_000;
 let browser: Browser;
 let page: Page;
+
+async function waitForDifferentFrame(orb: Locator, baseline: Buffer): Promise<Buffer> {
+  let changed: Buffer | undefined;
+  await expect.poll(async () => {
+    const candidate = await orb.screenshot();
+    if (!candidate.equals(baseline)) changed = candidate;
+    return changed !== undefined;
+  }, { timeout: 5_000, interval: 50, message: 'worker canvas pixels never changed' }).toBe(true);
+  if (!changed) throw new Error('worker canvas pixels never changed');
+  return changed;
+}
 
 beforeAll(async () => {
   try {
@@ -37,11 +48,9 @@ describe('Thinking Orb worker renderer in Chromium', () => {
       detail: { state: 'connected', since: Date.now() },
     })));
     const orb = page.locator('.thinking-orb');
-    await page.waitForTimeout(50);
     const firstFrame = await orb.screenshot();
-    await page.waitForTimeout(100);
-    const laterFrame = await orb.screenshot();
-    expect(laterFrame.equals(firstFrame)).toBe(false);
+    const paintedFrame = await waitForDifferentFrame(orb, firstFrame);
+    await waitForDifferentFrame(orb, paintedFrame);
     const mainRafCount = await page.evaluate(
       () => (window as typeof window & { __mainRafCount: number }).__mainRafCount,
     );


### PR DESCRIPTION
## What changed
- replace one fixed 100 ms screenshot comparison with a bounded 50 ms poll
- require two consecutive pixel transitions so an initial blank-to-painted frame cannot create a false pass
- retain the zero main-thread requestAnimationFrame assertion and 5-second diagnostic deadline

## Why
The old unchanged test failed twice across four observed runs because one fixed sleep did not guarantee that the worker paint advanced before the second screenshot.

## Verification
- old focused behavior reproduced pass, fail, pass under identical code
- new focused test passed five consecutive runs
- full traced suite after rebasing #96: 136 files, 1,713 tests passed
- npm run typecheck
- npm run build
- npm run lint:comments
- git diff --check
- independent browser-test review: no findings

Closes #97