### PR TITLE
feat(broker): add per-file mutation gate

### DIFF
--- a/cli/src/command-catalog.ts
+++ b/cli/src/command-catalog.ts
@@ -37,6 +37,13 @@ export const COMMANDS: CommandCatalogEntry[] = [
       + 'SECONDS, default 60 — on timeout this exits non-zero with E_NO_PLUGIN instead of the '
       + 'normal payload.',
   },
+  {
+    name: 'mutation-gate',
+    description:
+      '<pause|resume|status> --file-key <raw-key>   control the local broker\'s durable per-file '
+      + 'mutation admission gate. The key is passed verbatim and must be a nonempty raw Figma fileKey; '
+      + 'this command never derives identity from a filename.',
+  },
   { name: 'seat', description: 'Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]' },
   {
     name: 'bind',
@@ -206,6 +213,13 @@ export const GLOBAL_FLAGS: GlobalFlagEntry[] = [
       + 'FIGMA_AGENT_FILE; payloads >512KB route by the env pin but are still guarded)',
   },
   {
+    flag: '--target-file-key <raw Figma fileKey>',
+    description:
+      'exact broker-side target assertion for a disconnected mutation. It is passed verbatim, '
+      + 'must be nonempty and unpadded, never derives from a filename/bind cache/reply, and is '
+      + 'mutually exclusive with --file and --instance.',
+  },
+  {
     flag: '--instance <instanceId>',
     description:
       "route to that EXACT plugin instance (from `status`'s instanceId column) — beats --file and "
@@ -222,9 +236,9 @@ export const GLOBAL_FLAGS: GlobalFlagEntry[] = [
   {
     flag: '--read-only',
     description:
-      'declare that this command only READS. Skips the per-file mutation queue (backlog 1.1+2.6+4.3). '
-      + 'TRUSTED, NOT ENFORCED — the plugin sandbox cannot verify it, so a mis-declared mutation can '
-      + "interleave with another agent's work.",
+      'request the broker-safe read path. Only STATUS, GET_SELECTION, EXPORT_PNG, SCAN_DESIGN_SYSTEM, '
+      + 'GET_CORRECTION_MEMORY, LIST_CONNECTIONS, VERIFY_CONNECTIONS, and SHADER_GRADIENT_PROBE bypass '
+      + 'the per-file mutation gate; the caller cannot declare any other command safe.',
   },
   {
     flag: '--agent <id> | FIGMA_AGENT_ID',

--- a/cli/src/commands/batch.ts
+++ b/cli/src/commands/batch.ts
@@ -2,7 +2,13 @@
 // BATCH request (single round-trip; plugin executes sequentially).
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { COMMAND_TIMEOUTS, COMMANDS, DEFAULT_TIMEOUT_MS, type CommandName } from '../../../shared/protocol.ts';
+import {
+  COMMAND_TIMEOUTS,
+  COMMANDS,
+  DEFAULT_TIMEOUT_MS,
+  isBrokerTerminalCommand,
+  type CommandName,
+} from '../../../shared/protocol.ts';
 import type { CommandArgs } from '../figma-agent.ts';
 import { CliError } from '../transport/protocol-helpers.ts';
 import { runCommand } from '../transport/broker-client.ts';
@@ -26,6 +32,12 @@ function loadOps(filePath: string): BatchOp[] {
     const candidate = op as { cmd?: unknown; params?: unknown };
     if (typeof candidate?.cmd !== 'string' || !(COMMANDS as readonly string[]).includes(candidate.cmd)) {
       throw new CliError('E_INVALID_ARGS', `batch[${i}].cmd invalid — must be one of: ${COMMANDS.join(', ')}`);
+    }
+    if (isBrokerTerminalCommand(candidate.cmd)) {
+      throw new CliError(
+        'E_INVALID_ARGS',
+        `batch[${i}].cmd ${candidate.cmd} is broker-terminal and cannot run inside BATCH`,
+      );
     }
     return { cmd: candidate.cmd as CommandName, params: candidate.params ?? {} };
   });

--- a/cli/src/commands/mutation-gate.ts
+++ b/cli/src/commands/mutation-gate.ts
@@ -1,0 +1,26 @@
+// Broker-terminal mutation-admission control. This command deliberately accepts
+// only a raw durable file key: a filename is neither an equivalent nor a fallback.
+import type { CommandArgs } from '../figma-agent.ts';
+import { runCommand } from '../transport/broker-client.ts';
+import { CliError } from '../transport/protocol-helpers.ts';
+
+const MODES = ['pause', 'resume', 'status'] as const;
+type MutationGateMode = typeof MODES[number];
+
+function isMode(value: string | undefined): value is MutationGateMode {
+  return value !== undefined && (MODES as readonly string[]).includes(value);
+}
+
+export async function run(args: CommandArgs): Promise<unknown> {
+  const mode = args.positionals[0];
+  if (args.positionals.length !== 1 || !isMode(mode)) {
+    throw new CliError('E_INVALID_ARGS', 'mutation-gate requires one mode: pause, resume, or status');
+  }
+
+  const fileKey = args.str('file-key');
+  if (fileKey === undefined || fileKey.trim() === '') {
+    throw new CliError('E_INVALID_ARGS', 'mutation-gate requires a nonempty --file-key <raw-key>');
+  }
+
+  return runCommand('MUTATION_GATE', { mode, fileKey });
+}

--- a/cli/src/commands/scan-conventions.ts
+++ b/cli/src/commands/scan-conventions.ts
@@ -111,11 +111,10 @@ export async function scanConventions(
 ): Promise<SectionDNA[]> {
   const code = buildWalkCode(sectionIds, budget);
   // Cold big-file walks can exceed the timeout on the first pass; retry once warm.
-  // `readOnly: true` (concurrency & jobs, backlog 1.1+2.6+4.3) — an aggregate walk, no
-  // writes; EXEC_JS is mutating by default, so this declares itself explicitly rather
-  // than queueing behind another agent's mutation.
+  // Executable source is never an admission bypass, even when this particular walk
+  // intends only to aggregate. It therefore participates in the file mutation FIFO.
   const reply = (await runWithWarmRetry(() =>
-    runner('EXEC_JS', { code, timeoutMs: walkTimeoutMs }, { timeoutMs: walkTimeoutMs + WIRE_MARGIN_MS, readOnly: true }),
+    runner('EXEC_JS', { code, timeoutMs: walkTimeoutMs }, { timeoutMs: walkTimeoutMs + WIRE_MARGIN_MS }),
   )) as { result?: unknown } | null;
   const result = reply && typeof reply === 'object' ? (reply as { result?: unknown }).result : undefined;
   if (!Array.isArray(result)) {

--- a/cli/src/commands/scan-node.ts
+++ b/cli/src/commands/scan-node.ts
@@ -23,7 +23,7 @@ const WIRE_MARGIN_MS = 2_000;
 export type Runner = (
   cmd: string,
   params: unknown,
-  opts?: { timeoutMs?: number; activity?: string; readOnly?: boolean },
+  opts?: { timeoutMs?: number; activity?: string },
 ) => Promise<unknown>;
 
 /** The walker's output, opaque to the CLI: plain JSON, compared structurally. */
@@ -75,19 +75,14 @@ export function resolveScanTimeout(requested?: number): number {
  * no local name; a font field has no slot).
  */
 /**
- * `readOnly` (concurrency & jobs, backlog 1.1+2.6+4.3) defaults to FALSE — EXEC_JS is
- * mutating by default, and this same walker is shared by TWO very different callers:
- * a bare `scan-node` (a pure read — declares `true`, see `run` below) and
- * `mirror-verify`'s "scan original"/"scan rebuild" steps (part of a workflow that ALSO
- * rebuilds and removes a node — left at the mutating default, consistent with the rest
- * of that workflow; see mirror-verify.ts's own `readOnly: NO` classification).
+ * EXEC_JS source is not inspectable by the broker, so every walker invocation enters the
+ * mutation admission path. The runner surface intentionally has no readOnly override.
  */
 export async function scanNodeSpec(
   nodeId: string,
   timeoutMs: number,
   run: Runner = runCommand,
   activity = `Scan · ${nodeId}`,
-  readOnly = false,
 ): Promise<ScannedSpec> {
   const code = `${SCAN_NODE_WALKER_BUNDLE}
 const node = await figma.getNodeByIdAsync(${JSON.stringify(nodeId)});
@@ -99,15 +94,12 @@ return __scan.nodeToSpec(node, tokenNames, mainComps, keyedVars);`;
   // The label is the caller's, because EXEC_JS says nothing: this same walker runs
   // as a bare `scan-node`, as mirror-verify's "scan original" and as its "scan
   // rebuild" — three different waits the panel must be able to tell apart.
-  const reply = await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS, activity, readOnly });
+  const reply = await run('EXEC_JS', { code, timeoutMs }, { timeoutMs: timeoutMs + WIRE_MARGIN_MS, activity });
   return unwrapExecJsReply(reply);
 }
 
 export async function run(args: CommandArgs): Promise<unknown> {
   const nodeId = args.positionals[0];
   if (!nodeId) throw new CliError('E_INVALID_ARGS', 'scan-node requires a <nodeId>');
-  // A bare `scan-node` is a pure walker read — never queues, even while another mutation
-  // is running (mirror capture's own 40-sequential-child-process reconcile apply would
-  // otherwise stall behind any other agent's mutation — see figma-mirror-capture-run.ts).
-  return scanNodeSpec(nodeId, resolveScanTimeout(args.num('timeout')), runCommand, `Scan · ${nodeId}`, true);
+  return scanNodeSpec(nodeId, resolveScanTimeout(args.num('timeout')), runCommand, `Scan · ${nodeId}`);
 }

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -103,6 +103,7 @@ export async function run(args: CommandArgs): Promise<unknown> {
     pid: ad.pid,
     uptimeMs: (hello.uptimeMs as number | undefined) ?? null,
     protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
+    ...(hello.targetFileKeyAdmissionV === 1 && { targetFileKeyAdmissionV: 1 }),
     // Sender-verification counter (backlog 2.10 / issue #15) — mirrors BROKER_HELLO's
     // own byte-identical-when-zero contract: present only once a cross-instance reply
     // has actually been discarded, so the common (zero) case stays unchanged here too.
@@ -157,6 +158,9 @@ export async function run(args: CommandArgs): Promise<unknown> {
   // still see what IS connected even though it doesn't match what they asked about.
   return {
     broker, plugins, activePlugin, plugin, protocolVersion: broker.protocolVersion,
+    ...(Array.isArray(hello.mutationGates) && { mutationGates: hello.mutationGates }),
+    ...(hello.mutationGateStoreHealth !== null && typeof hello.mutationGateStoreHealth === 'object'
+      && { mutationGateStoreHealth: hello.mutationGateStoreHealth }),
     ...(wantedFile ? { pluginsAll: all } : {}),
     // Broker-restart reconnect visibility — a HINT from last-known state, never a live
     // plugin (it must never appear in `plugins`/`pluginsAll` above); present only when

--- a/cli/src/figma-agent.ts
+++ b/cli/src/figma-agent.ts
@@ -13,7 +13,15 @@ import { fileURLToPath } from 'node:url';
 import { runBrokerDaemon } from './transport/broker-daemon.ts';
 import { parseArgs, type CommandArgs } from './arg-parse.ts';
 import { CliError } from './transport/protocol-helpers.ts';
-import { getLastFileContext, setAgent, setExpectedFile, setExpectedInstance, setProjectDir, setReadOnly } from './transport/broker-client.ts';
+import {
+  getLastFileContext,
+  setAgent,
+  setExpectedFile,
+  setExpectedInstance,
+  setProjectDir,
+  setReadOnly,
+  setTargetFileKey,
+} from './transport/broker-client.ts';
 import { printErrorJson, printJson, withFileContext } from './util/json-out.ts';
 import { HELP } from './help-text.ts';
 import { renderSkill } from './skill-emitter.ts';
@@ -53,6 +61,7 @@ import * as seat from './commands/seat.ts';
 import * as setText from './commands/set-text.ts';
 import * as setVariant from './commands/set-variant.ts';
 import * as status from './commands/status.ts';
+import * as mutationGate from './commands/mutation-gate.ts';
 import * as syncCorrections from './commands/sync-corrections.ts';
 import * as installSkill from './commands/install-skill.ts';
 import * as installHook from './commands/install-hook.ts';
@@ -65,6 +74,7 @@ export type { CommandArgs } from './arg-parse.ts';
 // this list a second time.
 export const COMMAND_MODULES: Record<string, { run(args: CommandArgs): Promise<unknown> }> = {
   status,
+  'mutation-gate': mutationGate,
   seat,
   bind,
   'get-selection': getSelection,
@@ -171,6 +181,10 @@ async function main(): Promise<void> {
   if (args.bool('instance') && (args.str('instance') ?? '').trim() === '') {
     printErrorJson(new CliError('E_INVALID_ARGS', '--instance needs an instanceId, e.g. --instance p_3_1712345678'));
   }
+  const targetFileKey = args.str('target-file-key');
+  if (args.bool('target-file-key') && (targetFileKey === undefined || targetFileKey === '' || targetFileKey.trim() !== targetFileKey)) {
+    printErrorJson(new CliError('E_INVALID_ARGS', '--target-file-key needs an exact unpadded raw Figma fileKey'));
+  }
   const fileFlag = (args.str('file') ?? '').trim();
   const instanceFlag = (args.str('instance') ?? '').trim();
   // Mutual exclusion at the CLI boundary: both set is refused outright,
@@ -182,10 +196,17 @@ async function main(): Promise<void> {
       `--instance "${instanceFlag}" and --file "${fileFlag}" are mutually exclusive on one request — drop one`,
     ));
   }
+  if (targetFileKey !== undefined && (fileFlag !== '' || instanceFlag !== '')) {
+    printErrorJson(new CliError(
+      'E_INVALID_ARGS',
+      '--target-file-key is mutually exclusive with --file and --instance on one request — drop the filename or instance selector',
+    ));
+  }
   setExpectedFile(args.str('file'));   // global flag — verified: no command reads --file today
   setExpectedInstance(args.str('instance')); // global flag, same choke point as --file
+  setTargetFileKey(targetFileKey);
   setProjectDir(resolve(args.str('dir') ?? process.cwd())); // registry-integrity phase 01 §1
-  setReadOnly(args.bool('read-only')); // concurrency & jobs (backlog 1.1+2.6+4.3) — TRUSTED, not enforced
+  setReadOnly(args.bool('read-only')); // broker permits this declaration only for its safe-read allowlist
   setAgent(resolveAgent(args)); // auto-connect slice 2 — same choke point as --file/--instance
   try {
     const result = await command.run(args);

--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -18,7 +18,7 @@ import {
   type WireError,
 } from '../../../shared/protocol.ts';
 import { ensureBroker, isPidAlive, loopbackWsUrl } from './broker-discovery.ts';
-import { MUTATING_COMMANDS } from '../../../shared/mutating-commands.ts';
+import { isBrokerSafeRead } from '../../../shared/mutating-commands.ts';
 import {
   ChunkAssembler,
   CliError,
@@ -45,6 +45,7 @@ const requestNamespace = randomBytes(8).toString('hex');
 
 let expectedFile: string | undefined;
 let expectedInstance: string | undefined;
+let targetFileKey: string | undefined;
 let lastFileContext: FileContext | undefined;
 let projectDir: string | undefined;
 let readOnlyGlobal = false;
@@ -60,6 +61,9 @@ export function setExpectedFile(name: string | undefined): void { expectedFile =
  * non-empty here.
  */
 export function setExpectedInstance(id: string | undefined): void { expectedInstance = id; }
+
+/** Set once per invocation from global `--target-file-key`; never inferred from any filename or reply context. */
+export function setTargetFileKey(fileKey: string | undefined): void { targetFileKey = fileKey; }
 export function getLastFileContext(): FileContext | undefined { return lastFileContext; }
 
 /**
@@ -72,9 +76,8 @@ export function setProjectDir(dir: string | undefined): void { projectDir = dir;
 
 /**
  * Set once per CLI invocation from the global `--read-only` flag (concurrency & jobs,
- * backlog 1.1+2.6+4.3, phase 02 §4). A per-call `runCommand({ readOnly: true })` (used by
- * internal read-only callers riding EXEC_JS, e.g. scan-node/scan-conventions) always
- * wins over this global — see `runCommand`'s own `opts?.readOnly ?? readOnlyGlobal`.
+ * backlog 1.1+2.6+4.3, phase 02 §4). A per-call runCommand readOnly value overrides this
+ * global, but true is valid only for the broker's explicit safe-read allowlist.
  */
 export function setReadOnly(v: boolean): void { readOnlyGlobal = v; }
 
@@ -87,17 +90,13 @@ export function setAgent(id: string | undefined): void { agentId = id; }
 
 /**
  * Stage-4 fix round (minor 8, ruling Q4) — `--read-only` is a PARTIAL hardening, not a
- * blanket promise: asserting read-only on a command that mutates BY NAME (e.g. SET_TEXT,
- * CREATE_FRAME) is always a lie, so refuse it outright rather than silently trust the
- * caller. EXEC_JS is the one deliberate exception — it IS the flag's designed use (a
- * read-only script the broker cannot inspect the body of); a script that mutates despite
- * the flag is on the caller, not something this layer can detect by name. A command
- * that's already read-only by nature makes the flag a harmless no-op either way.
- * Pure (no CommandName lookup outside MUTATING_COMMANDS) so it's unit-testable without a
- * live broker.
+ * blanket promise: asserting read-only only works for the broker's exact safe-read
+ * allowlist. Every other command, including EXEC_JS, is refused rather than trusting a
+ * caller-provided declaration that could bypass mutation admission. Pure (no command
+ * lookup outside the shared allowlist) so it is unit-testable without a live broker.
  */
 export function refusesReadOnlyAssertion(wireCmd: CommandName, readOnly: boolean): boolean {
-  return readOnly && wireCmd !== 'EXEC_JS' && MUTATING_COMMANDS.includes(wireCmd);
+  return readOnly && !isBrokerSafeRead(wireCmd);
 }
 
 function connectWs(port: number): Promise<WebSocket> {
@@ -197,7 +196,9 @@ export function exchange(
     ws.on('error', (err) => finish(() => reject(new CliError('E_NO_BROKER', `broker socket error: ${err.message}`))));
 
     try {
-      sendWireMsg(ws, makeRequestFrame(id, cmd, params, activity, expectedFile, projectDir, readOnly, expectedInstance, agentId));
+      sendWireMsg(ws, makeRequestFrame(
+        id, cmd, params, activity, expectedFile, projectDir, readOnly, expectedInstance, agentId, targetFileKey,
+      ));
     } catch (err) {
       finish(() => reject(new CliError('E_NO_BROKER', `failed to send request: ${(err as Error).message}`)));
     }
@@ -279,11 +280,9 @@ export async function retryAmbiguousConnect(
  * the wire `cmd` (see RequestMsg.activity) — pass it from any command whose `cmd`
  * does not say what the user is actually waiting for.
  *
- * `opts.readOnly` (concurrency & jobs, backlog 1.1+2.6+4.3) is a per-call declaration
- * that ALWAYS wins over the global `--read-only` flag (`setReadOnly`) — the choke point
- * for internal callers that ride EXEC_JS but are themselves read-only regardless of
- * whatever the caller's own CLI invocation declared (scan-node, scan-conventions).
- * `undefined` (the default) falls back to the global flag's current value.
+ * `opts.readOnly` (concurrency & jobs, backlog 1.1+2.6+4.3) overrides the global
+ * `--read-only` flag (`setReadOnly`). A true value must name a broker safe-read; an
+ * undefined value falls back to the global flag's current value.
  */
 export async function runCommand(
   cmd: string,
@@ -297,7 +296,7 @@ export async function runCommand(
   if (refusesReadOnlyAssertion(wireCmd, readOnlyRequested)) {
     throw new CliError(
       'E_INVALID_ARGS',
-      `--read-only cannot be asserted on ${wireCmd} — it mutates by design; drop the flag or use EXEC_JS for a script the broker cannot inspect`,
+      `--read-only cannot be asserted on ${wireCmd} — only broker-known safe reads may bypass mutation admission`,
     );
   }
   let ad = await ensureBroker();

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -1021,23 +1021,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (targetWs && targetWs.readyState !== WebSocket.OPEN) targetWs = undefined;
     if (requestedTargetFileKey !== undefined) {
       // The caller's key is a routing assertion, never canonical evidence: only the
-      // currently registered scene key may select a plugin. A live keyless plugin is an
-      // identity failure; a live different key is a wrong-file refusal, never a guess.
+      // currently registered exact scene key may select a plugin. A live keyless plugin
+      // or different key is unrelated — leave the request unresolved so exact-key parking
+      // can wait for the asserted file without emitting a false wrong-file refusal.
       const live = st.registry.liveEntries();
       const exact = live.find((entry) => durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === requestedTargetFileKey);
       if (exact) {
         targetWs = exact.ws;
-      } else if (live.length > 0) {
-        const hasMissingKey = live.some((entry) => durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === null);
-        sendReplyErr(
-          from,
-          id,
-          hasMissingKey ? 'E_FILE_KEY_UNAVAILABLE' : 'E_WRONG_FILE',
-          hasMissingKey
-            ? 'targetFileKey cannot be verified because a live plugin has no raw fileKey'
-            : `no live plugin matches targetFileKey ${JSON.stringify(requestedTargetFileKey)}`,
-        );
-        return;
       }
     } else if (!targetWs) {
       const hits = st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind });
@@ -1073,7 +1063,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // a pinned file connect after the command was issued.
       const parkable = !(cmd && WAIT_EXEMPT.has(cmd)) && PLUGIN_WAIT_TIMEOUT_MS > 0;
       if (!parkable) {
-        sendReplyErr(from, id, 'E_NO_PLUGIN', noPluginMessage(st.registry, filter));
+        sendReplyErr(
+          from,
+          id,
+          'E_NO_PLUGIN',
+          requestedTargetFileKey === undefined
+            ? noPluginMessage(st.registry, filter)
+            : `no live plugin matches targetFileKey ${JSON.stringify(requestedTargetFileKey)}`,
+        );
         return;
       }
       // A mutation cannot claim a durable target identity from a filename, a route
@@ -1253,7 +1250,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (req.from.readyState !== WebSocket.OPEN) continue; // CLI gone — drop silently
       const targetExists = req.targetFileKey === undefined
         ? st.registry.selectTarget(req.filter.value, { exact: req.filter.exact, kind: req.filter.kind }) !== null
-        : st.registry.liveEntries().length > 0;
+        : st.registry.liveEntries().some((entry) =>
+          durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === req.targetFileKey,
+        );
       if (targetExists) {
         const flagValue = req.filter.source === 'flag' ? req.filter.value ?? undefined : undefined;
         admitRequest(
@@ -1782,6 +1781,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           broadcastPeers();
           promotePendingBind(ws); // registry-integrity phase 01 §2 — fill a pending fileKey on first sight
           schedulePluginSetPersist(); // broker-restart reconnect visibility — scene changed
+          // The UI relay can register before main's first FILE_INFO carries its raw key.
+          // A valid scene-identity update is therefore another exact-target readiness
+          // transition, after the existing broadcast/promotion/persistence side effects.
+          flushWaiting();
         }
       } else if (msg.type === 'DOC_CHANGE') {
         // Live-sync capture: append the plugin's coalesced batch to the change log.
@@ -2038,7 +2041,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         // The request's OWN filter, not the env pin — otherwise a timed-out --file
         // request blames FIGMA_AGENT_FILE (or prints the generic message) instead of
         // naming the flag the caller actually used.
-        sendReplyErr(req.from, req.id, 'E_NO_PLUGIN', noPluginMessage(st.registry, req.filter));
+        sendReplyErr(
+          req.from,
+          req.id,
+          'E_NO_PLUGIN',
+          req.targetFileKey === undefined
+            ? noPluginMessage(st.registry, req.filter)
+            : `no plugin matching targetFileKey ${JSON.stringify(req.targetFileKey)} connected before the wait deadline`,
+        );
       } else {
         survivors.push(req);
       }

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -25,6 +25,9 @@ import {
 } from './protocol-helpers.ts';
 import { PluginRegistry, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
+import { MutationAdmissionGate, mutationGatePathFor } from './mutation-admission-gate.ts';
+import { durableFileKey, exactTargetFileKey } from './file-identity.ts';
+import { isBrokerSafeRead } from '../../../shared/mutating-commands.ts';
 import {
   clearReconnected, filterAwaitingReconnect, lastPluginsPathFor, readLastPlugins,
   toAwaitingReconnectStatus, writeLastPluginsAtomic, type AwaitingReconnectEntry, type LastPluginRecord,
@@ -80,17 +83,6 @@ const IDLE_CHECK_MS = Math.min(60_000, Math.max(500, Math.floor(IDLE_SHUTDOWN_MS
 // never parked in the plugin-wait queue (a status probe must not hang 12s).
 const WAIT_EXEMPT = new Set(['STATUS']);
 
-// Concurrency & jobs (backlog 1.1+2.6+4.3) — commands implicitly read-only for QUEUEING
-// purposes even without an explicit `readOnly` flag on the envelope. A DIFFERENT axis
-// from mutating-commands.ts's undo-commit classification: AUDIT_DS is classified
-// MUTATING here (deliberately absent from this set) even though it seals no undo step —
-// it calls `setCurrentPageAsync` for every page without restoring the original
-// (executor-audit.ts), and `figma.currentPage` is shared view state a concurrent
-// mutating script reads implicitly. `EXEC_JS` is mutating by default; every read
-// implemented through it (scan-node, scan-conventions) must declare `readOnly: true`
-// itself — it is never inferred from `cmd` alone.
-const IMPLICIT_READ_ONLY = new Set(['STATUS', 'GET_SELECTION', 'EXPORT_PNG', 'SCAN_DESIGN_SYSTEM', 'GET_CORRECTION_MEMORY']);
-
 // A running job with no reply within this window is marked failed(E_TIMEOUT) FOR
 // REPORTING ONLY — the file's mutation slot stays blocked (the script may still be
 // running; the sandbox cannot interrupt a live `eval`, so advancing would deliberately
@@ -144,6 +136,12 @@ interface ParkedRequest {
   cmd?: string;
   readOnly?: boolean;
   activity?: string;
+  /** Exact raw assertion captured before a mutation parks; never inferred at flush. */
+  targetFileKey?: string;
+  /** Target-local gate revision that was open when this parked mutation was admitted. */
+  admissionRevision?: number;
+  /** Audit timestamp of that parking admission; no durable parked job is ever created. */
+  admittedAt?: number;
 }
 
 /**
@@ -399,6 +397,7 @@ function appendContentionLog(path: string, fileSlug: string, queuedMs: number | 
  */
 export interface BrokerDaemonOptions {
   advertisePath?: string;
+  mutationGatePath?: string;
   ports?: readonly number[];
   exit?: (code: number) => never;
   logFile?: string;
@@ -412,6 +411,7 @@ function defaultPortRange(): number[] {
 
 export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<void> {
   const advertisePath = options?.advertisePath ?? BROKER_FILE;
+  const mutationGate = new MutationAdmissionGate(options?.mutationGatePath ?? mutationGatePathFor(advertisePath));
   const ports = options?.ports ?? defaultPortRange();
   const exit: (code: number) => never = options?.exit ?? ((code: number): never => process.exit(code));
   // Resolved BEFORE any `log()` call below — a harness-spawned broker must never
@@ -851,6 +851,23 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const errReplyFrame = (id: string, code: ErrorCode, message: string): string =>
     JSON.stringify({ id, ok: false, error: { code, message } } satisfies ReplyErr);
 
+  /** Finalize a not-yet-running mutation after a gate denial. The same stored frame is
+   * delivered live and remains available through JOB polling. */
+  const cancelQueuedForGate = (job: JobRecord, code: ErrorCode, message: string): boolean => {
+    const frame = errReplyFrame(job.requestId, code, message);
+    const result = st.jobs.cancelQueued(job.jobId, [frame]);
+    if (!result.ok) return false;
+    const q = st.queues.get(job.fileSlug);
+    if (q && q.running !== job.jobId) st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
+    recordContention(job);
+    if (job.from && job.from.readyState === WebSocket.OPEN) {
+      try { job.from.send(frame); } catch { /* requester vanished */ }
+    }
+    st.pending.delete(job.requestId);
+    st.dispatchedTo.delete(job.requestId);
+    return true;
+  };
+
   /**
    * Write-through a finished job's `queuedMs` into its durable contention counter — the
    * ONE seam every `st.jobs.finish`/`cancelQueued` call site below routes through, right
@@ -929,6 +946,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       advanceQueue(nextJob);
       return;
     }
+    if (!nextJob.readOnly) {
+      const admission = mutationGate.admit(nextJob.fileSlug);
+      if (!admission.ok) {
+        if (cancelQueuedForGate(nextJob, admission.error.code, admission.error.message)) advanceQueue(nextJob);
+        return;
+      }
+    }
     st.jobs.markRunning(nextJob.jobId);
     dispatchJob(nextJob, entry.ws);
   };
@@ -944,7 +968,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    */
   const admitRequest = (
     from: WebSocket, id: string, rawText: string, cmd?: string, expectedFile?: string,
-    expectedInstance?: string, readOnly = false, projectDir?: string, activity?: string,
+    expectedInstance?: string, targetFileKey?: unknown, _readOnly = false, projectDir?: string, activity?: string,
+    parkedAdmission?: { targetFileKey: string; admissionRevision: number; admittedAt: number },
   ): void => {
     const duplicateJob = st.jobs.byRequestId(id);
     const duplicateWaiting = st.waiting.some((request) => request.id === id);
@@ -954,6 +979,28 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       log(`refused duplicate request id ${id}${duplicateJob ? ` (job ${duplicateJob.jobId})` : ' (parked)'}`);
       return;
     }
+    const requestedTargetFileKey = targetFileKey === undefined
+      ? undefined
+      : exactTargetFileKey(typeof targetFileKey === 'string' ? targetFileKey : null);
+    if (targetFileKey !== undefined && requestedTargetFileKey === null) {
+      sendReplyErr(from, id, 'E_INVALID_ARGS', 'targetFileKey must be a nonempty unpadded raw Figma fileKey');
+      return;
+    }
+    if (requestedTargetFileKey !== undefined && (expectedFile !== undefined || expectedInstance !== undefined)) {
+      sendReplyErr(from, id, 'E_INVALID_ARGS', 'targetFileKey is mutually exclusive with expectedFile and expectedInstance');
+      return;
+    }
+    const isReadOnly = cmd !== undefined && isBrokerSafeRead(cmd);
+    // Durable gate health precedes every mutation identity, routing, ownership, and frame
+    // decision. A corrupt/unreadable store must not become a misleading key or route error.
+    if (!isReadOnly) {
+      const status = mutationGate.status();
+      if (status.health.state === 'unavailable') {
+        sendReplyErr(from, id, 'E_MUTATION_GATE_UNAVAILABLE',
+          `mutation gate store is unavailable: ${status.health.reason ?? 'unreadable store'}`);
+        return;
+      }
+    }
     // #35 P2: the standing runtime pin is consulted BEFORE `resolveRouteFilter` — a
     // per-request `--instance`/`--file` still bypasses it entirely (route-filter.ts's own
     // precedence), but a no-flag command with a pin set must never silently fall through
@@ -962,15 +1009,37 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // the override rule.
     const pin = targetInstancePin;
     const pinLive = pin !== null && st.registry.getByInstanceId(pin)?.ws.readyState === WebSocket.OPEN;
-    if (pin !== null && pinDisconnected(expectedFile, expectedInstance, pin, pinLive)) {
+    if (requestedTargetFileKey === undefined && pin !== null && pinDisconnected(expectedFile, expectedInstance, pin, pinLive)) {
       sendReplyErr(from, id, 'E_TARGET_DISCONNECTED',
         `the pinned plugin (instance ${pin}) is no longer connected — re-target it with the panel's "Target this plugin" button, or clear the pin and retry`);
       return;
     }
-    const filter = resolveRouteFilter(expectedFile, currentFilter(), expectedInstance, pinLive ? pin : null);
+    const filter: RouteFilter = requestedTargetFileKey === undefined
+      ? resolveRouteFilter(expectedFile, currentFilter(), expectedInstance, pinLive ? pin : null)
+      : { value: null, exact: true, source: 'none', kind: 'name' };
     let targetWs = st.dispatchedTo.get(id);
     if (targetWs && targetWs.readyState !== WebSocket.OPEN) targetWs = undefined;
-    if (!targetWs) {
+    if (requestedTargetFileKey !== undefined) {
+      // The caller's key is a routing assertion, never canonical evidence: only the
+      // currently registered scene key may select a plugin. A live keyless plugin is an
+      // identity failure; a live different key is a wrong-file refusal, never a guess.
+      const live = st.registry.liveEntries();
+      const exact = live.find((entry) => durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === requestedTargetFileKey);
+      if (exact) {
+        targetWs = exact.ws;
+      } else if (live.length > 0) {
+        const hasMissingKey = live.some((entry) => durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === null);
+        sendReplyErr(
+          from,
+          id,
+          hasMissingKey ? 'E_FILE_KEY_UNAVAILABLE' : 'E_WRONG_FILE',
+          hasMissingKey
+            ? 'targetFileKey cannot be verified because a live plugin has no raw fileKey'
+            : `no live plugin matches targetFileKey ${JSON.stringify(requestedTargetFileKey)}`,
+        );
+        return;
+      }
+    } else if (!targetWs) {
       const hits = st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind });
       // An explicit --file that matches two open files is AMBIGUOUS: same-named files are
       // indistinguishable here (fileKey is null for a non-org plugin), and guessing by recency
@@ -1007,11 +1076,30 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         sendReplyErr(from, id, 'E_NO_PLUGIN', noPluginMessage(st.registry, filter));
         return;
       }
+      // A mutation cannot claim a durable target identity from a filename, a route
+      // filter, or a later plugin HELLO. Only an explicit raw target key may park it.
+      if (!isReadOnly && requestedTargetFileKey === undefined) {
+        sendReplyErr(from, id, 'E_FILE_KEY_UNAVAILABLE',
+          'a disconnected mutation requires an exact raw targetFileKey; filename routing is not durable identity');
+        return;
+      }
+      const parkedAt = Date.now();
+      let admissionRevision: number | undefined;
+      if (!isReadOnly) {
+        const parkingAdmission = mutationGate.admit(requestedTargetFileKey);
+        if (!parkingAdmission.ok) {
+          sendReplyErr(from, id, parkingAdmission.error.code, parkingAdmission.error.message);
+          return;
+        }
+        admissionRevision = parkingAdmission.lastTransitionRevision;
+      }
       st.waiting.push({
         id, from, rawText, deadline: Date.now() + PLUGIN_WAIT_TIMEOUT_MS, filter, projectDir,
-        cmd, readOnly, activity,
+        cmd, readOnly: isReadOnly, activity,
+        ...(requestedTargetFileKey !== undefined && requestedTargetFileKey !== null && { targetFileKey: requestedTargetFileKey }),
+        ...(admissionRevision !== undefined && { admissionRevision, admittedAt: parkedAt }),
       });
-      log(`parked ${id}${cmd ? ` (${cmd})` : ''}${filter.value ? ` [${filter.source}="${filter.value}"]` : ''} — awaiting ${filter.value ? 'matching ' : ''}plugin (${st.waiting.length} queued)`);
+      log(`parked ${id}${cmd ? ` (${cmd})` : ''}${requestedTargetFileKey ? ` [targetFileKey=${JSON.stringify(requestedTargetFileKey)} rev=${admissionRevision ?? 'safe-read'} at=${parkedAt}]` : filter.value ? ` [${filter.source}="${filter.value}"]` : ''} — awaiting ${requestedTargetFileKey || filter.value ? 'matching ' : ''}plugin (${st.waiting.length} queued)`);
       return;
     }
 
@@ -1023,15 +1111,40 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       return;
     }
 
+    const rawFileKey = durableFileKey((targetEntry.scene.fileKey as string | null | undefined) ?? null);
+    if (requestedTargetFileKey !== undefined) {
+      if (rawFileKey === null) {
+        sendReplyErr(from, id, 'E_FILE_KEY_UNAVAILABLE', 'targetFileKey cannot be verified because the selected plugin has no raw fileKey');
+        return;
+      }
+      if (rawFileKey !== requestedTargetFileKey) {
+        sendReplyErr(from, id, 'E_WRONG_FILE', `selected plugin key does not match targetFileKey ${JSON.stringify(requestedTargetFileKey)}`);
+        return;
+      }
+    }
+    if (!isReadOnly) {
+      const admission = mutationGate.admit(rawFileKey);
+      if (!admission.ok) {
+        sendReplyErr(from, id, admission.error.code, admission.error.message);
+        return;
+      }
+      // A pause/resume of THIS target deliberately invalidates its formerly open
+      // parking decision; a store-wide sequence change for another target does not.
+      if (parkedAdmission !== undefined && admission.lastTransitionRevision > parkedAdmission.admissionRevision) {
+        sendReplyErr(from, id, 'E_STALE_ADMISSION',
+          `parked mutation for ${JSON.stringify(parkedAdmission.targetFileKey)} became stale after gate revision ${parkedAdmission.admissionRevision} (parked at ${parkedAdmission.admittedAt})`);
+        return;
+      }
+    }
+
     recordRequestBinding(targetWs, projectDir);
     st.pending.set(id, from);
     st.dispatchedTo.set(id, targetWs);
 
-    const fileSlug = fileIdentity(
-      (targetEntry.scene.fileKey as string | null | undefined) ?? null,
+    const fileSlug = rawFileKey ?? fileIdentity(
+      null,
       (targetEntry.scene.fileName as string | undefined) ?? null,
     );
-    const isReadOnly = readOnly === true || (cmd !== undefined && IMPLICIT_READ_ONLY.has(cmd));
     const job = st.jobs.create({
       requestId: id, cmd: cmd ?? '(unknown)', fileSlug, readOnly: isReadOnly,
       requestFrames: [rawText], from, targetInstanceId: targetEntry.instanceId,
@@ -1052,6 +1165,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const { q: nextQ, startNow } = enqueueJob(q, job.jobId);
     st.queues.set(fileSlug, nextQ);
     if (startNow) {
+      const admission = mutationGate.admit(rawFileKey);
+      if (!admission.ok) {
+        if (cancelQueuedForGate(job, admission.error.code, admission.error.message)) advanceQueue(job);
+        return;
+      }
       st.jobs.markRunning(job.jobId);
       dispatchJob(job, targetWs);
     } else {
@@ -1068,8 +1186,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    * `cmd`/`readOnly`/`expectedFile` — those live inside the reassembled JSON. Buffer until
    * `last`, then reassemble with the SAME `ChunkAssembler` used elsewhere (envelope-level
    * only — the broker still never reads `params`) and admit with the REAL envelope. Never
-   * invent a synthetic `CHUNKED` pseudo-command: that would misroute a filtered request,
-   * force a large declared-read-only EXEC_JS to queue, and put false metadata in `status`.
+   * invent a synthetic `CHUNKED` pseudo-command: that would misroute a filtered request
+   * and put false metadata in `status`.
    */
   const admitChunk = (from: WebSocket, id: string, rawText: string, last: boolean): void => {
     // A chunk belonging to an ALREADY-admitted job (running or queued) is a continuation
@@ -1115,7 +1233,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     }
     admitRequest(
       from, id, JSON.stringify(assembled), assembled.cmd, assembled.expectedFile, assembled.expectedInstance,
-      assembled.readOnly === true, assembled.projectDir, assembled.activity,
+      assembled.targetFileKey, assembled.readOnly === true, assembled.projectDir, assembled.activity,
     );
   };
 
@@ -1133,13 +1251,19 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     let delivered = 0;
     for (const req of queued) {
       if (req.from.readyState !== WebSocket.OPEN) continue; // CLI gone — drop silently
-      if (st.registry.selectTarget(req.filter.value, { exact: req.filter.exact, kind: req.filter.kind })) {
+      const targetExists = req.targetFileKey === undefined
+        ? st.registry.selectTarget(req.filter.value, { exact: req.filter.exact, kind: req.filter.kind }) !== null
+        : st.registry.liveEntries().length > 0;
+      if (targetExists) {
         const flagValue = req.filter.source === 'flag' ? req.filter.value ?? undefined : undefined;
         admitRequest(
           req.from, req.id, req.rawText, req.cmd,
           req.filter.kind === 'name' ? flagValue : undefined,
           req.filter.kind === 'instance' ? flagValue : undefined,
-          req.readOnly === true, req.projectDir, req.activity,
+          req.targetFileKey, req.readOnly === true, req.projectDir, req.activity,
+          req.targetFileKey !== undefined && req.admissionRevision !== undefined && req.admittedAt !== undefined
+            ? { targetFileKey: req.targetFileKey, admissionRevision: req.admissionRevision, admittedAt: req.admittedAt }
+            : undefined,
         );
         delivered++;
       } else {
@@ -1351,6 +1475,54 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       : { job: info });
   };
 
+  /** Broker-terminal durable pause/open control. It intentionally uses only the raw
+   * file key supplied by the caller; a file name never becomes gate state. */
+  const handleMutationGate = (ws: WebSocket, msg: RequestMsg): void => {
+    const params = msg.params as { mode?: unknown; fileKey?: unknown } | null;
+    const mode = typeof params?.mode === 'string' ? params.mode : null;
+    const fileKey = durableFileKey(typeof params?.fileKey === 'string' ? params.fileKey : null);
+    if (fileKey === null) {
+      sendReplyErr(ws, msg.id, 'E_FILE_KEY_UNAVAILABLE', 'MUTATION_GATE requires a nonempty raw fileKey');
+      return;
+    }
+    if (mode === 'status') {
+      const status = mutationGate.status();
+      if (status.health.state === 'unavailable') {
+        sendReplyErr(ws, msg.id, 'E_MUTATION_GATE_UNAVAILABLE', `mutation gate store is unavailable: ${status.health.reason ?? 'unreadable store'}`);
+        return;
+      }
+      const row = status.gates.find((gate) => gate.fileKey === fileKey)
+        ?? { fileKey, state: 'open' as const, lastTransitionRevision: 0 };
+      sendReplyOk(ws, msg.id, { ...row, mutationGateStoreHealth: status.health });
+      return;
+    }
+    if (mode !== 'pause' && mode !== 'resume') {
+      sendReplyErr(ws, msg.id, 'E_INVALID_ARGS', 'MUTATION_GATE mode must be pause, resume, or status');
+      return;
+    }
+    const transition = mutationGate.transition(fileKey, mode === 'pause' ? 'paused' : 'open');
+    if (!transition.ok) {
+      sendReplyErr(ws, msg.id, transition.error.code, transition.error.message);
+      return;
+    }
+    if (transition.state === 'paused') {
+      const q = st.queues.get(fileKey);
+      for (const jobId of [...(q?.waiting ?? [])]) {
+        const job = st.jobs.byId(jobId);
+        if (job !== 'unknown' && job !== 'expired') {
+          cancelQueuedForGate(job, 'E_MUTATIONS_PAUSED', `mutations are paused for fileKey ${JSON.stringify(fileKey)}`);
+        }
+      }
+    }
+    sendReplyOk(ws, msg.id, {
+      fileKey,
+      state: transition.state,
+      lastTransitionRevision: transition.lastTransitionRevision,
+      sequence: transition.sequence,
+      mutationGateStoreHealth: transition.health,
+    });
+  };
+
   /**
    * auto-connect slice 3 — `figma-agent cowork`. Broker-terminal (same precedent as
    * PROJECT_BIND/JOB): resolves a target plugin ONCE using the SAME routing filter
@@ -1517,7 +1689,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // elsewhere (envelope-level only — the broker still never reads `params`), and
       // THEN admits the request with its real `cmd`/`readOnly`/`expectedFile`/
       // `projectDir` — never a synthetic pseudo-command that would misroute a filtered
-      // request or force a declared-read-only EXEC_JS to queue.
+      // request or misclassify its broker-safe-read admission.
       if (isPlugin) { st.registry.touchActive(ws); routeFromPlugin(msg.id, text, msg.last, ws); }
       else admitChunk(ws, msg.id, text, msg.last);
     } else if (isReplyMsg(msg)) {
@@ -1549,10 +1721,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     } else if (isRequestMsg(msg)) {
       if (msg.cmd === 'PROJECT_BIND') handleProjectBind(ws, msg);
       else if (msg.cmd === 'JOB') handleJobCommand(ws, msg);
+      else if (msg.cmd === 'MUTATION_GATE') handleMutationGate(ws, msg);
       else if (msg.cmd === 'COWORK') handleCowork(ws, msg);
       // Envelope-only: cmd + readOnly decide queueing. params are never parsed — the
       // pure-relay rule (concurrency & jobs, backlog 1.1+2.6+4.3).
-      else admitRequest(ws, msg.id, text, msg.cmd, msg.expectedFile, msg.expectedInstance, msg.readOnly === true, msg.projectDir, msg.activity);
+      else admitRequest(
+        ws, msg.id, text, msg.cmd, msg.expectedFile, msg.expectedInstance, msg.targetFileKey,
+        msg.readOnly === true, msg.projectDir, msg.activity,
+      );
     } else if (isEventMsg(msg)) {
       if (msg.type === 'PLUGIN_HELLO') {
         // Multi-plugin: register this instance in its OWN slot — never evict another
@@ -1761,6 +1937,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           currentFilter(),
           Date.now,
           jobStatusFor,
+          mutationGate.status(),
         ),
         ...(awaitingReconnect.length > 0 && { awaitingReconnect }),
       },

--- a/cli/src/transport/broker-peek.ts
+++ b/cli/src/transport/broker-peek.ts
@@ -2,7 +2,13 @@
 // able to call this without ever starting a broker. NEVER calls `ensureBroker`
 // (broker-discovery.ts, which spawns); only reads the /tmp advertisement and,
 // if one looks live, asks that broker ONE short question with its own deadline.
-import { BROKER_FILE, PROTOCOL_VERSION, type PluginStatusEntry } from '../../../shared/protocol.ts';
+import {
+  BROKER_FILE,
+  PROTOCOL_VERSION,
+  type MutationGateRow,
+  type MutationGateStoreHealth,
+  type PluginStatusEntry,
+} from '../../../shared/protocol.ts';
 import { isAdvertisementLive, readAdvertisement } from './broker-discovery.ts';
 import { fetchBrokerHello } from './broker-client.ts';
 import { envMs } from './protocol-helpers.ts';
@@ -26,11 +32,13 @@ export interface PeekResult {
   idle?: true;
   reason?: string;
   degraded?: string;
-  broker: { port: number; pid: number; protocolVersion?: number; uptimeMs?: number } | null;
+  broker: { port: number; pid: number; protocolVersion?: number; uptimeMs?: number; targetFileKeyAdmissionV?: 1 } | null;
   plugins?: PeekPluginEntry[];
   cliVersion: string;
   versionMatch?: boolean | null;
   protocolMatch?: boolean | null;
+  mutationGates?: MutationGateRow[];
+  mutationGateStoreHealth?: MutationGateStoreHealth;
 }
 
 /** `undefined` (the field was never sent) is UNKNOWN, not a mismatch. */
@@ -130,10 +138,14 @@ export async function peek(opts?: { path?: string; queryMs?: number }): Promise<
       pid: ad.pid,
       protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
       uptimeMs: (hello.uptimeMs as number | undefined) ?? undefined,
+      ...(hello.targetFileKeyAdmissionV === 1 && { targetFileKeyAdmissionV: 1 as const }),
     },
     plugins,
     cliVersion: CLI_VERSION,
     versionMatch: active ? active.versionMatch : null,
     protocolMatch: active ? active.protocolMatch : null,
+    ...(Array.isArray(hello.mutationGates) && { mutationGates: hello.mutationGates as MutationGateRow[] }),
+    ...(hello.mutationGateStoreHealth !== null && typeof hello.mutationGateStoreHealth === 'object'
+      && { mutationGateStoreHealth: hello.mutationGateStoreHealth as MutationGateStoreHealth }),
   };
 }

--- a/cli/src/transport/broker-status.ts
+++ b/cli/src/transport/broker-status.ts
@@ -2,7 +2,7 @@
 // (`figma-agent status` reads it) and the E_NO_PLUGIN message. Kept out of
 // broker-daemon.ts so both are unit-testable without a live socket.
 import type { PluginRegistry, RegistrySocket } from './plugin-registry.ts';
-import type { JobInfo, PluginStatusEntry } from '../../../shared/protocol.ts';
+import type { JobInfo, MutationGateRow, MutationGateStoreHealth, PluginStatusEntry } from '../../../shared/protocol.ts';
 import type { RouteFilter } from './route-filter.ts';
 import { fileIdentity } from './file-identity.ts';
 
@@ -17,6 +17,11 @@ export interface FileJobStatus {
 /** A `plugins[]` row once `jobStatusFor` augments it (see `buildBrokerHelloData`) —
  *  status.ts's own type for reading the field back, instead of an untyped cast. */
 export type PluginStatusEntryWithJob = PluginStatusEntry & FileJobStatus;
+
+export interface MutationGateStatus {
+  health: MutationGateStoreHealth;
+  gates: MutationGateRow[];
+}
 
 /** Daemon-owned fields the registry can't know (identity + uptime). */
 export interface BrokerMeta {
@@ -57,6 +62,7 @@ export function buildBrokerHelloData(
   // omitted key, per each row's OWN fileSlug (`fileIdentity(fileKey, fileName)` — the
   // SAME identity chain routing + registry + jobs already share).
   jobStatusFor?: (fileSlug: string) => FileJobStatus,
+  mutationGateStatus?: MutationGateStatus,
 ): Record<string, unknown> {
   const plugins: PluginStatusEntry[] = registry.statusList();
   const target = registry.selectTarget(filter);
@@ -68,10 +74,17 @@ export function buildBrokerHelloData(
         const { runningJob, queueDepth } = jobStatusFor(slug);
         return { ...p, runningJob, queueDepth };
       });
+  const mutationGates = mutationGateStatus?.gates.map((gate) => ({
+    ...gate,
+    ...(plugins.some((plugin) => plugin.fileKey === gate.fileKey) && { connected: true }),
+  }));
   return {
     port: meta.port,
     pid: meta.pid,
     protocolV: meta.protocolV,
+    // Capability, not a protocol-version bump: a bundled current broker can enforce an
+    // exact `targetFileKey` admission assertion while older brokers simply omit it.
+    targetFileKeyAdmissionV: 1,
     buildMtime: meta.buildMtime,
     uptimeMs: meta.uptimeMs,
     plugins: withJobs,
@@ -93,6 +106,10 @@ export function buildBrokerHelloData(
     pluginState: connected ? 'connected' : 'disconnected',
     lastHeartbeatAge: target && target.lastSeenAt ? now() - target.lastSeenAt : null,
     pluginInfo: target ? target.scene : null,
+    ...(mutationGateStatus !== undefined && {
+      mutationGates,
+      mutationGateStoreHealth: mutationGateStatus.health,
+    }),
   };
 }
 

--- a/cli/src/transport/file-identity.ts
+++ b/cli/src/transport/file-identity.ts
@@ -27,3 +27,21 @@ export function fileIdentity(fileKey: string | null | undefined, fileName: strin
   if (typeof fileKey === 'string' && fileKey.trim() !== '') return fileKey;
   return safeSlug(fileName ?? '');
 }
+
+/**
+ * Exact identity for durable broker mutation state. Unlike `fileIdentity`, this
+ * deliberately has no filename or `unknown` fallback: a gate keyed by a name could
+ * silently apply to a different Figma file after rename or collision.
+ */
+export function durableFileKey(fileKey: string | null | undefined, _fileName?: string | null): string | null {
+  return typeof fileKey === 'string' && fileKey.trim() !== '' ? fileKey : null;
+}
+
+/**
+ * Exact client-provided target assertion. Unlike a scene-supplied durable key, this is
+ * deliberately strict: padding would prove neither identity nor intent, and trimming it
+ * would silently retarget a caller. Internal whitespace remains raw and valid.
+ */
+export function exactTargetFileKey(fileKey: string | null | undefined): string | null {
+  return typeof fileKey === 'string' && fileKey !== '' && fileKey.trim() === fileKey ? fileKey : null;
+}

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -234,7 +234,7 @@ export class JobTable {
   }
 
   /** Refuses a RUNNING job — the sandbox cannot interrupt a live `eval`. */
-  cancelQueued(jobId: string): { ok: boolean; reason?: string } {
+  cancelQueued(jobId: string, replyFrames: string[] = []): { ok: boolean; reason?: string } {
     const rec = this.jobs.get(jobId);
     if (!rec) return { ok: false, reason: 'no such job' };
     if (rec.state === 'running') {
@@ -244,9 +244,11 @@ export class JobTable {
     rec.state = 'cancelled';
     rec.finishedAt = this.now();
     rec.queuedMs = rec.finishedAt - rec.createdAt;
+    rec.replyFrames = replyFrames;
     delete rec.queuePosition;
     this.finishedOrder.push(jobId);
     this.enforceFinishedCap();
+    this.enforceByteBudget();
     return { ok: true };
   }
 

--- a/cli/src/transport/mutation-admission-gate.ts
+++ b/cli/src/transport/mutation-admission-gate.ts
@@ -1,0 +1,151 @@
+import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import type { ErrorCode, MutationGateRow, MutationGateState, MutationGateStoreHealth } from '../../../shared/protocol.ts';
+import { durableFileKey } from './file-identity.ts';
+
+export const MUTATION_GATE_FILENAME = 'mutation-gates.json';
+const SCHEMA_VERSION = 1;
+
+interface PersistedGate { state: MutationGateState; lastTransitionRevision: number; }
+interface PersistedTransition { fileKey: string; from: MutationGateState; to: MutationGateState; at: number; revision: number; }
+interface PersistedSnapshot { schemaVersion: 1; sequence: number; gates: Record<string, PersistedGate>; latestTransition?: PersistedTransition; }
+
+export interface MutationGateStatus { health: MutationGateStoreHealth; gates: MutationGateRow[]; }
+export type MutationGateDecision =
+  | { ok: true; fileKey: string; state: MutationGateState; lastTransitionRevision: number; health: MutationGateStoreHealth }
+  | { ok: false; fileKey?: string; lastTransitionRevision?: number; error: { code: ErrorCode; message: string }; health: MutationGateStoreHealth };
+type MutationGateDenied = Extract<MutationGateDecision, { ok: false }>;
+export type MutationGateTransition =
+  | { ok: true; fileKey: string; state: MutationGateState; previousState: MutationGateState; lastTransitionRevision: number; sequence: number; health: MutationGateStoreHealth }
+  | MutationGateDenied;
+
+export interface MutationAdmissionGateOptions {
+  now?: () => number;
+  writeFile?: (path: string, data: string) => void;
+  rename?: (from: string, to: string) => void;
+}
+
+export function mutationGatePathFor(advertisePath: string): string {
+  return join(dirname(advertisePath), MUTATION_GATE_FILENAME);
+}
+
+function validState(value: unknown): value is MutationGateState {
+  return value === 'paused' || value === 'open';
+}
+
+function validSnapshot(value: unknown): value is PersistedSnapshot {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+  const snapshot = value as Record<string, unknown>;
+  if (snapshot.schemaVersion !== SCHEMA_VERSION || !Number.isSafeInteger(snapshot.sequence) || (snapshot.sequence as number) < 0) return false;
+  if (snapshot.gates === null || typeof snapshot.gates !== 'object' || Array.isArray(snapshot.gates)) return false;
+  const sequence = snapshot.sequence as number;
+  const gates = snapshot.gates as Record<string, unknown>;
+  for (const [fileKey, record] of Object.entries(gates)) {
+    if (fileKey.trim() === '' || record === null || typeof record !== 'object') return false;
+    const gate = record as Record<string, unknown>;
+    if (!validState(gate.state) || !Number.isSafeInteger(gate.lastTransitionRevision)
+      || (gate.lastTransitionRevision as number) < 0 || (gate.lastTransitionRevision as number) > sequence) return false;
+  }
+  if (sequence === 0) return snapshot.latestTransition === undefined || snapshot.latestTransition === null;
+  const latest = snapshot.latestTransition;
+  if (latest === null || typeof latest !== 'object' || Array.isArray(latest)) return false;
+  const transition = latest as Record<string, unknown>;
+  const latestGate = typeof transition.fileKey === 'string' ? gates[transition.fileKey] : undefined;
+  if (latestGate === null || typeof latestGate !== 'object') return false;
+  const gate = latestGate as Record<string, unknown>;
+  return typeof transition.fileKey === 'string' && transition.fileKey.trim() !== '' && validState(transition.from)
+    && validState(transition.to) && Number.isFinite(transition.at) && transition.revision === sequence
+    && gate.lastTransitionRevision === sequence && gate.state === transition.to;
+}
+
+function freshSnapshot(): PersistedSnapshot {
+  return { schemaVersion: SCHEMA_VERSION, sequence: 0, gates: Object.create(null) };
+}
+
+export class MutationAdmissionGate {
+  private readonly now: () => number;
+  private readonly writeFile: (path: string, data: string) => void;
+  private readonly rename: (from: string, to: string) => void;
+  private unavailableReason: string | null = null;
+
+  constructor(readonly path: string, options: MutationAdmissionGateOptions = {}) {
+    this.now = options.now ?? Date.now;
+    this.writeFile = options.writeFile ?? ((path, data) => writeFileSync(path, data, 'utf8'));
+    this.rename = options.rename ?? renameSync;
+  }
+
+  private health(state: MutationGateStoreHealth['state'], reason?: string): MutationGateStoreHealth {
+    return { state, path: this.path, ...(reason !== undefined && { reason }) };
+  }
+
+  private unavailable(reason: string, fileKey?: string, lastTransitionRevision?: number): MutationGateDenied {
+    this.unavailableReason = reason;
+    return { ok: false, ...(fileKey !== undefined && { fileKey }), ...(lastTransitionRevision !== undefined && { lastTransitionRevision }),
+      error: { code: 'E_MUTATION_GATE_UNAVAILABLE', message: `mutation gate store is unavailable: ${reason}` }, health: this.health('unavailable', reason) };
+  }
+
+  private load(): { snapshot: PersistedSnapshot; health: MutationGateStoreHealth } | null {
+    if (this.unavailableReason !== null) return null;
+    let raw: string;
+    try { raw = readFileSync(this.path, 'utf8'); }
+    catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ENOENT') return { snapshot: freshSnapshot(), health: this.health('missing') };
+      this.unavailableReason = (err as Error).message;
+      return null;
+    }
+    try {
+      const parsed: unknown = JSON.parse(raw);
+      if (!validSnapshot(parsed)) throw new Error('invalid schema or gate entry');
+      return { snapshot: parsed, health: this.health('healthy') };
+    } catch (err) {
+      this.unavailableReason = (err as Error).message;
+      return null;
+    }
+  }
+
+  admit(fileKey: string | null | undefined): MutationGateDecision {
+    const rawKey = durableFileKey(fileKey);
+    if (rawKey === null) {
+      return { ok: false, error: { code: 'E_FILE_KEY_UNAVAILABLE', message: 'mutation admission requires a nonempty raw Figma fileKey' }, health: this.health('missing') };
+    }
+    const loaded = this.load();
+    if (!loaded) return this.unavailable(this.unavailableReason ?? 'unreadable store', rawKey);
+    const gate = loaded.snapshot.gates[rawKey] ?? { state: 'open', lastTransitionRevision: 0 };
+    if (gate.state === 'paused') {
+      return { ok: false, fileKey: rawKey, lastTransitionRevision: gate.lastTransitionRevision,
+        error: { code: 'E_MUTATIONS_PAUSED', message: `mutations are paused for fileKey ${JSON.stringify(rawKey)}` }, health: loaded.health };
+    }
+    return { ok: true, fileKey: rawKey, state: gate.state, lastTransitionRevision: gate.lastTransitionRevision, health: loaded.health };
+  }
+
+  transition(fileKey: string | null | undefined, state: MutationGateState): MutationGateTransition {
+    const rawKey = durableFileKey(fileKey);
+    if (rawKey === null) return { ok: false, error: { code: 'E_FILE_KEY_UNAVAILABLE', message: 'mutation admission requires a nonempty raw Figma fileKey' }, health: this.health('missing') };
+    const loaded = this.load();
+    if (!loaded) return this.unavailable(this.unavailableReason ?? 'unreadable store', rawKey);
+    const previous = loaded.snapshot.gates[rawKey] ?? { state: 'open', lastTransitionRevision: 0 };
+    const sequence = loaded.snapshot.sequence + 1;
+    const gates = Object.assign(Object.create(null), loaded.snapshot.gates, { [rawKey]: { state, lastTransitionRevision: sequence } });
+    const next: PersistedSnapshot = { schemaVersion: SCHEMA_VERSION, sequence, gates,
+      latestTransition: { fileKey: rawKey, from: previous.state, to: state, at: this.now(), revision: sequence } };
+    const tmpPath = `${this.path}.${process.pid}.${Date.now()}.tmp`;
+    try {
+      mkdirSync(dirname(this.path), { recursive: true });
+      this.writeFile(tmpPath, JSON.stringify(next));
+      this.rename(tmpPath, this.path);
+    } catch (err) {
+      try { unlinkSync(tmpPath); } catch { /* evidence remains in the prior atomic target */ }
+      return this.unavailable((err as Error).message, rawKey, previous.lastTransitionRevision) as MutationGateTransition;
+    }
+    return { ok: true, fileKey: rawKey, state, previousState: previous.state, lastTransitionRevision: sequence, sequence, health: this.health('healthy') };
+  }
+
+  status(): MutationGateStatus {
+    const loaded = this.load();
+    if (!loaded) return { health: this.health('unavailable', this.unavailableReason ?? 'unreadable store'), gates: [] };
+    const gates = Object.entries(loaded.snapshot.gates)
+      .map(([fileKey, gate]) => ({ fileKey, state: gate.state, lastTransitionRevision: gate.lastTransitionRevision }))
+      .sort((a, b) => a.fileKey.localeCompare(b.fileKey));
+    return { health: loaded.health, gates };
+  }
+}

--- a/plugin/src/ui/orb-command-state.ts
+++ b/plugin/src/ui/orb-command-state.ts
@@ -19,7 +19,7 @@ const COMMANDS_BY_STATE = {
     'SET_VARIANT', 'BIND_VARIABLE', 'SET_AUTOLAYOUT', 'SET_CONSTRAINTS', 'CLONE_TRAITS',
   ]),
   weaving: new Set(['BATCH', 'CONNECT', 'DISCONNECT', 'REROUTE', 'RECONCILE']),
-  working: new Set(['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB']),
+  working: new Set(['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB', 'MUTATION_GATE']),
   listening: new Set(['COWORK']),
 } satisfies Partial<Record<OrbState, ReadonlySet<string>>>;
 

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1537,7 +1537,7 @@ body { overflow: hidden; }
       "CLONE_TRAITS"
     ]),
     weaving: /* @__PURE__ */ new Set(["BATCH", "CONNECT", "DISCONNECT", "REROUTE", "RECONCILE"]),
-    working: /* @__PURE__ */ new Set(["EXEC_JS", "SET_CORRECTION_MEMORY", "PROJECT_BIND", "JOB"]),
+    working: /* @__PURE__ */ new Set(["EXEC_JS", "SET_CORRECTION_MEMORY", "PROJECT_BIND", "JOB", "MUTATION_GATE"]),
     listening: /* @__PURE__ */ new Set(["COWORK"])
   };
   var STATUS_BY_STATE = {
@@ -2651,7 +2651,7 @@ body { overflow: hidden; }
     }, 4e3);
     render();
   });
-  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "c2bd0ef" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "e945a9d" : "dev"}`;
   replaceIcon(targetRailBtn, "files");
   replaceIcon(syncRailBtn, "refresh-cw");
   replaceIcon(toggleBtn, "chevron-down");

--- a/shared/mutating-commands.ts
+++ b/shared/mutating-commands.ts
@@ -10,6 +10,26 @@
 // that invites a non-pure import down the line. shared/ has no such boundary to cross.
 import type { CommandName } from './protocol';
 
+/**
+ * The only commands that can bypass broker mutation admission. This is intentionally
+ * separate from undo-step classification: it describes broker-visible effects, not
+ * whether a plugin command calls `figma.commitUndo()`.
+ */
+export const BROKER_SAFE_READ_COMMANDS: readonly CommandName[] = [
+  'STATUS',
+  'GET_SELECTION',
+  'EXPORT_PNG',
+  'SCAN_DESIGN_SYSTEM',
+  'GET_CORRECTION_MEMORY',
+  'LIST_CONNECTIONS',
+  'VERIFY_CONNECTIONS',
+  'SHADER_GRADIENT_PROBE',
+];
+
+export function isBrokerSafeRead(command: string): command is CommandName {
+  return (BROKER_SAFE_READ_COMMANDS as readonly string[]).includes(command);
+}
+
 // Each successful mutating command becomes its own undo step. Without commitUndo, Figma's
 // default makes an entire agent session ONE ⌘Z. BATCH is absent deliberately: its children
 // commit individually (inside runBatch), which is the granularity a user wants. Read-only

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -74,6 +74,9 @@ export const COMMANDS = [
   // comment for why that does not violate the pure-relay rule (a request ADDRESSED TO the
   // broker is not a request being RELAYED).
   'JOB',
+  // Broker-terminal mutation admission control. This is deliberately local to the
+  // broker: it persists per-file pause state without adding a plugin or panel route.
+  'MUTATION_GATE',
   // auto-connect slice 3: BROKER-TERMINAL, same precedent as PROJECT_BIND/JOB —
   // intercepted before `admitRequest`/`forwardToPlugin`, never reaches a plugin. Waits
   // for one designer change-cycle (the broker already watches every EDIT_FEED batch,
@@ -91,6 +94,22 @@ export const COMMANDS = [
   'VERIFY_CONNECTIONS',
 ] as const;
 export type CommandName = (typeof COMMANDS)[number];
+
+/**
+ * Commands answered by the broker itself before plugin relay. They cannot be children of
+ * BATCH because a BATCH is executed by the plugin, which has no broker-local handlers.
+ */
+export const BROKER_TERMINAL_COMMANDS = [
+  'PROJECT_BIND',
+  'JOB',
+  'MUTATION_GATE',
+  'COWORK',
+] as const satisfies readonly CommandName[];
+export type BrokerTerminalCommand = (typeof BROKER_TERMINAL_COMMANDS)[number];
+
+export function isBrokerTerminalCommand(command: string): command is BrokerTerminalCommand {
+  return (BROKER_TERMINAL_COMMANDS as readonly string[]).includes(command);
+}
 
 // ── Envelopes ───────────────────────────────────────────────────────
 export interface RequestMsg {
@@ -127,6 +146,13 @@ export interface RequestMsg {
    */
   expectedInstance?: string;
   /**
+   * An exact raw Figma file key used as a broker-side target assertion. It is additive
+   * and omitted when unset; the broker rejects blank or padded values and never derives
+   * it from a filename, bind cache, or a previous reply. For this P0 contract it is
+   * mutually exclusive with `expectedFile` and `expectedInstance`.
+   */
+  targetFileKey?: string;
+  /**
    * Absolute project root of the CALLER (its cwd, or --dir). The broker records
    * fileIdentity → projectDir from this, so panel/idle sync can apply into the right project
    * instead of the daemon's spawn cwd. Omitted only by a pre-binding CLI.
@@ -134,10 +160,9 @@ export interface RequestMsg {
   projectDir?: string;
   /**
    * Concurrency & jobs (backlog 1.1+2.6+4.3) — caller's DECLARATION that this command only
-   * reads. Skips the per-file mutation queue. TRUSTED, NOT ENFORCED: the plugin sandbox
-   * cannot prove a script is read-only (no reliable static parse), so a mis-declared
-   * mutation will interleave — `--help` says so in those words. Omitted entirely when
-   * unset, exactly like `activity`/`expectedFile`/`projectDir` — an unguarded frame must
+   * reads. The broker honors the declaration only for its exact safe-read allowlist;
+   * every other command remains on the mutation path. Omitted entirely when unset,
+   * exactly like `activity`/`expectedFile`/`projectDir` — an unguarded frame must
    * serialize byte-identically to what a pre-flag CLI sent.
    */
   readOnly?: boolean;
@@ -211,6 +236,23 @@ export interface JobInfo {
   queuedMs?: number;      // time spent waiting — the evidence for the subtree-lock upgrade trigger
   startedAt?: number;
   finishedAt?: number;
+}
+
+export type MutationGateState = 'paused' | 'open';
+
+/** One durable broker gate row. `connected` is a status-only live annotation. */
+export interface MutationGateRow {
+  fileKey: string;
+  state: MutationGateState;
+  lastTransitionRevision: number;
+  connected?: boolean;
+}
+
+/** Missing state is safe-open; an unreadable or failed store is unavailable and fail-closed. */
+export interface MutationGateStoreHealth {
+  state: 'missing' | 'healthy' | 'unavailable';
+  path: string;
+  reason?: string;
 }
 
 // Unsolicited broadcasts (no `id`).
@@ -379,12 +421,13 @@ export type ErrorCode =
   // are different facts for the caller to act on.
   | 'E_JOB_UNKNOWN'
   | 'E_JOB_EXPIRED'
-  // Concurrency & jobs — a `--read-only` EXEC_JS detected to have mutated the scene
-  // anyway. `readOnly` on the envelope is TRUSTED, NOT ENFORCED at the wire
-  // layer (see `RequestMsg.readOnly`'s own comment): the plugin is the one place that
-  // can actually observe whether the script wrote anything, so this is where the
-  // mis-declaration turns from a silent breach into a refusal.
+  // Compatibility code for a plugin-side read-only violation. Broker admission accepts
+  // readOnly only for its explicit safe-read allowlist, never for EXEC_JS source.
   | 'E_READONLY_VIOLATION'
+  | 'E_MUTATIONS_PAUSED'
+  | 'E_MUTATION_GATE_UNAVAILABLE'
+  | 'E_FILE_KEY_UNAVAILABLE'
+  | 'E_STALE_ADMISSION'
   // #35 P2 — a no-flag command with a standing `targetInstancePin` set, whose pinned
   // instance has disconnected. Never falls through to the env pin or recency (Law 1: a
   // standing pin never silently re-points at another plugin) — the caller re-targets via
@@ -474,14 +517,21 @@ export function makeRequestFrame(
   // auto-connect slice 2 — appended, never inserted, so every existing call/test that
   // pads earlier optional positionals with `undefined` keeps addressing the SAME
   // parameter it always did (see broker-daemon-harness.test.ts's own 8-positional
-  // precedent). A 9th positional is already a lot for this signature — the NEXT field
-  // here should be an options object instead, not a 10th slot.
+  // precedent). A 9th positional is already a lot for this signature — the next
+  // optional fields stay appended for compatibility until this becomes an options object.
   agent?: string,
+  targetFileKey?: string,
 ): RequestMsg {
   const frame: RequestMsg = { id, cmd, params, v: PROTOCOL_VERSION };
   if (typeof activity === 'string' && activity.trim() !== '') frame.activity = activity;
   if (typeof expectedFile === 'string' && expectedFile.trim() !== '') frame.expectedFile = expectedFile;
   if (typeof expectedInstance === 'string' && expectedInstance.trim() !== '') frame.expectedInstance = expectedInstance;
+  // The CLI rejects blank/padded `--target-file-key` before this builder; keep the raw direct
+  // caller surface conservative too: an invalid assertion is omitted rather than trimmed
+  // into a different key. The broker still rejects a malformed raw wire field explicitly.
+  if (typeof targetFileKey === 'string' && targetFileKey !== '' && targetFileKey.trim() === targetFileKey) {
+    frame.targetFileKey = targetFileKey;
+  }
   if (typeof projectDir === 'string' && projectDir.trim() !== '') frame.projectDir = projectDir;
   if (typeof agent === 'string' && agent.trim() !== '') frame.agent = agent;
   // Concurrency & jobs — omitted (never `readOnly: false`) when unset, exactly like the

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -51,6 +51,7 @@ exactly one JSON object to stdout and exits 0, or `{error:{code,message}}` and e
 ## Command reference
 
 - `status` — Broker + plugin connection info [--peek [--json]] [--wait [--timeout N]] — --peek reads only the /tmp broker advertisement plus one short broker query; it NEVER spawns a broker. --json is accepted for compatibility but is a no-op: output is always the same single JSON object. --wait blocks (MAY spawn a broker) until a matching plugin registers, printing a figma:// deep link (when one can be built) to stderr immediately; --timeout N is in SECONDS, default 60 — on timeout this exits non-zero with E_NO_PLUGIN instead of the normal payload.
+- `mutation-gate` — <pause|resume|status> --file-key <raw-key>   control the local broker's durable per-file mutation admission gate. The key is passed verbatim and must be a nonempty raw Figma fileKey; this command never derives identity from a filename.
 - `seat` — Probe seat → {seat, bridge, reason} [--seat free|paid skips the probe]
 - `bind` — --file "<name>" --dir <projectDir>   bind a file to a project for panel/idle sync (refuses to guess otherwise) [--list] [--unbind]
 - `get-selection` — Serialize the current selection [--depth 1]

--- a/tests/activity-labels.test.ts
+++ b/tests/activity-labels.test.ts
@@ -5,14 +5,23 @@
 // mirror-verify's scans, its rebuild-removal and an ad-hoc script are all the same
 // `cmd` on the wire. Without a label the panel can only ever log "exec js" four
 // times and the user learns nothing — the whole reason the field exists.
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { PROTOCOL_VERSION, makeRequestFrame } from '../shared/protocol.ts';
-import { scanNodeSpec } from '../cli/src/commands/scan-node.ts';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+import { refusesReadOnlyAssertion } from '../cli/src/transport/broker-client.ts';
+import { run as runScanNode, scanNodeSpec } from '../cli/src/commands/scan-node.ts';
 import { execute as mirrorVerify } from '../cli/src/commands/mirror-verify.ts';
 
 interface Call { cmd: string; params: unknown; opts?: { timeoutMs?: number; activity?: string } }
 
 const SPEC = { type: 'FRAME', name: 'Card', width: 100, height: 40 };
+
+const transportSpies = vi.hoisted(() => ({ runCommand: vi.fn() }));
+
+vi.mock('../cli/src/transport/broker-client.ts', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../cli/src/transport/broker-client.ts')>();
+  return { ...actual, runCommand: transportSpies.runCommand };
+});
 
 /** Records every wire call; answers each command with a plausible reply. */
 function recorder(calls: Call[]) {
@@ -55,6 +64,24 @@ describe('scan-node — labels the wait with the node it is scanning', () => {
     const calls: Call[] = [];
     await scanNodeSpec('1:23', 30_000, recorder(calls), 'Mirror-verify · scan rebuild');
     expect(calls[0]?.opts?.activity).toBe('Mirror-verify · scan rebuild');
+  });
+
+  it('bare CLI scan omits an internal readOnly claim, so EXEC_JS reaches broker mutation admission', async () => {
+    transportSpies.runCommand.mockReset();
+    transportSpies.runCommand.mockResolvedValue({ result: SPEC, ms: 1 });
+    const args: CommandArgs = {
+      positionals: ['1:23'],
+      str: () => undefined,
+      req: () => { throw new Error('not used'); },
+      num: () => undefined,
+      bool: () => false,
+    };
+
+    await expect(runScanNode(args)).resolves.toEqual(SPEC);
+    expect(transportSpies.runCommand).toHaveBeenCalledOnce();
+    const [, , opts] = transportSpies.runCommand.mock.calls[0] as [string, unknown, { timeoutMs?: number; activity?: string; readOnly?: boolean }];
+    expect(opts).toEqual({ timeoutMs: 32_000, activity: 'Scan · 1:23' });
+    expect(refusesReadOnlyAssertion('EXEC_JS', opts.readOnly === true)).toBe(false);
   });
 });
 

--- a/tests/batch-op-ceiling.test.ts
+++ b/tests/batch-op-ceiling.test.ts
@@ -15,6 +15,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { assertBatchAdmissible, execute, maxBatchOps, type Runner } from '../cli/src/commands/batch.ts';
+import type { CommandName } from '../shared/protocol.ts';
 
 describe('maxBatchOps — derived from the exact PR #14 formula, not re-guessed', () => {
   it('REGRESSION LOCK: the boundary is 95 ops (95*1200+5000=119000 <= 120000; 96*1200+5000=120200 > 120000)', () => {
@@ -58,10 +59,10 @@ describe('assertBatchAdmissible — hard refusal above the 120s scaled-timeout c
 describe('execute() — the refusal fires BEFORE any dispatch, so the runner is never called', () => {
   let scratchDir: string;
 
-  function writeBatchFile(count: number): string {
+  function writeBatchFile(count: number, command: CommandName = 'SET_TEXT'): string {
     scratchDir = mkdtempSync(join(tmpdir(), 'fa-batch-ceiling-'));
     const filePath = join(scratchDir, 'ops.json');
-    const ops = Array.from({ length: count }, () => ({ cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' } }));
+    const ops = Array.from({ length: count }, () => ({ cmd: command, params: { nodeId: '1:1', text: 'x' } }));
     writeFileSync(filePath, JSON.stringify(ops));
     return filePath;
   }
@@ -95,6 +96,36 @@ describe('execute() — the refusal fires BEFORE any dispatch, so the runner is 
       };
       await expect(execute(filePath, false, runner)).rejects.toThrow();
       expect(called).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('rejects every broker-terminal child before BATCH dispatch, while ordinary plugin commands remain admissible', async () => {
+    for (const command of ['PROJECT_BIND', 'JOB', 'MUTATION_GATE', 'COWORK'] as const) {
+      const filePath = writeBatchFile(1, command);
+      try {
+        let called = false;
+        const runner: Runner = async () => {
+          called = true;
+          return { ok: true };
+        };
+        await expect(execute(filePath, false, runner)).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+        expect(called).toBe(false);
+      } finally {
+        cleanup();
+      }
+    }
+
+    const pluginFile = writeBatchFile(1, 'SET_TEXT');
+    try {
+      let called = false;
+      const runner: Runner = async () => {
+        called = true;
+        return { ok: true };
+      };
+      await expect(execute(pluginFile, false, runner)).resolves.toEqual({ ok: true });
+      expect(called).toBe(true);
     } finally {
       cleanup();
     }

--- a/tests/broker-client-read-only.test.ts
+++ b/tests/broker-client-read-only.test.ts
@@ -1,26 +1,30 @@
-// Concurrency & jobs stage-4 fix round (minor 8, ruling Q4) — `--read-only` is a PARTIAL
-// hardening: refuse the assertion outright when the outgoing command mutates BY NAME
-// (asserting read-only on SET_TEXT/CREATE_FRAME/etc. is always a lie), but EXEC_JS keeps
-// the trusted assertion (that IS the flag's designed use — a read-only script body the
-// broker cannot inspect). Already-read-only commands make the flag a harmless no-op.
-import { describe, expect, it } from 'vitest';
-import { refusesReadOnlyAssertion } from '../cli/src/transport/broker-client.ts';
-import { MUTATING_COMMANDS } from '../shared/mutating-commands.ts';
+// `--read-only` is an explicit broker safe-read declaration. EXEC_JS and every other
+// non-member remain on the mutation path; already safe-read commands retain a harmless
+// no-op declaration.
+import { afterEach, describe, expect, it } from 'vitest';
+import { EventEmitter } from 'node:events';
+import type WebSocket from 'ws';
+import { exchange, refusesReadOnlyAssertion, setTargetFileKey } from '../cli/src/transport/broker-client.ts';
+import { BROKER_SAFE_READ_COMMANDS, MUTATING_COMMANDS } from '../shared/mutating-commands.ts';
+
+function fakeWs(): EventEmitter & { send: (text: string) => void; sent: string[] } {
+  const emitter = new EventEmitter() as EventEmitter & { send: (text: string) => void; sent: string[] };
+  emitter.sent = [];
+  emitter.send = (text: string) => { emitter.sent.push(text); };
+  return emitter;
+}
+
+afterEach(() => setTargetFileKey(undefined));
 
 describe('refusesReadOnlyAssertion', () => {
   it('refuses a mutating-by-name command (SET_TEXT) asserting --read-only', () => {
     expect(refusesReadOnlyAssertion('SET_TEXT', true)).toBe(true);
   });
 
-  it('refuses every MUTATING_COMMANDS entry except EXEC_JS when readOnly is true', () => {
-    for (const cmd of MUTATING_COMMANDS) {
-      const expected = cmd !== 'EXEC_JS';
-      expect(refusesReadOnlyAssertion(cmd, true)).toBe(expected);
-    }
-  });
-
-  it('EXEC_JS keeps the trusted assertion — never refused, that IS the flag\'s designed use', () => {
-    expect(refusesReadOnlyAssertion('EXEC_JS', true)).toBe(false);
+  it('permits only the broker-owned safe-read allowlist when readOnly is true', () => {
+    for (const cmd of BROKER_SAFE_READ_COMMANDS) expect(refusesReadOnlyAssertion(cmd, true)).toBe(false);
+    for (const cmd of MUTATING_COMMANDS) expect(refusesReadOnlyAssertion(cmd, true)).toBe(true);
+    for (const cmd of ['BATCH', 'AUDIT_DS'] as const) expect(refusesReadOnlyAssertion(cmd, true)).toBe(true);
   });
 
   it('an already-read-only command (STATUS) makes the flag a harmless no-op', () => {
@@ -30,5 +34,23 @@ describe('refusesReadOnlyAssertion', () => {
   it('readOnly=false never refuses anything, regardless of command', () => {
     expect(refusesReadOnlyAssertion('SET_TEXT', false)).toBe(false);
     expect(refusesReadOnlyAssertion('EXEC_JS', false)).toBe(false);
+  });
+
+  it('stamps only the exact global target-file-key on outgoing request frames', async () => {
+    setTargetFileKey('Raw/Key 7');
+    const ws = fakeWs();
+    const pending = exchange(ws as unknown as WebSocket, 'STATUS', {}, 5_000);
+    const sent = JSON.parse(ws.sent[0]!) as { id: string; targetFileKey?: string };
+    expect(sent.targetFileKey).toBe('Raw/Key 7');
+    ws.emit('message', Buffer.from(JSON.stringify({ id: sent.id, ok: true, result: { ok: true } })));
+    await expect(pending).resolves.toEqual({ ok: true });
+
+    setTargetFileKey(undefined);
+    const withoutTarget = fakeWs();
+    const noTargetPending = exchange(withoutTarget as unknown as WebSocket, 'STATUS', {}, 5_000);
+    const noTargetSent = JSON.parse(withoutTarget.sent[0]!) as { id: string; targetFileKey?: string };
+    expect(noTargetSent).not.toHaveProperty('targetFileKey');
+    withoutTarget.emit('message', Buffer.from(JSON.stringify({ id: noTargetSent.id, ok: true, result: { ok: true } })));
+    await expect(noTargetPending).resolves.toEqual({ ok: true });
   });
 });

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -178,10 +178,10 @@ async function waitFor(
   }
 }
 
-async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string): Promise<void> {
+async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null): Promise<void> {
   ws.send(JSON.stringify({
     type: 'PLUGIN_HELLO',
-    data: { instanceId, fileName, fileKey: null, caps: ['fileGuard'] },
+    data: { instanceId, fileName, fileKey, caps: ['fileGuard'] },
   } satisfies EventMsg));
   // BROKER_HELLO arrives on connect, before HELLO is even processed — SYNC_CONFIG is the
   // registration ack this test waits on, so it never races the plugin being registered.
@@ -281,6 +281,310 @@ afterEach(async () => {
   rmSync(scratchDir, { recursive: true, force: true });
 });
 
+describe('daemon harness — mutation admission', () => {
+  it('routes a targetFileKey only to an exact raw scene key and preserves it through chunk reassembly', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-target-exact', 'Target Exact', 'Raw/Target-Key');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const request = makeRequestFrame(
+      'c_target_chunked', 'SET_TEXT', { nodeId: '1:1', text: 'x'.repeat(1_024) },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Target-Key',
+    );
+    const serialized = JSON.stringify(request);
+    const cut = Math.floor(serialized.length / 2);
+    const jobState = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify({ id: request.id, seq: 0, last: false, chunk: serialized.slice(0, cut) }));
+    cli.send(JSON.stringify({ id: request.id, seq: 1, last: true, chunk: serialized.slice(cut) }));
+
+    await jobState;
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === request.id));
+    expect(pluginFrames.frames.find((frame) => (frame as { id?: string }).id === request.id)).toMatchObject({
+      targetFileKey: 'Raw/Target-Key',
+    });
+  });
+
+  it('rejects blank/padded/conflicting target assertions and a mismatched live scene key before ownership', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-target-other', 'Target Other', 'Raw/Other-Key');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+
+    const mismatch = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_mismatch');
+    cli.send(JSON.stringify(makeRequestFrame(
+      'c_target_mismatch', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
+    )));
+    expect((await mismatch).error.code).toBe('E_WRONG_FILE');
+
+    const blank = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_blank');
+    cli.send(JSON.stringify({
+      id: 'c_target_blank', cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' }, v: 1,
+      targetFileKey: '',
+    }));
+    expect((await blank).error.code).toBe('E_INVALID_ARGS');
+
+    const padded = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_padded');
+    cli.send(JSON.stringify({
+      id: 'c_target_padded', cmd: 'SET_TEXT', params: { nodeId: '1:1', text: 'x' }, v: 1,
+      targetFileKey: ' Raw/Expected-Key ',
+    }));
+    expect((await padded).error.code).toBe('E_INVALID_ARGS');
+
+    const conflict = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_conflict');
+    cli.send(JSON.stringify(makeRequestFrame(
+      'c_target_conflict', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, 'Target Other', undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
+    )));
+    expect((await conflict).error.code).toBe('E_INVALID_ARGS');
+    expect(pluginFrames.frames.some((frame) => ['c_target_mismatch', 'c_target_blank', 'c_target_padded', 'c_target_conflict']
+      .includes((frame as { id?: string }).id ?? ''))).toBe(false);
+  });
+
+  it('returns E_FILE_KEY_UNAVAILABLE when a target assertion meets a keyless live plugin', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-target-missing', 'Target Missing', null);
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const reply = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_missing');
+    cli.send(JSON.stringify(makeRequestFrame(
+      'c_target_missing', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
+    )));
+
+    expect((await reply).error.code).toBe('E_FILE_KEY_UNAVAILABLE');
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_missing')).toBe(false);
+  });
+
+  it('returns E_MUTATION_GATE_UNAVAILABLE before missing live identity or job ownership when the gate store is corrupt', async () => {
+    writeFileSync(join(scratchDir, 'mutation-gates.json'), '{ malformed');
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-target-gate-corrupt', 'Target Gate Corrupt', null);
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const cliFrames = collectFrames(cli);
+    const reply = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_gate_corrupt');
+
+    cli.send(JSON.stringify(makeRequestFrame('c_target_gate_corrupt', 'SET_TEXT', { nodeId: '1:1', text: 'x' })));
+
+    expect((await reply).error.code).toBe('E_MUTATION_GATE_UNAVAILABLE');
+    expect(cliFrames.frames.some((frame) => (frame as EventMsg).type === 'JOB_STATE')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_gate_corrupt')).toBe(false);
+  });
+
+  it('returns E_MUTATION_GATE_UNAVAILABLE before a mismatched target assertion or job ownership when the gate store is unreadable', async () => {
+    mkdirSync(join(scratchDir, 'mutation-gates.json'));
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-target-gate-unreadable', 'Target Gate Unreadable', 'Raw/Actual-Key');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const cliFrames = collectFrames(cli);
+    const reply = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_gate_unreadable');
+
+    cli.send(JSON.stringify(makeRequestFrame(
+      'c_target_gate_unreadable', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
+    )));
+
+    expect((await reply).error.code).toBe('E_MUTATION_GATE_UNAVAILABLE');
+    expect(cliFrames.frames.some((frame) => (frame as EventMsg).type === 'JOB_STATE')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_gate_unreadable')).toBe(false);
+  });
+
+  it('fails keyless offline mutations immediately, while a keyed mutation and a keyless safe read park for a matching plugin', async () => {
+    const port = await startTestBroker();
+    const keylessCli = await connectSocket(port);
+    const keyless = nextFrame<ReplyErr>(keylessCli, (frame) => (frame as ReplyErr).id === 'c_target_keyless');
+    keylessCli.send(JSON.stringify(makeRequestFrame('c_target_keyless', 'SET_TEXT', { nodeId: '1:1', text: 'x' })));
+    expect((await keyless).error.code).toBe('E_FILE_KEY_UNAVAILABLE');
+
+    const keyedCli = await connectSocket(port);
+    const keyedJob = nextFrame<EventMsg>(keyedCli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    keyedCli.send(JSON.stringify(makeRequestFrame(
+      'c_target_parked', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Parked-Key',
+    )));
+    const safeCli = await connectSocket(port);
+    const safeJob = nextFrame<EventMsg>(safeCli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    safeCli.send(JSON.stringify(makeRequestFrame('c_target_safe_parked', 'GET_SELECTION', {})));
+
+    const plugin = await connectSocket(port);
+    const pluginFrames = collectFrames(plugin);
+    await helloPlugin(plugin, 'p-target-parked', 'Target Parked', 'Raw/Parked-Key');
+    await Promise.all([keyedJob, safeJob]);
+    await waitFor(() => ['c_target_parked', 'c_target_safe_parked'].every((id) =>
+      pluginFrames.frames.some((frame) => (frame as { id?: string }).id === id),
+    ));
+  });
+
+  it('stales parked work after a pause and resume of that same target', async () => {
+    const port = await startTestBroker();
+    const staleCli = await connectSocket(port);
+    const control = await connectSocket(port);
+    const staleReply = nextFrame<ReplyErr>(staleCli, (frame) => (frame as ReplyErr).id === 'c_target_stale');
+    staleCli.send(JSON.stringify(makeRequestFrame(
+      'c_target_stale', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Stale-A',
+    )));
+
+    for (const [id, fileKey, mode] of [
+      ['c_target_pause_a', 'Raw/Stale-A', 'pause'],
+      ['c_target_resume_a', 'Raw/Stale-A', 'resume'],
+    ] as const) {
+      const reply = nextFrame<ReplyOk>(control, (frame) => (frame as ReplyOk).id === id);
+      control.send(JSON.stringify(makeRequestFrame(id, 'MUTATION_GATE', { mode, fileKey })));
+      await reply;
+    }
+
+    const stalePlugin = await connectSocket(port);
+    const stalePluginFrames = collectFrames(stalePlugin);
+    await helloPlugin(stalePlugin, 'p-target-stale', 'Target Stale', 'Raw/Stale-A');
+    expect((await staleReply).error.code).toBe('E_STALE_ADMISSION');
+    expect(stalePluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_stale')).toBe(false);
+  });
+
+  it('keeps a parked target fresh when only an unrelated target transitions', async () => {
+    const port = await startTestBroker();
+    const cli = await connectSocket(port);
+    const control = await connectSocket(port);
+    const freshJob = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify(makeRequestFrame(
+      'c_target_fresh', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Fresh-B',
+    )));
+    for (const [id, mode] of [['c_target_pause_c', 'pause'], ['c_target_resume_c', 'resume']] as const) {
+      const reply = nextFrame<ReplyOk>(control, (frame) => (frame as ReplyOk).id === id);
+      control.send(JSON.stringify(makeRequestFrame(id, 'MUTATION_GATE', { mode, fileKey: 'Raw/Unrelated-C' })));
+      await reply;
+    }
+
+    const plugin = await connectSocket(port);
+    const pluginFrames = collectFrames(plugin);
+    await helloPlugin(plugin, 'p-target-fresh', 'Target Fresh', 'Raw/Fresh-B');
+    await freshJob;
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_fresh'));
+  });
+
+  it('keeps a persisted pause across a replacement broker and admits only a fresh post-resume mutation', async () => {
+    const firstPort = await startTestBroker();
+    const firstCli = await connectSocket(firstPort);
+    const paused = nextFrame<ReplyOk>(firstCli, (frame) => (frame as ReplyOk).id === 'c_target_restart_pause');
+    firstCli.send(JSON.stringify(makeRequestFrame('c_target_restart_pause', 'MUTATION_GATE', { mode: 'pause', fileKey: 'Raw/Restart-Key' })));
+    await paused;
+    rmSync(advertisePath, { force: true });
+
+    const replacementPort = await startTestBroker();
+    const plugin = await connectSocket(replacementPort);
+    await helloPlugin(plugin, 'p-target-restart', 'Target Restart', 'Raw/Restart-Key');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(replacementPort);
+    const blocked = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_restart_blocked');
+    cli.send(JSON.stringify(makeRequestFrame('c_target_restart_blocked', 'SET_TEXT', { nodeId: '1:1', text: 'x' })));
+    expect((await blocked).error.code).toBe('E_MUTATIONS_PAUSED');
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_restart_blocked')).toBe(false);
+
+    const resumed = nextFrame<ReplyOk>(cli, (frame) => (frame as ReplyOk).id === 'c_target_restart_resume');
+    cli.send(JSON.stringify(makeRequestFrame('c_target_restart_resume', 'MUTATION_GATE', { mode: 'resume', fileKey: 'Raw/Restart-Key' })));
+    await resumed;
+    const freshJob = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify(makeRequestFrame('c_target_restart_fresh', 'SET_TEXT', { nodeId: '1:1', text: 'x' })));
+    await freshJob;
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_restart_fresh'));
+  });
+
+  it('handles a raw-key pause at the broker, then refuses mutations without owning a job or forwarding a frame', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-gate', 'Gate File', 'Raw Gate Key');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const gateFrames = collectFrames(cli);
+    const pauseId = 'c_gate_pause_1';
+
+    cli.send(JSON.stringify(makeRequestFrame(pauseId, 'MUTATION_GATE', { mode: 'pause', fileKey: 'Raw Gate Key' })));
+    await waitFor(() => gateFrames.frames.some((frame) => (frame as { id?: string; type?: string }).id === pauseId || (frame as { type?: string }).type === 'JOB_STATE'));
+    expect(gateFrames.frames.find((frame) => (frame as { id?: string }).id === pauseId)).toMatchObject({
+      ok: true,
+      result: { fileKey: 'Raw Gate Key', state: 'paused' },
+    });
+    expect(gateFrames.frames.some((frame) => (frame as { type?: string }).type === 'JOB_STATE')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === pauseId)).toBe(false);
+
+    const mutationId = 'c_gate_mutation_1';
+    const mutationFrames = collectFrames(cli);
+    cli.send(JSON.stringify(makeRequestFrame(mutationId, 'SET_TEXT', { nodeId: '1:1', text: 'blocked' })));
+    await waitFor(() => mutationFrames.frames.some((frame) => (frame as { id?: string; type?: string }).id === mutationId || (frame as { type?: string }).type === 'JOB_STATE'));
+    expect(mutationFrames.frames.find((frame) => (frame as { id?: string }).id === mutationId)).toMatchObject({
+      ok: false,
+      error: { code: 'E_MUTATIONS_PAUSED' },
+    });
+    expect(mutationFrames.frames.some((frame) => (frame as { type?: string }).type === 'JOB_STATE')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === mutationId)).toBe(false);
+  });
+
+  it('leaves a running job alone while terminal-cancelling every queued job with a pollable pause reply', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-gate-queue', 'Gate Queue', 'Raw Queue Key');
+    const pluginFrames = collectFrames(plugin);
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'c_gate_running');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_gate_running'));
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'c_gate_queued_b');
+    const cliC = await connectSocket(port);
+    const jobC = await sendMutatingJob(cliC, 'c_gate_queued_c');
+
+    const pausedB = nextFrame<ReplyErr>(cliB, (frame) => (frame as ReplyErr).id === 'c_gate_queued_b');
+    const pausedC = nextFrame<ReplyErr>(cliC, (frame) => (frame as ReplyErr).id === 'c_gate_queued_c');
+    cliA.send(JSON.stringify(makeRequestFrame('c_gate_pause_queue', 'MUTATION_GATE', { mode: 'pause', fileKey: 'Raw Queue Key' })));
+    await nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === 'c_gate_pause_queue');
+
+    expect((await pausedB).error.code).toBe('E_MUTATIONS_PAUSED');
+    expect((await pausedC).error.code).toBe('E_MUTATIONS_PAUSED');
+    expect((await pollJob(cliB, jobB, 'c_gate_poll_b')).job.state).toBe('cancelled');
+    const polledC = await pollJob(cliC, jobC, 'c_gate_poll_c');
+    expect(polledC.job.state).toBe('cancelled');
+    expect(polledC.resultFrames?.join('\n')).toContain('E_MUTATIONS_PAUSED');
+    expect((await pollJob(cliA, jobA, 'c_gate_poll_a')).job.state).toBe('running');
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_gate_queued_b')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_gate_queued_c')).toBe(false);
+  });
+
+  it('allows only the shared safe-read set through a paused file and ignores caller readOnly claims for executable paths', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'p-gate-safe-reads', 'Gate Safe Reads', 'Raw Safe Reads');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    cli.send(JSON.stringify(makeRequestFrame('c_gate_pause_reads', 'MUTATION_GATE', { mode: 'pause', fileKey: 'Raw Safe Reads' })));
+    await nextFrame<ReplyOk>(cli, (frame) => (frame as ReplyOk).id === 'c_gate_pause_reads');
+
+    const safeReads = [
+      'STATUS', 'GET_SELECTION', 'EXPORT_PNG', 'SCAN_DESIGN_SYSTEM', 'GET_CORRECTION_MEMORY',
+      'LIST_CONNECTIONS', 'VERIFY_CONNECTIONS', 'SHADER_GRADIENT_PROBE',
+    ] as const;
+    for (const [index, cmd] of safeReads.entries()) {
+      const id = `c_gate_safe_${index}`;
+      cli.send(JSON.stringify(makeRequestFrame(id, cmd, {})));
+      await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === id));
+    }
+
+    for (const [index, cmd] of (['EXEC_JS', 'BATCH', 'AUDIT_DS'] as const).entries()) {
+      const id = `c_gate_unsafe_${index}`;
+      cli.send(JSON.stringify(makeRequestFrame(id, cmd, {}, undefined, undefined, undefined, true)));
+      const reply = await nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === id);
+      expect(reply.error.code).toBe('E_MUTATIONS_PAUSED');
+      expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === id)).toBe(false);
+    }
+  });
+});
+
 describe('daemon harness — process listeners belong to one daemon lifetime', () => {
   it('restores signal and exception listener counts after BROKER_SHUTDOWN_REQUEST', async () => {
     const events = ['SIGTERM', 'SIGINT', 'uncaughtException'] as const;
@@ -301,7 +605,7 @@ describe('daemon harness — duplicate request ids never overwrite reply ownersh
   it('refuses the second socket and delivers the plugin reply only to the first', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-duplicate-id', 'Duplicate Id File');
+    await helloPlugin(plugin, 'plugin-duplicate-id', 'Duplicate Id File', 'RawDuplicate');
     const pluginFrames = collectFrames(plugin);
     const first = await connectSocket(port);
     const second = await connectSocket(port);
@@ -314,8 +618,8 @@ describe('daemon harness — duplicate request ids never overwrite reply ownersh
     await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === id));
 
     second.send(request);
-    await waitFor(() => secondFrames.frames.length > 0);
-    expect(secondFrames.frames[0]).toMatchObject({
+    await waitFor(() => secondFrames.frames.some((frame) => (frame as { id?: string }).id === id));
+    expect(secondFrames.frames.find((frame) => (frame as { id?: string }).id === id)).toMatchObject({
       id,
       ok: false,
       error: { code: 'E_INVALID_ARGS', message: expect.stringContaining('duplicate request id') },
@@ -333,7 +637,7 @@ describe('daemon harness — cancel-then-complete never dispatches the cancelled
   it('a QUEUED job cancelled via `job --cancel` is never resurrected when the running job finishes', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-1', 'F1');
+    await helloPlugin(plugin, 'plugin-1', 'F1', 'RawF1');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -370,7 +674,7 @@ describe('daemon harness — plugin disconnect fails a queued job, reconnect nev
   it('E_NO_PLUGIN reaches the CLI for both the running and queued job; a same-instanceId reconnect gets nothing', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-2', 'F2');
+    await helloPlugin(plugin, 'plugin-2', 'F2', 'RawF2');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -395,7 +699,7 @@ describe('daemon harness — plugin disconnect fails a queued job, reconnect nev
 
     // Reconnect with the SAME instanceId — no parked/queued work exists to flush.
     const plugin2 = await connectSocket(port);
-    await helloPlugin(plugin2, 'plugin-2', 'F2');
+    await helloPlugin(plugin2, 'plugin-2', 'F2', 'RawF2');
     const plugin2Frames = collectFrames(plugin2);
     await new Promise((resolve) => setTimeout(resolve, 200));
     const dispatched = plugin2Frames.frames.filter((f) => 'cmd' in (f as Record<string, unknown>));
@@ -407,7 +711,7 @@ describe('daemon harness — a watchdog-failed job answered late returns the tim
   it('the late reply is discarded and counted, the ORIGINAL E_TIMEOUT outcome survives', async () => {
     const port = await startTestBroker({ [WATCHDOG_MS_KEY]: '150' }); // real watchdog, shrunk
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-3', 'F3');
+    await helloPlugin(plugin, 'plugin-3', 'F3', 'RawF3');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -725,8 +1029,8 @@ describe('daemon harness — routeFromPlugin verifies the reply sender against t
     const port = await startTestBroker();
     const pluginX = await connectSocket(port);
     const pluginY = await connectSocket(port);
-    await helloPlugin(pluginX, 'inst-x', 'FileX');
-    await helloPlugin(pluginY, 'inst-y', 'FileY');
+    await helloPlugin(pluginX, 'inst-x', 'FileX', 'RawFileX');
+    await helloPlugin(pluginY, 'inst-y', 'FileY', 'RawFileY');
 
     const cli = await connectSocket(port);
     const reqId = 'req-sender-verify-1';
@@ -770,8 +1074,8 @@ describe('daemon harness — routeFromPlugin verifies the reply sender against t
     const port = await startTestBroker();
     const pluginX = await connectSocket(port);
     const pluginY = await connectSocket(port);
-    await helloPlugin(pluginX, 'inst-x', 'FileX');
-    await helloPlugin(pluginY, 'inst-y', 'FileY');
+    await helloPlugin(pluginX, 'inst-x', 'FileX', 'RawFileX');
+    await helloPlugin(pluginY, 'inst-y', 'FileY', 'RawFileY');
 
     const cli = await connectSocket(port);
     const reqId = 'req-sender-verify-mismatch-count';
@@ -912,11 +1216,9 @@ describe('daemon harness — SYNC_CONFIG idleMs routes through the binding, neve
 // in-process broker started with its own scratch advertisement path, ephemeral port,
 // and log file, so it never touches a live plugin session's broker discovery.
 describe('daemon harness — admitRequest with an `--instance` (expectedInstance) filter', () => {
-  it('an instanceId matching NO connected plugin → E_NO_PLUGIN names the instanceId, never "open the file panel"', async () => {
-    // A non-matching --instance parks (same as any unmatched filter) until the plugin-wait
-    // window elapses, then answers E_NO_PLUGIN — shrink the window so this test observes
-    // that real deadline instead of the 12s production default (same envMs override
-    // pattern the watchdog tests already use).
+  it('a keyless mutation with an unmatched instance refuses E_FILE_KEY_UNAVAILABLE instead of parking by name', async () => {
+    // The durable mutation gate supersedes the old keyless parking behavior: an instance
+    // name is not a raw fileKey, so it cannot snapshot an admission revision safely.
     const port = await startTestBroker({ [PLUGIN_WAIT_MS_KEY]: '200' });
     const plugin = await connectSocket(port);
     await helloPlugin(plugin, 'inst-live', 'FileLive');
@@ -928,17 +1230,16 @@ describe('daemon harness — admitRequest with an `--instance` (expectedInstance
     ));
     const reply = await nextFrame<ReplyErr>(cli, (m) => (m as ReplyOk | ReplyErr).id === reqId);
     expect(reply.ok).toBe(false);
-    expect(reply.error.code).toBe('E_NO_PLUGIN');
-    expect(reply.error.message).toContain('--instance "inst-gone"');
-    expect(reply.error.message).not.toContain('panel');
+    expect(reply.error.code).toBe('E_FILE_KEY_UNAVAILABLE');
+    expect(reply.error.message).toContain('targetFileKey');
   });
 
   it('two plugins sharing the SAME fileName ("Untitled") → --instance routes to the exact one, never the other', async () => {
     const port = await startTestBroker();
     const pluginA = await connectSocket(port);
     const pluginB = await connectSocket(port);
-    await helloPlugin(pluginA, 'inst-a', 'Untitled');
-    await helloPlugin(pluginB, 'inst-b', 'Untitled');
+    await helloPlugin(pluginA, 'inst-a', 'Untitled', 'RawUntitledA');
+    await helloPlugin(pluginB, 'inst-b', 'Untitled', 'RawUntitledB');
     const framesA = collectFrames(pluginA);
     const framesB = collectFrames(pluginB);
 
@@ -962,7 +1263,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
   it('a bare `--force-release` on a job still `running` inside the watchdog window is REFUSED — the slot stays held, nothing advances', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-fr1', 'FFR1');
+    await helloPlugin(plugin, 'plugin-fr1', 'FFR1', 'RawFFR1');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -994,7 +1295,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
   it('`--force-release` + `override:true` (the CLI\'s `--force`) overrides the guard — the slot frees, the queued job advances, its result is discarded', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-fr2', 'FFR2');
+    await helloPlugin(plugin, 'plugin-fr2', 'FFR2', 'RawFFR2');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -1023,7 +1324,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
   it('regression: a watchdog-wedged job (state !== "running") still force-releases with a BARE `--force-release`, no `--force` needed', async () => {
     const port = await startTestBroker({ [WATCHDOG_MS_KEY]: '150' }); // real watchdog, shrunk
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-fr3', 'FFR3');
+    await helloPlugin(plugin, 'plugin-fr3', 'FFR3', 'RawFFR3');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -1056,7 +1357,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
   it('an UNBOUND file\'s queued time lands at the broker cwd default, keyed by its own fileSlug', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-cont-1', 'Contention File');
+    await helloPlugin(plugin, 'plugin-cont-1', 'Contention File', 'RawContention');
     const pluginFrames = collectFrames(plugin);
 
     const cli = await connectSocket(port);
@@ -1070,7 +1371,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
     const path = join(scratchDir, 'figma-contention.json');
     await waitFor(() => existsSync(path));
     const store = JSON.parse(readFileSync(path, 'utf8')) as ContentionStore;
-    const slug = 'contention-file'; // safeSlug('Contention File') — no fileKey, so fileIdentity falls back to the name slug
+    const slug = 'RawContention';
     const days = store[slug];
     expect(days).toBeDefined();
     const totals = Object.values(days!)[0]!;
@@ -1081,7 +1382,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
   it('a BOUND file\'s queued time lands in its OWN project, never the broker cwd default', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-cont-2', 'Bound Contention File');
+    await helloPlugin(plugin, 'plugin-cont-2', 'Bound Contention File', 'RawBoundContention');
 
     const boundProjectDir = mkdtempSync(join(tmpdir(), 'fa-bound-contention-'));
     try {
@@ -1104,7 +1405,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
       const cwdDefaultPath = join(scratchDir, 'figma-contention.json');
       await waitFor(() => existsSync(boundPath));
       const store = JSON.parse(readFileSync(boundPath, 'utf8')) as ContentionStore;
-      const slug = 'bound-contention-file';
+    const slug = 'RawBoundContention';
       expect(store[slug]).toBeDefined();
       expect(Object.values(store[slug]!)[0]!.jobCount).toBe(1);
       // Never ALSO written to the broker's own cwd default for this identity.
@@ -1120,7 +1421,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
   it('a job cancelled while still QUEUED also write-throughs its own queuedMs (cancelQueued stamps it, not markRunning)', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'plugin-cont-3', 'Cancel Contention File');
+    await helloPlugin(plugin, 'plugin-cont-3', 'Cancel Contention File', 'RawCancelContention');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
@@ -1135,7 +1436,7 @@ describe('daemon harness — a finished job\'s queuedMs write-throughs into the 
     expect((cancelReply.result as { ok: boolean }).ok).toBe(true);
 
     const path = join(scratchDir, 'figma-contention.json');
-    const slug = 'cancel-contention-file';
+    const slug = 'RawCancelContention';
     await waitFor(() => {
       if (!existsSync(path)) return false;
       const store = JSON.parse(readFileSync(path, 'utf8')) as ContentionStore;
@@ -1156,7 +1457,7 @@ function setTarget(ws: WebSocket, instanceId: string): void {
 function clearTarget(ws: WebSocket, instanceId: string): void {
   ws.send(JSON.stringify({ type: 'CLEAR_TARGET', data: { instanceId } } satisfies EventMsg));
 }
-/** A read-only request (GET_SELECTION, IMPLICIT_READ_ONLY) — dispatches immediately, no
+/** A broker-safe read (GET_SELECTION) — dispatches immediately, no
  *  per-file queue to reason about, so a test only has to observe WHICH plugin received it. */
 function sendReadOnlyRequest(ws: WebSocket, reqId: string, expectedInstance?: string): void {
   ws.send(JSON.stringify(makeRequestFrame(reqId, 'GET_SELECTION', {}, undefined, undefined, undefined, undefined, expectedInstance)));

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -68,6 +68,7 @@ let scratchDir: string;
 let advertisePath: string;
 let scratchLogFile: string;
 let sockets: WebSocket[];
+let priorPluginWaitMs: string | undefined;
 
 /** Load `broker-daemon.ts` fresh, AFTER the given env vars are set — required for the
  *  module-load-time `envMs(...)` constants (see file header). */
@@ -261,6 +262,7 @@ async function bindProject(
 }
 
 beforeEach(() => {
+  priorPluginWaitMs = process.env[PLUGIN_WAIT_MS_KEY];
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-broker-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
   scratchLogFile = join(scratchDir, 'broker.log');
@@ -279,6 +281,8 @@ afterEach(async () => {
   await new Promise((resolve) => setTimeout(resolve, 50));
   for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
   rmSync(scratchDir, { recursive: true, force: true });
+  if (priorPluginWaitMs === undefined) delete process.env[PLUGIN_WAIT_MS_KEY];
+  else process.env[PLUGIN_WAIT_MS_KEY] = priorPluginWaitMs;
 });
 
 describe('daemon harness — mutation admission', () => {
@@ -305,19 +309,110 @@ describe('daemon harness — mutation admission', () => {
     });
   });
 
-  it('rejects blank/padded/conflicting target assertions and a mismatched live scene key before ownership', async () => {
+  it('keeps an exact-key request parked when a different raw-key plugin reconnects, then dispatches only to the exact key', async () => {
+    const port = await startTestBroker();
+    const cli = await connectSocket(port);
+    const cliFrames = collectFrames(cli);
+    const requestId = 'c_target_reconnect_exact';
+    const jobState = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify(makeRequestFrame(
+      requestId, 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Reconnect-A',
+    )));
+
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'p-target-reconnect-b', 'Target Reconnect B', 'Raw/Reconnect-B');
+    const pluginBFrames = collectFrames(pluginB);
+    await new Promise((resolve) => setTimeout(resolve, HARNESS_SETTLE_MS));
+
+    expect(cliFrames.frames.some((frame) =>
+      (frame as EventMsg).type === 'JOB_STATE' || (frame as { id?: string }).id === requestId,
+    )).toBe(false);
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+
+    const pluginA = await connectSocket(port);
+    const pluginAFrames = collectFrames(pluginA);
+    await helloPlugin(pluginA, 'p-target-reconnect-a', 'Target Reconnect A', 'Raw/Reconnect-A');
+    await jobState;
+    await waitFor(() => pluginAFrames.frames.some((frame) => (frame as { id?: string }).id === requestId));
+
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+  });
+
+  it('parks an initial exact-key request while a different raw-key plugin is already connected', async () => {
+    const port = await startTestBroker();
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'p-target-initial-b', 'Target Initial B', 'Raw/Initial-B');
+    const pluginBFrames = collectFrames(pluginB);
+    const cli = await connectSocket(port);
+    const cliFrames = collectFrames(cli);
+    const requestId = 'c_target_initial_exact';
+    const jobState = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify(makeRequestFrame(
+      requestId, 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Initial-A',
+    )));
+    await new Promise((resolve) => setTimeout(resolve, HARNESS_SETTLE_MS));
+
+    expect(cliFrames.frames.some((frame) =>
+      (frame as EventMsg).type === 'JOB_STATE' || (frame as { id?: string }).id === requestId,
+    )).toBe(false);
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+
+    const pluginA = await connectSocket(port);
+    const pluginAFrames = collectFrames(pluginA);
+    await helloPlugin(pluginA, 'p-target-initial-a', 'Target Initial A', 'Raw/Initial-A');
+    await jobState;
+    await waitFor(() => pluginAFrames.frames.some((frame) => (frame as { id?: string }).id === requestId));
+
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+  });
+
+  it('flushes an exact-key parked request only after FILE_INFO supplies its raw key', async () => {
+    const port = await startTestBroker();
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'p-target-file-info-b', 'Target File Info B', 'Raw/File-Info-B');
+    const pluginBFrames = collectFrames(pluginB);
+    const cli = await connectSocket(port);
+    const cliFrames = collectFrames(cli);
+    const requestId = 'c_target_file_info_exact';
+    cli.send(JSON.stringify(makeRequestFrame(
+      requestId, 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/File-Info-A',
+    )));
+
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'p-target-file-info-a', 'Target File Info A', null);
+    const pluginAFrames = collectFrames(pluginA);
+    await new Promise((resolve) => setTimeout(resolve, HARNESS_SETTLE_MS));
+
+    expect(cliFrames.frames.some((frame) =>
+      (frame as EventMsg).type === 'JOB_STATE' || (frame as { id?: string }).id === requestId,
+    )).toBe(false);
+    expect(pluginAFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+
+    const jobState = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    sendFileInfo(pluginA, 'Target File Info A', 'Raw/File-Info-A');
+    const admission = await Promise.race<EventMsg | null>([
+      jobState,
+      new Promise<null>((resolve) => setTimeout(() => resolve(null), Math.max(1_000, HARNESS_SETTLE_MS * 4))),
+    ]);
+    expect(admission).not.toBeNull();
+    await waitFor(() => pluginAFrames.frames.some((frame) => (frame as { id?: string }).id === requestId));
+
+    expect(pluginAFrames.frames.find((frame) => (frame as { id?: string }).id === requestId)).toMatchObject({
+      targetFileKey: 'Raw/File-Info-A',
+    });
+    expect(pluginBFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+  });
+
+  it('rejects blank, padded, and conflicting target assertions before ownership', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
     await helloPlugin(plugin, 'p-target-other', 'Target Other', 'Raw/Other-Key');
     const pluginFrames = collectFrames(plugin);
     const cli = await connectSocket(port);
-
-    const mismatch = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_mismatch');
-    cli.send(JSON.stringify(makeRequestFrame(
-      'c_target_mismatch', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
-      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
-    )));
-    expect((await mismatch).error.code).toBe('E_WRONG_FILE');
 
     const blank = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_blank');
     cli.send(JSON.stringify({
@@ -339,24 +434,51 @@ describe('daemon harness — mutation admission', () => {
       undefined, 'Target Other', undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
     )));
     expect((await conflict).error.code).toBe('E_INVALID_ARGS');
-    expect(pluginFrames.frames.some((frame) => ['c_target_mismatch', 'c_target_blank', 'c_target_padded', 'c_target_conflict']
+    expect(pluginFrames.frames.some((frame) => ['c_target_blank', 'c_target_padded', 'c_target_conflict']
       .includes((frame as { id?: string }).id ?? ''))).toBe(false);
   });
 
-  it('returns E_FILE_KEY_UNAVAILABLE when a target assertion meets a keyless live plugin', async () => {
-    const port = await startTestBroker();
-    const plugin = await connectSocket(port);
-    await helloPlugin(plugin, 'p-target-missing', 'Target Missing', null);
-    const pluginFrames = collectFrames(plugin);
-    const cli = await connectSocket(port);
-    const reply = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'c_target_missing');
-    cli.send(JSON.stringify(makeRequestFrame(
-      'c_target_missing', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
-      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
-    )));
+  it('keeps an exact-key request parked across a keyless reconnect, then expires as E_NO_PLUGIN naming that key', async () => {
+    let controlledNow = 1_000_000;
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => controlledNow);
+    try {
+      const port = await startTestBroker({ [PLUGIN_WAIT_MS_KEY]: '300' });
+      const cli = await connectSocket(port);
+      const cliFrames = collectFrames(cli);
+      const requestId = 'c_target_keyless';
+      const expiry = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === requestId);
+      cli.send(JSON.stringify(makeRequestFrame(
+        requestId, 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+        undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Expected-Key',
+      )));
+      await new Promise((resolve) => setTimeout(resolve, Math.min(HARNESS_SETTLE_MS, 100)));
 
-    expect((await reply).error.code).toBe('E_FILE_KEY_UNAVAILABLE');
-    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'c_target_missing')).toBe(false);
+      // Move the broker clock partway through the parked window before a keyless HELLO.
+      // Advancing it to the original deadline below proves that this HELLO did not reset
+      // `ParkedRequest.deadline`; only the real 100 ms sweep timer remains asynchronous.
+      controlledNow += 200;
+      const plugin = await connectSocket(port);
+      await helloPlugin(plugin, 'p-target-missing', 'Target Missing', null);
+      const pluginFrames = collectFrames(plugin);
+      await new Promise((resolve) => setTimeout(resolve, Math.min(HARNESS_SETTLE_MS, 100)));
+
+      expect(cliFrames.frames.some((frame) =>
+        (frame as EventMsg).type === 'JOB_STATE' || (frame as { id?: string }).id === requestId,
+      )).toBe(false);
+      expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+
+      controlledNow += 100;
+      const reply = await Promise.race<ReplyErr | null>([
+        expiry,
+        new Promise<null>((resolve) => setTimeout(() => resolve(null), Math.max(1_000, HARNESS_SETTLE_MS * 4))),
+      ]);
+      expect(reply).not.toBeNull();
+      expect((reply as ReplyErr).error.code).toBe('E_NO_PLUGIN');
+      expect((reply as ReplyErr).error.message).toContain('Raw/Expected-Key');
+      expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === requestId)).toBe(false);
+    } finally {
+      dateNow.mockRestore();
+    }
   });
 
   it('returns E_MUTATION_GATE_UNAVAILABLE before missing live identity or job ownership when the gate store is corrupt', async () => {

--- a/tests/broker-status.test.ts
+++ b/tests/broker-status.test.ts
@@ -5,6 +5,7 @@ import { describe, it, expect } from 'vitest';
 import { PluginRegistry, WS_OPEN, type RegistrySocket } from '../cli/src/transport/plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage, type BrokerMeta } from '../cli/src/transport/broker-status.ts';
 import type { RouteFilter } from '../cli/src/transport/route-filter.ts';
+import type { MutationGateStatus } from '../cli/src/transport/mutation-admission-gate.ts';
 
 const sock = (): RegistrySocket => ({ readyState: WS_OPEN });
 const META: BrokerMeta = {
@@ -98,6 +99,27 @@ describe('buildBrokerHelloData — jobStatusFor (concurrency & jobs, backlog 1.1
     // An idle file reports null + 0 explicitly — never an omitted key.
     expect(ds.runningJob).toBeNull();
     expect(ds.queueDepth).toBe(0);
+  });
+});
+
+describe('buildBrokerHelloData — persisted mutation gates', () => {
+  it('keeps disconnected rows and adds a live annotation only when an exact raw file key is connected', () => {
+    const { reg, clock } = seed();
+    reg.register(sock(), { instanceId: 'a', fileName: 'Connected', fileKey: 'RawA' });
+    const gates: MutationGateStatus = {
+      health: { state: 'healthy', path: '/tmp/mutation-gates.json' },
+      gates: [
+        { fileKey: 'RawA', state: 'paused', lastTransitionRevision: 2 },
+        { fileKey: 'RawB', state: 'open', lastTransitionRevision: 5 },
+      ],
+    };
+
+    const data = buildBrokerHelloData(reg, META, null, clock, undefined, gates);
+    expect(data.mutationGateStoreHealth).toEqual(gates.health);
+    expect(data.mutationGates).toEqual([
+      { fileKey: 'RawA', state: 'paused', lastTransitionRevision: 2, connected: true },
+      { fileKey: 'RawB', state: 'open', lastTransitionRevision: 5 },
+    ]);
   });
 });
 

--- a/tests/file-identity.test.ts
+++ b/tests/file-identity.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { makeRequestFrame } from '../shared/protocol.ts';
+import { durableFileKey, exactTargetFileKey } from '../cli/src/transport/file-identity.ts';
+
+describe('durableFileKey', () => {
+  it('preserves a nonempty raw file key verbatim', () => {
+    expect(durableFileKey('AbC 123', 'Renamed design file')).toBe('AbC 123');
+  });
+
+  it('refuses absent or whitespace-only keys without falling back to a file name', () => {
+    for (const key of [undefined, null, '', '   ']) {
+      expect(durableFileKey(key, 'Renamed design file')).toBeNull();
+    }
+  });
+
+  it('accepts only an unpadded raw target assertion and preserves it exactly on the wire', () => {
+    expect(exactTargetFileKey('Raw/Key-9')).toBe('Raw/Key-9');
+    for (const key of [undefined, null, '', '  ', ' Raw/Key-9', 'Raw/Key-9 ']) {
+      expect(exactTargetFileKey(key)).toBeNull();
+    }
+
+    const withoutTarget = makeRequestFrame('id-none', 'STATUS', {});
+    expect(withoutTarget).not.toHaveProperty('targetFileKey');
+    expect(makeRequestFrame(
+      'id-raw', 'SET_TEXT', { nodeId: '1:1', text: 'x' },
+      undefined, undefined, undefined, undefined, undefined, undefined, 'Raw/Key-9',
+    )).toMatchObject({ targetFileKey: 'Raw/Key-9' });
+  });
+});

--- a/tests/job-table.test.ts
+++ b/tests/job-table.test.ts
@@ -122,6 +122,16 @@ describe('JobTable — cancelQueued', () => {
     expect((t.byId(rec.jobId) as { state: string }).state).toBe('cancelled');
   });
 
+  it('stores a supplied terminal cancellation reply so the result remains pollable', () => {
+    const t = new JobTable();
+    const rec = t.create(input());
+    const frame = JSON.stringify({ id: rec.requestId, ok: false, error: { code: 'E_MUTATIONS_PAUSED', message: 'paused' } });
+
+    expect(t.cancelQueued(rec.jobId, [frame]).ok).toBe(true);
+    const found = t.byId(rec.jobId) as { state: string; replyFrames: string[] };
+    expect(found).toMatchObject({ state: 'cancelled', replyFrames: [frame] });
+  });
+
   it('refuses a RUNNING job, naming the sandbox reason', () => {
     const t = new JobTable();
     const rec = t.create(input());

--- a/tests/mutating-commands.test.ts
+++ b/tests/mutating-commands.test.ts
@@ -5,7 +5,7 @@
 // imported outside a live plugin sandbox; see mutating-commands.ts's header).
 import { describe, it, expect } from 'vitest';
 import { COMMANDS, type CommandName } from '../shared/protocol.ts';
-import { MUTATING_COMMANDS } from '../shared/mutating-commands.ts';
+import { BROKER_SAFE_READ_COMMANDS, MUTATING_COMMANDS } from '../shared/mutating-commands.ts';
 
 // Nothing to seal into an undo step: STATUS/GET_SELECTION/SCAN_DESIGN_SYSTEM/AUDIT_DS/
 // GET_CORRECTION_MEMORY/EXPORT_PNG are read-only; HTML_TO_FIGMA never reaches main (arrives as
@@ -19,11 +19,11 @@ import { MUTATING_COMMANDS } from '../shared/mutating-commands.ts';
 // need its own undo step?), a DIFFERENT axis from the concurrency wave's queueing
 // classification: AUDIT_DS is read-only here (nothing to undo — it writes no scene
 // content) but MUTATING for queueing purposes (it moves `figma.currentPage` per page
-// without restoring, which is shared view state) — see admitRequest's own
-// IMPLICIT_READ_ONLY set in broker-daemon.ts for that deliberate asymmetry.
+// without restoring, which is shared view state) — broker admission therefore excludes
+// it from the explicit BROKER_SAFE_READ_COMMANDS allowlist.
 const READ_ONLY_COMMANDS: readonly CommandName[] = [
   'STATUS', 'GET_SELECTION', 'SCAN_DESIGN_SYSTEM', 'AUDIT_DS',
-  'GET_CORRECTION_MEMORY', 'EXPORT_PNG', 'HTML_TO_FIGMA', 'BATCH', 'PROJECT_BIND', 'JOB', 'COWORK',
+  'GET_CORRECTION_MEMORY', 'EXPORT_PNG', 'HTML_TO_FIGMA', 'BATCH', 'PROJECT_BIND', 'JOB', 'MUTATION_GATE', 'COWORK',
   // SHADER_GRADIENT is READ_ONLY for the same reason HTML_TO_FIGMA is: it never reaches
   // main. The UI renders it and posts IMPORT_GRADIENT, and THAT is the mutating half.
   'SHADER_GRADIENT', 'SHADER_GRADIENT_PROBE',
@@ -31,6 +31,22 @@ const READ_ONLY_COMMANDS: readonly CommandName[] = [
 ];
 
 describe('command classification — every COMMANDS entry is MUTATING xor READ_ONLY', () => {
+  it('exports the exact broker-safe read set separately from undo classification', () => {
+    expect(BROKER_SAFE_READ_COMMANDS).toEqual([
+      'STATUS',
+      'GET_SELECTION',
+      'EXPORT_PNG',
+      'SCAN_DESIGN_SYSTEM',
+      'GET_CORRECTION_MEMORY',
+      'LIST_CONNECTIONS',
+      'VERIFY_CONNECTIONS',
+      'SHADER_GRADIENT_PROBE',
+    ]);
+    for (const cmd of ['EXEC_JS', 'BATCH', 'AUDIT_DS']) {
+      expect(BROKER_SAFE_READ_COMMANDS).not.toContain(cmd);
+    }
+  });
+
   it('no command is in both lists', () => {
     const overlap = MUTATING_COMMANDS.filter((c) => READ_ONLY_COMMANDS.includes(c));
     expect(overlap).toEqual([]);

--- a/tests/mutation-admission-gate.test.ts
+++ b/tests/mutation-admission-gate.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { MutationAdmissionGate, mutationGatePathFor } from '../cli/src/transport/mutation-admission-gate.ts';
+
+let scratchDirs: string[] = [];
+
+function makeStorePath(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'fa-mutation-gate-'));
+  scratchDirs.push(dir);
+  return mutationGatePathFor(join(dir, 'broker.json'));
+}
+
+afterEach(() => {
+  for (const dir of scratchDirs) rmSync(dir, { recursive: true, force: true });
+  scratchDirs = [];
+});
+
+describe('MutationAdmissionGate — durable raw-key admission', () => {
+  it('treats a missing store as open and does not create it for a read', () => {
+    const storePath = makeStorePath();
+    const gate = new MutationAdmissionGate(storePath);
+
+    expect(gate.admit('AbC123')).toMatchObject({ ok: true, state: 'open', lastTransitionRevision: 0 });
+    expect(existsSync(storePath)).toBe(false);
+    expect(gate.status()).toMatchObject({ health: { state: 'missing' }, gates: [] });
+  });
+
+  it('persists exact keys, target-local revisions, monotonic order, and a latest transition audit', () => {
+    const storePath = makeStorePath();
+    let now = 1_000;
+    const gate = new MutationAdmissionGate(storePath, { now: () => now++ });
+
+    expect(gate.transition('A Key', 'paused')).toMatchObject({
+      ok: true,
+      state: 'paused',
+      lastTransitionRevision: 1,
+      sequence: 1,
+    });
+    expect(gate.transition('B Key', 'paused')).toMatchObject({
+      ok: true,
+      state: 'paused',
+      lastTransitionRevision: 2,
+      sequence: 2,
+    });
+    expect(gate.transition('A Key', 'open')).toMatchObject({
+      ok: true,
+      state: 'open',
+      lastTransitionRevision: 3,
+      sequence: 3,
+    });
+
+    const persisted = JSON.parse(readFileSync(storePath, 'utf8')) as Record<string, unknown>;
+    expect(persisted).toMatchObject({
+      schemaVersion: 1,
+      sequence: 3,
+      gates: {
+        'A Key': { state: 'open', lastTransitionRevision: 3 },
+        'B Key': { state: 'paused', lastTransitionRevision: 2 },
+      },
+      latestTransition: { fileKey: 'A Key', from: 'paused', to: 'open', revision: 3, at: 1_002 },
+    });
+    expect(readdirSync(join(storePath, '..')).filter((name) => name.includes('.tmp'))).toEqual([]);
+  });
+
+  it('keeps an unrelated target fresh when another target transitions', () => {
+    const storePath = makeStorePath();
+    const gate = new MutationAdmissionGate(storePath);
+    gate.transition('A', 'paused');
+    gate.transition('B', 'paused');
+    const parkedB = gate.admit('B');
+    expect(parkedB).toMatchObject({ ok: false, error: { code: 'E_MUTATIONS_PAUSED' }, lastTransitionRevision: 2 });
+
+    gate.transition('A', 'open');
+    const status = gate.status();
+    expect(status.gates).toEqual(expect.arrayContaining([
+      { fileKey: 'A', state: 'open', lastTransitionRevision: 3 },
+      { fileKey: 'B', state: 'paused', lastTransitionRevision: 2 },
+    ]));
+  });
+
+  it('fails closed and preserves corrupt evidence instead of replacing it', () => {
+    const storePath = makeStorePath();
+    const corrupt = '{not-json';
+    writeFileSync(storePath, corrupt, 'utf8');
+    const gate = new MutationAdmissionGate(storePath);
+
+    expect(gate.admit('AbC123')).toMatchObject({ ok: false, error: { code: 'E_MUTATION_GATE_UNAVAILABLE' } });
+    expect(gate.transition('AbC123', 'paused')).toMatchObject({ ok: false, error: { code: 'E_MUTATION_GATE_UNAVAILABLE' } });
+    expect(readFileSync(storePath, 'utf8')).toBe(corrupt);
+  });
+
+  it('fails closed for wrong schema and malformed gate records', () => {
+    const storePath = makeStorePath();
+    writeFileSync(storePath, JSON.stringify({ schemaVersion: 2, sequence: 0, gates: {} }), 'utf8');
+    expect(new MutationAdmissionGate(storePath).admit('A')).toMatchObject({
+      ok: false,
+      error: { code: 'E_MUTATION_GATE_UNAVAILABLE' },
+    });
+
+    writeFileSync(storePath, JSON.stringify({
+      schemaVersion: 1,
+      sequence: 1,
+      gates: { A: { state: 'paused', lastTransitionRevision: 'wrong' } },
+      latestTransition: { fileKey: 'A', from: 'open', to: 'paused', at: 1, revision: 1 },
+    }), 'utf8');
+    expect(new MutationAdmissionGate(storePath).admit('A')).toMatchObject({
+      ok: false,
+      error: { code: 'E_MUTATION_GATE_UNAVAILABLE' },
+    });
+
+    writeFileSync(storePath, JSON.stringify({
+      schemaVersion: 1,
+      sequence: 1,
+      gates: { A: { state: 'paused', lastTransitionRevision: 2 } },
+      latestTransition: { fileKey: 'A', from: 'open', to: 'paused', at: 1, revision: 1 },
+    }), 'utf8');
+    expect(new MutationAdmissionGate(storePath).admit('A')).toMatchObject({
+      ok: false,
+      error: { code: 'E_MUTATION_GATE_UNAVAILABLE' },
+    });
+  });
+
+  it('fails closed when the store path is unreadable and preserves its evidence', () => {
+    const storePath = makeStorePath();
+    mkdirSync(storePath);
+
+    expect(new MutationAdmissionGate(storePath).admit('A')).toMatchObject({
+      ok: false,
+      error: { code: 'E_MUTATION_GATE_UNAVAILABLE' },
+    });
+    expect(existsSync(storePath)).toBe(true);
+  });
+
+  it('fails closed on an atomic-write failure and leaves prior bytes untouched', () => {
+    const storePath = makeStorePath();
+    const before = JSON.stringify({
+      schemaVersion: 1,
+      sequence: 1,
+      gates: { A: { state: 'paused', lastTransitionRevision: 1 } },
+      latestTransition: { fileKey: 'A', from: 'open', to: 'paused', at: 1, revision: 1 },
+    });
+    writeFileSync(storePath, before, 'utf8');
+    const gate = new MutationAdmissionGate(storePath, {
+      writeFile: () => { throw new Error('disk full'); },
+    });
+
+    expect(gate.transition('A', 'open')).toMatchObject({ ok: false, error: { code: 'E_MUTATION_GATE_UNAVAILABLE' } });
+    expect(gate.admit('A')).toMatchObject({ ok: false, error: { code: 'E_MUTATION_GATE_UNAVAILABLE' } });
+    expect(readFileSync(storePath, 'utf8')).toBe(before);
+  });
+
+  it('uses distinct missing-key and paused denials', () => {
+    const storePath = makeStorePath();
+    const gate = new MutationAdmissionGate(storePath);
+    expect(gate.admit('  ')).toMatchObject({ ok: false, error: { code: 'E_FILE_KEY_UNAVAILABLE' } });
+    gate.transition('A', 'paused');
+    expect(gate.admit('A')).toMatchObject({ ok: false, error: { code: 'E_MUTATIONS_PAUSED' } });
+  });
+});

--- a/tests/mutation-gate-command.test.ts
+++ b/tests/mutation-gate-command.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CommandArgs } from '../cli/src/arg-parse.ts';
+
+vi.mock('../cli/src/transport/broker-client.ts', () => ({ runCommand: vi.fn() }));
+
+const { runCommand } = await import('../cli/src/transport/broker-client.ts');
+const { run } = await import('../cli/src/commands/mutation-gate.ts');
+
+function fakeArgs(positionals: string[], flags: Record<string, string | boolean> = {}): CommandArgs {
+  return {
+    positionals,
+    str: (name) => (typeof flags[name] === 'string' ? flags[name] as string : undefined),
+    req: (name) => {
+      const value = flags[name];
+      if (typeof value !== 'string') throw new Error(`missing --${name}`);
+      return value;
+    },
+    num: () => undefined,
+    bool: (name) => flags[name] === true || flags[name] === 'true',
+  };
+}
+
+describe('mutation-gate command', () => {
+  beforeEach(() => vi.mocked(runCommand).mockReset());
+
+  it.each(['pause', 'resume', 'status'] as const)('sends %s with the exact raw file key', async (mode) => {
+    vi.mocked(runCommand).mockResolvedValue({ mode });
+
+    await expect(run(fakeArgs([mode], { 'file-key': '  Raw Key / unchanged  ' }))).resolves.toEqual({ mode });
+    expect(runCommand).toHaveBeenCalledWith('MUTATION_GATE', {
+      mode,
+      fileKey: '  Raw Key / unchanged  ',
+    });
+  });
+
+  it.each([
+    [[], { 'file-key': 'Raw' }],
+    [['unknown'], { 'file-key': 'Raw' }],
+    [['pause'], {}],
+    [['pause'], { 'file-key': '' }],
+    [['pause'], { 'file-key': ' \t\n ' }],
+  ] as const)('rejects invalid CLI input with E_INVALID_ARGS: %j', async (positionals, flags) => {
+    await expect(run(fakeArgs([...positionals], { ...flags }))).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    expect(runCommand).not.toHaveBeenCalled();
+  });
+});

--- a/tests/orb-command-state.test.ts
+++ b/tests/orb-command-state.test.ts
@@ -18,7 +18,7 @@ const groups = [
   ['shaping', 'Shaping', ['SET_VARIANT', 'BIND_VARIABLE', 'SET_AUTOLAYOUT',
     'SET_CONSTRAINTS', 'CLONE_TRAITS']],
   ['weaving', 'Coordinating', ['BATCH', 'CONNECT', 'DISCONNECT', 'REROUTE', 'RECONCILE']],
-  ['working', 'Processing', ['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB']],
+  ['working', 'Processing', ['EXEC_JS', 'SET_CORRECTION_MEMORY', 'PROJECT_BIND', 'JOB', 'MUTATION_GATE']],
   ['listening', 'Listening', ['COWORK']],
 ] as const;
 

--- a/tests/scan-conventions.test.ts
+++ b/tests/scan-conventions.test.ts
@@ -16,9 +16,9 @@ import {
 } from '../cli/src/commands/scan-conventions.ts';
 
 /** A stub runner that returns a fixed EXEC_JS `{result}` and records its calls. */
-function stubRunner(result: unknown, calls?: Array<{ cmd: string; params: unknown }>): Runner {
-  return async (cmd, params) => {
-    calls?.push({ cmd, params });
+function stubRunner(result: unknown, calls?: Array<{ cmd: string; params: unknown; opts?: { timeoutMs?: number; readOnly?: boolean } }>): Runner {
+  return async (cmd, params, opts) => {
+    calls?.push({ cmd, params, opts });
     return { result, console: [], ms: 1 };
   };
 }
@@ -62,11 +62,12 @@ describe('buildWalkCode — pure walk construction', () => {
 
 describe('scanConventions — EXEC_JS wiring (stubbed runner)', () => {
   it('issues one EXEC_JS carrying the walk code and returns the DNA array', async () => {
-    const calls: Array<{ cmd: string; params: unknown }> = [];
+    const calls: Array<{ cmd: string; params: unknown; opts?: { timeoutMs?: number; readOnly?: boolean } }> = [];
     const dna = await scanConventions(['1:1'], DEFAULT_BUDGET, stubRunner(DNA, calls));
     expect(calls).toHaveLength(1);
     expect(calls[0]?.cmd).toBe('EXEC_JS');
     expect((calls[0]?.params as { code: string }).code).toContain('SECTIONS = ["1:1"]');
+    expect(calls[0]?.opts?.readOnly).toBeUndefined();
     expect(dna).toEqual(DNA);
   });
 

--- a/tests/status-peek.test.ts
+++ b/tests/status-peek.test.ts
@@ -14,6 +14,7 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
 import { peek } from '../cli/src/transport/broker-peek.ts';
+import { mutationGatePathFor } from '../cli/src/transport/mutation-admission-gate.ts';
 
 /** Accepts a TCP connection and then says nothing, forever — the ONLY way to
  *  actually exercise the deadline-timer branch of peek()'s race (a closed port
@@ -105,6 +106,27 @@ describe('peek() — in-process, real broker + fake plugin', () => {
     expect(result.broker).not.toBeNull();
     expect(result.broker?.pid).toBe(process.pid);
     expect(result.plugins).toEqual([]);
+  });
+
+  it('keeps disconnected persisted mutation-gate rows and store health in the non-spawning projection', async () => {
+    writeFileSync(mutationGatePathFor(advertisePath), JSON.stringify({
+      schemaVersion: 1,
+      sequence: 7,
+      gates: { 'Raw Key / disconnected': { state: 'paused', lastTransitionRevision: 7 } },
+      latestTransition: {
+        fileKey: 'Raw Key / disconnected', from: 'open', to: 'paused', at: 1, revision: 7,
+      },
+    }));
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+
+    const result = await peek({ path: advertisePath });
+    expect(result.connected).toBe(false);
+    expect(result.broker).toMatchObject({ targetFileKeyAdmissionV: 1 });
+    expect(result.mutationGates).toEqual([
+      { fileKey: 'Raw Key / disconnected', state: 'paused', lastTransitionRevision: 7 },
+    ]);
+    expect(result.mutationGateStoreHealth).toMatchObject({ state: 'healthy', path: mutationGatePathFor(advertisePath) });
   });
 
   it('a matching plugin build reports versionMatch/protocolMatch true', async () => {
@@ -210,6 +232,30 @@ describe('status --peek — subprocess, no broker present', () => {
         env: { ...process.env, FIGMA_AGENT_BROKER_FILE: nonePath },
       });
       expect(Date.now() - started).toBeLessThan(2_000); // generous subprocess-startup allowance; peek() itself is <200ms
+    } finally {
+      rmSync(noneDir, { recursive: true, force: true });
+    }
+  });
+
+  it('validates --target-file-key before non-spawning peek and preserves its distinct selector contract', () => {
+    const noneDir = mkdtempSync(join(tmpdir(), 'fa-peek-target-key-'));
+    const nonePath = join(noneDir, 'none.json');
+    const errorFor = (args: string[]): { error: { code: string; message: string } } => {
+      try {
+        execFileSync(process.execPath, [CLI_DIST, 'status', '--peek', ...args], {
+          cwd: ROOT,
+          env: { ...process.env, FIGMA_AGENT_BROKER_FILE: nonePath },
+          encoding: 'utf8',
+        });
+      } catch (err) {
+        return JSON.parse(String((err as { stdout?: string }).stdout));
+      }
+      throw new Error('expected --target-file-key validation to reject before status --peek');
+    };
+    try {
+      expect(errorFor(['--target-file-key', ' Raw/Key'])).toMatchObject({ error: { code: 'E_INVALID_ARGS' } });
+      expect(errorFor(['--target-file-key', 'Raw/Key', '--file', 'Other file'])).toMatchObject({ error: { code: 'E_INVALID_ARGS' } });
+      expect(existsSync(nonePath)).toBe(false);
     } finally {
       rmSync(noneDir, { recursive: true, force: true });
     }

--- a/tests/status-wait.test.ts
+++ b/tests/status-wait.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
 import type { CommandArgs } from '../cli/src/arg-parse.ts';
+import { mutationGatePathFor } from '../cli/src/transport/mutation-admission-gate.ts';
 
 vi.mock('../cli/src/transport/broker-discovery.ts', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../cli/src/transport/broker-discovery.ts')>();
@@ -64,8 +65,8 @@ function connectSocket(port: number): Promise<WebSocket> {
   });
 }
 
-async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string): Promise<void> {
-  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey: null, caps: ['fileGuard'] } }));
+async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null): Promise<void> {
+  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey, caps: ['fileGuard'] } }));
   await new Promise<void>((resolvePromise) => {
     const handler = (raw: WebSocket.RawData): void => {
       const msg = JSON.parse(raw.toString()) as { type?: string };
@@ -97,6 +98,30 @@ afterEach(async () => {
 });
 
 describe('status --wait', () => {
+  it('keeps a persisted gate row and marks it connected only when the exact raw file key is live', async () => {
+    writeFileSync(mutationGatePathFor(advertisePath), JSON.stringify({
+      schemaVersion: 1,
+      sequence: 3,
+      gates: { 'Raw Key / connected': { state: 'paused', lastTransitionRevision: 3 } },
+      latestTransition: {
+        fileKey: 'Raw Key / connected', from: 'open', to: 'paused', at: 1, revision: 3,
+      },
+    }));
+    const mod = await loadBrokerDaemon();
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+    vi.mocked(ensureBroker).mockResolvedValue({ port: ad.port, pid: ad.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() });
+    const ws = await connectSocket(ad.port);
+    await helloPlugin(ws, 'p_1', 'My File', 'Raw Key / connected');
+
+    const result = await run(fakeArgs()) as { broker: Record<string, unknown>; mutationGates?: unknown[]; mutationGateStoreHealth?: unknown };
+    expect(result.broker.targetFileKeyAdmissionV).toBe(1);
+    expect(result.mutationGates).toEqual([
+      { fileKey: 'Raw Key / connected', state: 'paused', lastTransitionRevision: 3, connected: true },
+    ]);
+    expect(result.mutationGateStoreHealth).toMatchObject({ state: 'healthy', path: mutationGatePathFor(advertisePath) });
+  });
+
   it('a plugin that registers DURING the wait: exits normally with waitedMs, not a timeout', async () => {
     const mod = await loadBrokerDaemon();
     await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });


### PR DESCRIPTION
## Summary
- Adds a durable, fail-closed mutation admission gate keyed to an exact non-empty Figma file key.
- Fences new ownership and dispatch across direct mutation, queued and parked work, BATCH, and caller-provided read-only metadata while preserving the exact safe-read allowlist.
- Exposes per-file gate and store-health status, including disconnected persisted rows.

## Validation
- [x] Focused broker coverage: 15 files / 182 tests.
- [x] `npm run typecheck`, `npm run build`, `npm test` (139 files / 1752 tests), comment lint, and `git diff --check`.
- [x] Disposable live-Figma smoke on `BE0KVGCRdlUyp9KGYxv7es`: paused mutation denial without an EXEC_JS job, safe read, resume, temporary frame create/remove with child count 8 to 8, and store cleanup.

Closes #100