### PR TITLE
fix(broker): preserve exact targets through background throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,10 @@ whole session. Arbitrary scripts run inside a bracket that **undoes itself on er
 reports `rolledBack: true` only when the rollback actually completed. Mutations are **jobs**:
 one runs per file at a time, the rest queue in order, reads bypass the queue. A timeout tells
 you the work was *not* cancelled and hands you a job id to poll; cancel actually cancels; a
-reply that arrives after a job was killed is discarded, never served. Nothing is ever lost
+reply that arrives after a job was killed is discarded, never served. If transport drops
+after a mutation was dispatched, its outcome is unknown: poll the job, inspect the canvas,
+then run the reported bare `job <id> --force-release` command. Never retry that mutation
+automatically. Nothing is ever lost
 silently — every eviction, prune, and rotation leaves a counter, an archive, or an audit
 record. Every error lands in `design/figma-errors.jsonl` with its full untruncated reason —
 a log written for the agent that caused it, so it can read and fix — and `figma-agent errors`
@@ -101,12 +104,23 @@ reads it back without ever crashing on a bad line.
 ### Multiple files, one broker
 
 Several open Figma files stay connected at once — they no longer evict each other. Commands
-route to the most-recently-active file, or pin to one with `FIGMA_AGENT_FILE`. Several
+without a target prefer a ready file; set `FIGMA_AGENT_FILE` to pin the default by name.
+Exact `--file`/`--instance` targets never fall through to a different file. If the exact
+target is connected but app-unready, the broker probes only that target, then dispatches
+once after readiness returns or fails with bounded `E_APP_UNREADY`. Several
 *agents* can share one file too: pass `--agent claude` (or set `FIGMA_AGENT_ID`) and the
 panel's activity feed labels each entry with the harness that sent it, so a designer
 watching the canvas can tell who just did that. Omit it and the wire frame is byte-identical
 to what a pre-flag CLI sent — the panel's own `cli` default is applied when the row renders,
 never stamped onto the request.
+
+`status` reports transport and application state separately. `state: "connected"` means
+the WebSocket is open; `appState: "ready"` means the Figma app recently answered, while
+`"unready"` means an open socket whose app is silent or background-throttled.
+`appHeartbeatMode: "legacy"` identifies an older compatibility heartbeat; incomplete or
+unsupported readiness advertises `"unknown"` instead of guessing. Readiness gates only
+agent dispatch: manual Figma edits remain available and continue through the existing
+change feed and reconnect gap-fill.
 
 ## Install / build
 

--- a/cli/src/command-catalog.ts
+++ b/cli/src/command-catalog.ts
@@ -60,7 +60,8 @@ export const COMMANDS: CommandCatalogEntry[] = [
       + '<jobId> --force-release [--force]   poll/wait/cancel/list a job the CLI stopped waiting for '
       + '(backlog 1.1+2.6+4.3) — --force-release refuses a HEALTHY still-running job unless --force is '
       + 'also passed — --force overrides the guard and discards its result, unverified; a '
-      + 'watchdog-wedged job still unwedges without --force',
+      + 'watchdog-wedged job still unwedges without --force. An outcome-unknown job requires '
+      + 'canvas inspection, then a bare --force-release; never retry it automatically.',
   },
   {
     name: 'scan-design-system',

--- a/cli/src/commands/job.ts
+++ b/cli/src/commands/job.ts
@@ -43,6 +43,10 @@ export function isTerminal(state: JobInfo['state']): boolean {
   return state === 'done' || state === 'failed' || state === 'cancelled';
 }
 
+export function isPollSettled(state: JobInfo['state']): boolean {
+  return isTerminal(state) || state === 'outcome-unknown';
+}
+
 async function pollOnce(jobId: string): Promise<PollReply> {
   return (await runCommand('JOB', { mode: 'poll', jobId })) as PollReply;
 }
@@ -84,6 +88,27 @@ export function unwrapResult(frames: string[]): { ok: boolean; result?: unknown;
  *  exactly what the original command would have printed, plus the job envelope. */
 export function formatPoll(reply: PollReply): unknown {
   const { job, resultFrames, resultDropped, lateReplyCount } = reply;
+  if (job.state === 'outcome-unknown') {
+    const released = job.finishedAt !== undefined;
+    return {
+      job,
+      error: {
+        code: 'E_OUTCOME_UNKNOWN',
+        message: released
+          ? `${job.uncertaintyReason ?? 'plugin transport was lost after dispatch'}; ` +
+            'canvas inspection and slot release are complete. The slot is no longer held, ' +
+            'the canvas outcome remains unknown, and automatic retry is forbidden.'
+          : `${job.uncertaintyReason ?? 'plugin transport was lost after dispatch'}; ` +
+            'the canvas may or may not have changed. Inspect the canvas, then force-release the held slot.',
+        jobId: job.jobId,
+        ...(!released && job.recovery !== undefined && { recovery: job.recovery }),
+      },
+      ...(typeof lateReplyCount === 'number' && lateReplyCount > 0 && {
+        lateReplyCount,
+        lateReplyWarning: `${lateReplyCount} late reply frame(s) arrived after the outcome became uncertain and were discarded`,
+      }),
+    };
+  }
   if (!isTerminal(job.state) || resultFrames === undefined) return { job };
   // Closing round (R1+R2 unified) — merged onto whichever shape below applies; a late
   // reply is orthogonal to the job's own (already-final) outcome, never overriding it.
@@ -125,7 +150,7 @@ export async function waitForJob(
   const deadline = Date.now() + waitTimeoutMs;
   for (;;) {
     const reply = await poll(jobId);
-    if (isTerminal(reply.job.state)) return formatPoll(reply);
+    if (isPollSettled(reply.job.state)) return formatPoll(reply);
     if (Date.now() >= deadline) {
       return {
         job: reply.job,

--- a/cli/src/commands/status.ts
+++ b/cli/src/commands/status.ts
@@ -4,12 +4,12 @@
 // the ACTIVE plugin. Never throws E_NO_PLUGIN: an absent plugin is reported as
 // connected:false so `status` stays a diagnosis tool, not another command that
 // fails when nobody's listening.
-import { PROTOCOL_VERSION } from '../../../shared/protocol.ts';
+import { APP_READINESS_VERSION, PROTOCOL_VERSION } from '../../../shared/protocol.ts';
 import { fileMatches } from '../../../shared/file-match.ts';
 import type { CommandArgs } from '../figma-agent.ts';
 import { fetchBrokerHello, runCommand } from '../transport/broker-client.ts';
 import { ensureBroker } from '../transport/broker-discovery.ts';
-import { peek } from '../transport/broker-peek.ts';
+import { peek, projectReadiness } from '../transport/broker-peek.ts';
 import { waitForPlugin } from '../transport/plugin-wait.ts';
 import { buildDeepLink, type DeepLinkEntry } from '../transport/figma-deep-link.ts';
 import { fileIdentity, readBindCache, readBindMarker } from '../transport/project-bind.ts';
@@ -104,6 +104,10 @@ export async function run(args: CommandArgs): Promise<unknown> {
     uptimeMs: (hello.uptimeMs as number | undefined) ?? null,
     protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
     ...(hello.targetFileKeyAdmissionV === 1 && { targetFileKeyAdmissionV: 1 }),
+    ...(typeof hello.appReadinessV === 'number' && { appReadinessVersion: hello.appReadinessV }),
+    appReadinessVersionMatch: typeof hello.appReadinessV !== 'number'
+      ? null
+      : hello.appReadinessV === APP_READINESS_VERSION,
     // Sender-verification counter (backlog 2.10 / issue #15) — mirrors BROKER_HELLO's
     // own byte-identical-when-zero contract: present only once a cross-instance reply
     // has actually been discarded, so the common (zero) case stays unchanged here too.
@@ -113,7 +117,13 @@ export async function run(args: CommandArgs): Promise<unknown> {
     // without needing to grep the broker log.
     ...(hello.legacyMigrationDeferred === true && { legacyMigrationDeferred: true }),
   };
-  const all = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntryWithJob[]) : [];
+  const readinessVersion = typeof hello.appReadinessV === 'number' ? hello.appReadinessV : undefined;
+  const all = Array.isArray(hello.plugins)
+    ? (hello.plugins as PluginStatusEntryWithJob[]).map((row) => ({
+        ...row,
+        ...projectReadiness(row, readinessVersion),
+      }))
+    : [];
 
   // `--file` must not make the diagnosis self-contradictory: the BROKER_HELLO fields
   // below (activePlugin/pluginConnected/pluginInfo) are computed by the broker from
@@ -142,11 +152,13 @@ export async function run(args: CommandArgs): Promise<unknown> {
       // Raced: the active plugin left between the hello and the STATUS round-trip
       // (E_NO_PLUGIN), or the file the caller named no longer matches what answered
       // (E_WRONG_FILE) — either way `status` stays a diagnosis tool that never fails.
-      if (!(err instanceof CliError && (err.code === 'E_NO_PLUGIN' || err.code === 'E_WRONG_FILE'))) throw err;
-      connected = false;
-      state = 'disconnected';
-      lastHeartbeatAge = null;
-      scene = null;
+      if (!(err instanceof CliError && (err.code === 'E_NO_PLUGIN' || err.code === 'E_WRONG_FILE' || err.code === 'E_APP_UNREADY'))) throw err;
+      if (err.code !== 'E_APP_UNREADY') {
+        connected = false;
+        state = 'disconnected';
+        lastHeartbeatAge = null;
+        scene = null;
+      }
     }
   }
 

--- a/cli/src/transport/broker-client.ts
+++ b/cli/src/transport/broker-client.ts
@@ -188,7 +188,11 @@ export function exchange(
         if (reply.fileContext) lastFileContext = reply.fileContext;
         finish(() => {
           if (reply.ok) resolve(reply.result);
-          else reject(new CliError(reply.error.code, reply.error.message, { rolledBack: (reply.error as WireError).rolledBack }));
+          else reject(new CliError(reply.error.code, reply.error.message, {
+            rolledBack: (reply.error as WireError).rolledBack,
+            jobId: reply.error.jobId ?? (reply.error.code === 'E_OUTCOME_UNKNOWN' ? lastJob?.jobId : undefined),
+            recovery: reply.error.recovery,
+          }));
         });
       }
     });

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -12,7 +12,7 @@ import { join } from 'node:path';
 import WebSocket, { WebSocketServer } from 'ws';
 import {
   BROKER_FILE, BROKER_IDLE_SHUTDOWN_MS, COWORK_MAX_TIMEOUT_MS, EXEC_JS_MAX_TIMEOUT_MS, HEARTBEAT_INTERVAL_MS,
-  LOOPBACK_HOST, PLUGIN_WAIT_MS, PORT_RANGE_END, PORT_RANGE_START, PROTOCOL_VERSION,
+  LOOPBACK_HOST, PLUGIN_PONG_TIMEOUT_MS, PLUGIN_WAIT_MS, PORT_RANGE_END, PORT_RANGE_START, PROTOCOL_VERSION,
   type BrokerAdvertisement, type ErrorCode, type EventMsg, type JobInfo, type ReplyErr, type ReplyOk, type RequestMsg,
   type WireMsg,
 } from '../../../shared/protocol.ts';
@@ -23,7 +23,7 @@ import {
   ChunkAssembler, deleteConnectionChunk, envMs, getConnectionChunks, isChunkMsg, isEventMsg, isReplyMsg, isRequestMsg,
   parseWireMsg, rawToString, sendWireMsg, sweepAbandonedChunks, type ChunkBuffers,
 } from './protocol-helpers.ts';
-import { PluginRegistry, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
+import { PluginRegistry, appReadiness, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
 import { buildBrokerHelloData, noPluginMessage } from './broker-status.ts';
 import { MutationAdmissionGate, mutationGatePathFor } from './mutation-admission-gate.ts';
 import { durableFileKey, exactTargetFileKey } from './file-identity.ts';
@@ -75,6 +75,7 @@ let activeLogFile: string = LOG_FILE;
 const IDLE_SHUTDOWN_MS = envMs('FIGMA_AGENT_IDLE_SHUTDOWN_MS', BROKER_IDLE_SHUTDOWN_MS);
 const HEARTBEAT_MS = envMs('FIGMA_AGENT_HEARTBEAT_MS', HEARTBEAT_INTERVAL_MS);
 const PLUGIN_WAIT_TIMEOUT_MS = envMs('FIGMA_AGENT_PLUGIN_WAIT_MS', PLUGIN_WAIT_MS);
+const APP_READINESS_LEASE_MS = envMs('FIGMA_AGENT_APP_READINESS_MS', PLUGIN_PONG_TIMEOUT_MS);
 // Idle check cadence scales with the (possibly shrunk) idle window so a 5s test
 // override actually fires within a few seconds, not the fixed 60s of production.
 const IDLE_CHECK_MS = Math.min(60_000, Math.max(500, Math.floor(IDLE_SHUTDOWN_MS / 3)));
@@ -138,10 +139,26 @@ interface ParkedRequest {
   activity?: string;
   /** Exact raw assertion captured before a mutation parks; never inferred at flush. */
   targetFileKey?: string;
+  /** Original caller selector; distinct from the observed mutation key above. */
+  requestedTargetFileKey?: string;
   /** Target-local gate revision that was open when this parked mutation was admitted. */
   admissionRevision?: number;
   /** Audit timestamp of that parking admission; no durable parked job is ever created. */
   admittedAt?: number;
+  /** Set only after an exact live instance was resolved but lacked fresh app evidence. */
+  targetInstanceId?: string;
+  observedFileKey?: string | null;
+  readinessProbeId?: string;
+  awaitingReadiness?: true;
+}
+
+interface DispatchReservation {
+  generation: number;
+  targetInstanceId: string;
+  targetFileKey: string;
+  admissionRevision: number;
+  probeId?: string;
+  deadline?: number;
 }
 
 /**
@@ -206,6 +223,7 @@ interface BrokerState {
   // request. Broker-terminal (never forwarded, never queued) — same precedent as
   // `waiting` above, but fed by EDIT_FEED batches instead of plugin availability.
   coworkWaiters: CoworkWaiterEntry[];
+  dispatchReservations: Map<string, DispatchReservation>;
 }
 
 function log(line: string): void {
@@ -284,6 +302,15 @@ export function buildForceReleaseAuditLine(
 ): string {
   const requester = activity ?? 'unlabeled request';
   return `job ${jobId} (${cmd}) force-released${override ? ' via --force override' : ''} — requested by "${requester}" — "${fileSlug}"'s mutation slot freed; any later reply from that script is discarded`;
+}
+
+/** A FIFO slot owner that has not sent is cancelled, never force-released. */
+export function reservedForceReleaseReason(
+  jobId: string, state: JobInfo['state'], slotOwnerId: string | null,
+): string | null {
+  return state === 'queued' && slotOwnerId === jobId
+    ? `job '${jobId}' is queued and has not been dispatched; use: figma-agent job ${jobId} --cancel`
+    : null;
 }
 
 /**
@@ -504,7 +531,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     bindIndex, knownProjectDirs: new Set(usableDirs),
     jobs: new JobTable(), queues: new Map(), pendingChunks: new Map(),
     awaitingReconnect: initialAwaitingReconnect,
-    coworkWaiters: [],
+    coworkWaiters: [], dispatchReservations: new Map(),
   };
   // Sweep leftover `${advertisePath}.<pid>.tmp` files from a prior instance's hard
   // kill (SIGKILL between the temp write and the rename never runs its own cleanup)
@@ -530,6 +557,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // this daemon run (a closure local, not module-level) so it never leaks across daemon
   // instances started back-to-back within the same test process.
   let senderMismatchCount = 0;
+  let dispatchGeneration = 0;
+  let readinessProbeCounter = 0;
 
   // Live-sync idle-commit (spec 004 P4): the idle window sent to each plugin, and a
   // debounce so a double-click never launches two overlapping `ui figma reconcile
@@ -851,23 +880,6 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   const errReplyFrame = (id: string, code: ErrorCode, message: string): string =>
     JSON.stringify({ id, ok: false, error: { code, message } } satisfies ReplyErr);
 
-  /** Finalize a not-yet-running mutation after a gate denial. The same stored frame is
-   * delivered live and remains available through JOB polling. */
-  const cancelQueuedForGate = (job: JobRecord, code: ErrorCode, message: string): boolean => {
-    const frame = errReplyFrame(job.requestId, code, message);
-    const result = st.jobs.cancelQueued(job.jobId, [frame]);
-    if (!result.ok) return false;
-    const q = st.queues.get(job.fileSlug);
-    if (q && q.running !== job.jobId) st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
-    recordContention(job);
-    if (job.from && job.from.readyState === WebSocket.OPEN) {
-      try { job.from.send(frame); } catch { /* requester vanished */ }
-    }
-    st.pending.delete(job.requestId);
-    st.dispatchedTo.delete(job.requestId);
-    return true;
-  };
-
   /**
    * Write-through a finished job's `queuedMs` into its durable contention counter — the
    * ONE seam every `st.jobs.finish`/`cancelQueued` call site below routes through, right
@@ -891,6 +903,108 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     for (const frame of frames) ws.send(frame);
   };
 
+  const sendAppProbe = (ws: WebSocket, probeId: string): void => {
+    if (ws.readyState !== WebSocket.OPEN) return;
+    try { sendEvent(ws, 'APP_PROBE', { probeId }); } catch { /* close path settles ownership */ }
+  };
+
+  const nextReadinessProbeId = (): string => `ap_${++readinessProbeCounter}_${Date.now()}`;
+  const pluginFileKey = (entry: PluginEntry<WebSocket>): string | null =>
+    durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null);
+  const isAppReady = (entry: PluginEntry<WebSocket>): boolean =>
+    appReadiness(entry, Date.now(), APP_READINESS_LEASE_MS).appReady === true;
+  const selectDispatchTarget = (
+    filter: RouteFilter, hits: PluginEntry<WebSocket>[],
+  ): PluginEntry<WebSocket> | null => filter.source === 'none'
+    ? hits.find(isAppReady) ?? hits[0] ?? null
+    : hits[0] ?? null;
+
+  type ReservationFailure = { state: 'failed'; code: ErrorCode; message: string } | { state: 'cancelled' };
+  type DispatchClaim =
+    | { kind: 'claimed'; job: JobRecord; targetWs: WebSocket }
+    | { kind: 'wait'; targetWs: WebSocket }
+    | { kind: 'failure'; failure: ReservationFailure }
+    | { kind: 'noop' };
+  const failedReservation = (code: ErrorCode, message: string): ReservationFailure =>
+    ({ state: 'failed', code, message });
+  const failedClaim = (code: ErrorCode, message: string): DispatchClaim =>
+    ({ kind: 'failure', failure: failedReservation(code, message) });
+
+  const claimDispatchReservation = (jobId: string, generation: number): DispatchClaim => {
+    const reservation = st.dispatchReservations.get(jobId);
+    if (!reservation || reservation.generation !== generation) return { kind: 'noop' };
+    const job = st.jobs.byId(jobId);
+    const q = job !== 'unknown' && job !== 'expired' ? st.queues.get(job.fileSlug) : undefined;
+    if (job === 'unknown' || job === 'expired' || job.state !== 'queued' || q?.running !== jobId) return { kind: 'noop' };
+    const entry = st.registry.getByInstanceId(reservation.targetInstanceId);
+    if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
+      return failedClaim('E_NO_PLUGIN', 'Figma plugin disconnected while this job was queued');
+    }
+    const currentKey = pluginFileKey(entry);
+    if (currentKey === null || currentKey !== reservation.targetFileKey) {
+      return failedClaim('E_WRONG_FILE', `selected plugin key no longer matches targetFileKey ${JSON.stringify(reservation.targetFileKey)}`);
+    }
+    const admission = mutationGate.admit(reservation.targetFileKey);
+    if (!admission.ok) return failedClaim(admission.error.code, admission.error.message);
+    if (admission.lastTransitionRevision > reservation.admissionRevision) {
+      return failedClaim(
+        'E_STALE_ADMISSION',
+        `queued mutation for ${JSON.stringify(reservation.targetFileKey)} became stale after gate revision ${reservation.admissionRevision}`,
+      );
+    }
+    if (!isAppReady(entry)) return { kind: 'wait', targetWs: entry.ws };
+    if (!st.jobs.transitionQueuedToRunning(jobId)) return { kind: 'noop' };
+    st.dispatchReservations.delete(jobId);
+    return { kind: 'claimed', job, targetWs: entry.ws };
+  };
+
+  let drainFileQueue: (fileSlug: string, finishedJobId: string) => void;
+
+  const settleKnownNotDispatched = (
+    job: JobRecord,
+    state: 'failed' | 'cancelled',
+    frames: string[],
+  ): boolean => {
+    if (!st.jobs.settleQueued(job.jobId, state, frames)) return false;
+    recordContention(job);
+    if (frames.length > 0 && job.from?.readyState === WebSocket.OPEN) {
+      try { job.from.send(frames[0]!); } catch { /* requester vanished */ }
+    }
+    st.pending.delete(job.requestId);
+    st.dispatchedTo.delete(job.requestId);
+    return true;
+  };
+
+  const settleDispatchReservation = (jobId: string, generation: number, failure: ReservationFailure): boolean => {
+    const reservation = st.dispatchReservations.get(jobId);
+    if (!reservation || reservation.generation !== generation) return false;
+    const job = st.jobs.byId(jobId);
+    if (job === 'unknown' || job === 'expired') return false;
+    const q = st.queues.get(job.fileSlug);
+    if (q?.running !== jobId || job.state !== 'queued') return false;
+    const frames = failure.state === 'cancelled'
+      ? []
+      : [errReplyFrame(job.requestId, failure.code, failure.message)];
+    if (!settleKnownNotDispatched(job, failure.state, frames)) return false;
+    st.dispatchReservations.delete(jobId);
+    drainFileQueue(job.fileSlug, jobId);
+    return true;
+  };
+
+  /** Finalize an ordinary waiting-list mutation after a gate/transport denial. */
+  const settleWaitingJob = (
+    job: JobRecord,
+    code: ErrorCode,
+    message: string,
+    state: 'failed' | 'cancelled' = 'failed',
+  ): boolean => {
+    const frame = errReplyFrame(job.requestId, code, message);
+    if (!settleKnownNotDispatched(job, state, [frame])) return false;
+    const q = st.queues.get(job.fileSlug);
+    if (q && q.running !== job.jobId) st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
+    return true;
+  };
+
   const dispatchJob = (job: JobRecord, targetWs: WebSocket): void => {
     try {
       sendFrames(targetWs, job.requestFrames);
@@ -901,60 +1015,79 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (job.from && job.from.readyState === WebSocket.OPEN) sendReplyErr(job.from, job.requestId, 'E_PLUGIN_ERROR', msg);
       st.pending.delete(job.requestId);
       st.dispatchedTo.delete(job.requestId);
-      advanceQueue(job);
+      drainFileQueue(job.fileSlug, job.jobId);
     }
   };
 
-  /**
-   * A job finished (or was dequeued and immediately failed) — pop the next mutating job
-   * queued behind it on the SAME file, if any, and dispatch it. `JobRecord.targetInstanceId`
-   * is PINNED and never re-resolved by filter/recency at dequeue: a queued mutation must
-   * land in the file it was admitted for, never whichever file became most-recent while it
-   * waited (risk register: a queued job cannot be re-routed at dequeue). A vanished pinned
-   * target FAILS the job instead — recursing to keep draining the queue.
-   *
-   * Stage-4 fix round (BLOCKER 1) — `completeSkippingStale` (not plain `complete`) so a
-   * popped entry already resolved by some OTHER path (cancelled via `job --cancel`,
-   * already failed while queued via `handleClose`) is never resurrected: `markRunning` +
-   * dispatching a job the caller was told would not run was the exact bug. Defense in
-   * depth alongside the explicit dequeue those two paths now also do — this guard is what
-   * catches anything that resolves a queued job's state WITHOUT remembering to also call
-   * `removeFromQueue`.
-   */
-  const advanceQueue = (finishedJob: JobRecord): void => {
-    const q = st.queues.get(finishedJob.fileSlug) ?? emptyQueue();
-    const isStillQueued = (id: string): boolean => {
-      const rec = st.jobs.byId(id);
-      return rec !== 'unknown' && rec !== 'expired' && rec.state === 'queued';
-    };
-    const { q: nextQ, next } = completeSkippingStale(q, finishedJob.jobId, isStillQueued);
-    st.queues.set(finishedJob.fileSlug, nextQ);
-    if (next === null) return;
-    const nextJob = st.jobs.byId(next);
-    if (nextJob === 'unknown' || nextJob === 'expired') return; // defensive; should not happen
-    const entry = st.registry.getByInstanceId(nextJob.targetInstanceId);
-    if (!entry || entry.ws.readyState !== WebSocket.OPEN) {
-      const msg = 'Figma plugin disconnected while this job was queued';
-      const frame = errReplyFrame(nextJob.requestId, 'E_NO_PLUGIN', msg);
-      st.jobs.finish(nextJob.jobId, false, [frame]);
-      recordContention(nextJob);
-      if (nextJob.from && nextJob.from.readyState === WebSocket.OPEN) {
-        try { nextJob.from.send(frame); } catch { /* requester vanished */ }
-      }
-      st.pending.delete(nextJob.requestId);
-      st.dispatchedTo.delete(nextJob.requestId);
-      advanceQueue(nextJob);
+  /** Claim and synchronously send one reserved FIFO head, or leave/settle it exactly once. */
+  const tryDispatchPinnedJob = (jobId: string, generation: number): void => {
+    const claim = claimDispatchReservation(jobId, generation);
+    if (claim.kind === 'noop') return;
+    if (claim.kind === 'failure') {
+      settleDispatchReservation(jobId, generation, claim.failure);
       return;
     }
-    if (!nextJob.readOnly) {
-      const admission = mutationGate.admit(nextJob.fileSlug);
-      if (!admission.ok) {
-        if (cancelQueuedForGate(nextJob, admission.error.code, admission.error.message)) advanceQueue(nextJob);
-        return;
+    if (claim.kind === 'wait') {
+      const reservation = st.dispatchReservations.get(jobId);
+      if (!reservation || reservation.generation !== generation) return;
+      if (reservation.probeId === undefined) {
+        reservation.probeId = nextReadinessProbeId();
+        reservation.deadline = Date.now() + PLUGIN_WAIT_TIMEOUT_MS;
+        if (!st.jobs.markDispatchReserved(jobId)) return;
+        sendAppProbe(claim.targetWs, reservation.probeId);
       }
+      return;
     }
-    st.jobs.markRunning(nextJob.jobId);
-    dispatchJob(nextJob, entry.ws);
+    // No await may enter this sequence: map assignment is proof that the following
+    // synchronous send owns this exact target.
+    st.dispatchedTo.set(claim.job.requestId, claim.targetWs);
+    dispatchJob(claim.job, claim.targetWs);
+  };
+
+  const reserveDispatch = (job: JobRecord): DispatchReservation | null => {
+    if (job.targetFileKey === undefined || job.admissionRevision === undefined) return null;
+    const reservation = {
+      generation: ++dispatchGeneration,
+      targetInstanceId: job.targetInstanceId,
+      targetFileKey: job.targetFileKey,
+      admissionRevision: job.admissionRevision,
+    } satisfies DispatchReservation;
+    st.dispatchReservations.set(job.jobId, reservation);
+    return reservation;
+  };
+
+  const drainRequests: Array<{ fileSlug: string; finishedJobId: string }> = [];
+  let drainingQueues = false;
+  drainFileQueue = (fileSlug: string, finishedJobId: string): void => {
+    drainRequests.push({ fileSlug, finishedJobId });
+    if (drainingQueues) return;
+    drainingQueues = true;
+    try {
+      while (drainRequests.length > 0) {
+        const current = drainRequests.shift()!;
+        const q = st.queues.get(current.fileSlug) ?? emptyQueue();
+        const isStillQueued = (id: string): boolean => {
+          const rec = st.jobs.byId(id);
+          return rec !== 'unknown' && rec !== 'expired' && rec.state === 'queued';
+        };
+        const { q: nextQ, next } = completeSkippingStale(q, current.finishedJobId, isStillQueued);
+        st.queues.set(current.fileSlug, nextQ);
+        if (next === null) continue;
+        const nextJob = st.jobs.byId(next);
+        if (nextJob === 'unknown' || nextJob === 'expired') continue;
+        const reservation = reserveDispatch(nextJob);
+        if (reservation === null) {
+          const frame = errReplyFrame(nextJob.requestId, 'E_FILE_KEY_UNAVAILABLE', 'queued mutation lost its raw fileKey admission identity');
+          if (settleKnownNotDispatched(nextJob, 'failed', [frame])) {
+            drainRequests.push({ fileSlug: nextJob.fileSlug, finishedJobId: nextJob.jobId });
+          }
+          continue;
+        }
+        tryDispatchPinnedJob(nextJob.jobId, reservation.generation);
+      }
+    } finally {
+      drainingQueues = false;
+    }
   };
 
   /**
@@ -970,6 +1103,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     from: WebSocket, id: string, rawText: string, cmd?: string, expectedFile?: string,
     expectedInstance?: string, targetFileKey?: unknown, _readOnly = false, projectDir?: string, activity?: string,
     parkedAdmission?: { targetFileKey: string; admissionRevision: number; admittedAt: number },
+    parkedTarget?: { targetInstanceId: string; observedFileKey: string | null },
   ): void => {
     const duplicateJob = st.jobs.byRequestId(id);
     const duplicateWaiting = st.waiting.some((request) => request.id === id);
@@ -1017,15 +1151,18 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const filter: RouteFilter = requestedTargetFileKey === undefined
       ? resolveRouteFilter(expectedFile, currentFilter(), expectedInstance, pinLive ? pin : null)
       : { value: null, exact: true, source: 'none', kind: 'name' };
-    let targetWs = st.dispatchedTo.get(id);
-    if (targetWs && targetWs.readyState !== WebSocket.OPEN) targetWs = undefined;
-    if (requestedTargetFileKey !== undefined) {
+    let targetWs: WebSocket | undefined;
+    if (parkedTarget !== undefined) {
+      const exact = st.registry.getByInstanceId(parkedTarget.targetInstanceId);
+      const currentKey = exact ? pluginFileKey(exact) : null;
+      if (exact && exact.ws.readyState === WebSocket.OPEN && currentKey === parkedTarget.observedFileKey) targetWs = exact.ws;
+    } else if (requestedTargetFileKey !== undefined) {
       // The caller's key is a routing assertion, never canonical evidence: only the
       // currently registered exact scene key may select a plugin. A live keyless plugin
       // or different key is unrelated — leave the request unresolved so exact-key parking
       // can wait for the asserted file without emitting a false wrong-file refusal.
       const live = st.registry.liveEntries();
-      const exact = live.find((entry) => durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === requestedTargetFileKey);
+      const exact = live.find((entry) => pluginFileKey(entry) === requestedTargetFileKey);
       if (exact) {
         targetWs = exact.ws;
       }
@@ -1042,7 +1179,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           `or target one exactly with --instance <id> (e.g. --instance ${hits[0].instanceId})`);
         return;
       }
-      const target = hits[0] ?? null;
+      const target = selectDispatchTarget(filter, hits);
       targetWs = target?.ws;
       // A plugin that predates the guard would ignore expectedFile and run anyway; refuse BEFORE
       // forwarding rather than discovering it from a reply that has already mutated a file. Only
@@ -1093,7 +1230,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.waiting.push({
         id, from, rawText, deadline: Date.now() + PLUGIN_WAIT_TIMEOUT_MS, filter, projectDir,
         cmd, readOnly: isReadOnly, activity,
-        ...(requestedTargetFileKey !== undefined && requestedTargetFileKey !== null && { targetFileKey: requestedTargetFileKey }),
+        ...(requestedTargetFileKey !== undefined && requestedTargetFileKey !== null && {
+          targetFileKey: requestedTargetFileKey, requestedTargetFileKey,
+        }),
         ...(admissionRevision !== undefined && { admissionRevision, admittedAt: parkedAt }),
       });
       log(`parked ${id}${cmd ? ` (${cmd})` : ''}${requestedTargetFileKey ? ` [targetFileKey=${JSON.stringify(requestedTargetFileKey)} rev=${admissionRevision ?? 'safe-read'} at=${parkedAt}]` : filter.value ? ` [${filter.source}="${filter.value}"]` : ''} — awaiting ${requestedTargetFileKey || filter.value ? 'matching ' : ''}plugin (${st.waiting.length} queued)`);
@@ -1108,7 +1247,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       return;
     }
 
-    const rawFileKey = durableFileKey((targetEntry.scene.fileKey as string | null | undefined) ?? null);
+    const rawFileKey = pluginFileKey(targetEntry);
     if (requestedTargetFileKey !== undefined) {
       if (rawFileKey === null) {
         sendReplyErr(from, id, 'E_FILE_KEY_UNAVAILABLE', 'targetFileKey cannot be verified because the selected plugin has no raw fileKey');
@@ -1119,6 +1258,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         return;
       }
     }
+    let admissionRevision: number | undefined;
     if (!isReadOnly) {
       const admission = mutationGate.admit(rawFileKey);
       if (!admission.ok) {
@@ -1132,11 +1272,32 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           `parked mutation for ${JSON.stringify(parkedAdmission.targetFileKey)} became stale after gate revision ${parkedAdmission.admissionRevision} (parked at ${parkedAdmission.admittedAt})`);
         return;
       }
+      admissionRevision = parkedAdmission?.admissionRevision ?? admission.lastTransitionRevision;
+    }
+
+    if (!isAppReady(targetEntry)) {
+      if (!isReadOnly && rawFileKey === null) {
+        sendReplyErr(from, id, 'E_FILE_KEY_UNAVAILABLE', 'an app-unready mutation requires the selected plugin to expose a raw fileKey');
+        return;
+      }
+      const probeId = nextReadinessProbeId();
+      sendAppProbe(targetWs, probeId);
+      const parkedAt = Date.now();
+      st.waiting.push({
+        id, from, rawText, deadline: parkedAt + PLUGIN_WAIT_TIMEOUT_MS, filter, projectDir,
+        cmd, readOnly: isReadOnly, activity, targetInstanceId: targetEntry.instanceId,
+        observedFileKey: rawFileKey, readinessProbeId: probeId, awaitingReadiness: true,
+        ...(!isReadOnly && rawFileKey !== null && admissionRevision !== undefined
+          ? { targetFileKey: rawFileKey, admissionRevision, admittedAt: parkedAt }
+          : {}),
+        ...(requestedTargetFileKey !== undefined ? { requestedTargetFileKey } : {}),
+      });
+      log(`parked ${id}${cmd ? ` (${cmd})` : ''} for app readiness on [${targetEntry.instanceId}]`);
+      return;
     }
 
     recordRequestBinding(targetWs, projectDir);
     st.pending.set(id, from);
-    st.dispatchedTo.set(id, targetWs);
 
     const fileSlug = rawFileKey ?? fileIdentity(
       null,
@@ -1145,6 +1306,9 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const job = st.jobs.create({
       requestId: id, cmd: cmd ?? '(unknown)', fileSlug, readOnly: isReadOnly,
       requestFrames: [rawText], from, targetInstanceId: targetEntry.instanceId,
+      ...(!isReadOnly && rawFileKey !== null && admissionRevision !== undefined
+        ? { targetFileKey: rawFileKey, admissionRevision }
+        : {}),
       ...(activity !== undefined && { activity }),
     });
     // JOB_STATE — sent BEFORE any timeout can fire, so a CLI that gives up waiting still
@@ -1152,7 +1316,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     sendEvent(from, 'JOB_STATE', toJobInfo(job) as unknown as Record<string, unknown>);
 
     if (isReadOnly) {
-      st.jobs.markRunning(job.jobId);
+      if (!st.jobs.transitionQueuedToRunning(job.jobId)) return;
+      st.dispatchedTo.set(id, targetWs);
       dispatchJob(job, targetWs);
       return;
     }
@@ -1162,13 +1327,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const { q: nextQ, startNow } = enqueueJob(q, job.jobId);
     st.queues.set(fileSlug, nextQ);
     if (startNow) {
-      const admission = mutationGate.admit(rawFileKey);
-      if (!admission.ok) {
-        if (cancelQueuedForGate(job, admission.error.code, admission.error.message)) advanceQueue(job);
-        return;
-      }
-      st.jobs.markRunning(job.jobId);
-      dispatchJob(job, targetWs);
+      const reservation = reserveDispatch(job);
+      if (reservation !== null) tryDispatchPinnedJob(job.jobId, reservation.generation);
     } else {
       const pos = queuePosition(nextQ, job.jobId);
       if (pos !== undefined) {
@@ -1241,27 +1401,50 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // interleaving window, so two mutations parked together must still serialise correctly
   // once their plugin connects — the synchronous loop below guarantees that (the first
   // admits and dispatches/marks running, the second admits into the now-non-empty queue).
-  const flushWaiting = (): void => {
+  type ReadinessSignal = { targetInstanceId: string; probeId?: string };
+
+  const waitingTargetIsReady = (request: ParkedRequest, signal?: ReadinessSignal): boolean => {
+    if (request.targetInstanceId !== undefined) {
+      const pinned = st.registry.getByInstanceId(request.targetInstanceId);
+      const signalMatches = request.awaitingReadiness !== true || signal === undefined
+        || (signal.targetInstanceId === request.targetInstanceId
+          && (signal.probeId === undefined || signal.probeId === request.readinessProbeId));
+      return signalMatches
+        && pinned !== null
+        && pinned.ws.readyState === WebSocket.OPEN
+        && pluginFileKey(pinned) === request.observedFileKey
+        && isAppReady(pinned);
+    }
+    if (request.requestedTargetFileKey === undefined) {
+      return st.registry.selectTarget(request.filter.value, {
+        exact: request.filter.exact,
+        kind: request.filter.kind,
+      }) !== null;
+    }
+    return st.registry.liveEntries().some((entry) =>
+      pluginFileKey(entry) === request.requestedTargetFileKey,
+    );
+  };
+
+  const flushWaiting = (signal?: ReadinessSignal): void => {
     if (st.waiting.length === 0) return;
     const queued = st.waiting;
     st.waiting = [];
     let delivered = 0;
     for (const req of queued) {
       if (req.from.readyState !== WebSocket.OPEN) continue; // CLI gone — drop silently
-      const targetExists = req.targetFileKey === undefined
-        ? st.registry.selectTarget(req.filter.value, { exact: req.filter.exact, kind: req.filter.kind }) !== null
-        : st.registry.liveEntries().some((entry) =>
-          durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null) === req.targetFileKey,
-        );
-      if (targetExists) {
+      if (waitingTargetIsReady(req, signal)) {
         const flagValue = req.filter.source === 'flag' ? req.filter.value ?? undefined : undefined;
         admitRequest(
           req.from, req.id, req.rawText, req.cmd,
           req.filter.kind === 'name' ? flagValue : undefined,
           req.filter.kind === 'instance' ? flagValue : undefined,
-          req.targetFileKey, req.readOnly === true, req.projectDir, req.activity,
+          req.requestedTargetFileKey, req.readOnly === true, req.projectDir, req.activity,
           req.targetFileKey !== undefined && req.admissionRevision !== undefined && req.admittedAt !== undefined
             ? { targetFileKey: req.targetFileKey, admissionRevision: req.admissionRevision, admittedAt: req.admittedAt }
+            : undefined,
+          req.targetInstanceId !== undefined
+            ? { targetInstanceId: req.targetInstanceId, observedFileKey: req.observedFileKey ?? null }
             : undefined,
         );
         delivered++;
@@ -1270,6 +1453,20 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       }
     }
     if (delivered > 0) log(`flushed ${delivered} parked request(s)`);
+  };
+
+  const resumeReadiness = (ws: WebSocket, msg: WireMsg): void => {
+    const entry = st.registry.getByWs(ws);
+    if (!entry) return;
+    const probeId = isEventMsg(msg) && msg.type === 'APP_PROBE_ACK' && typeof msg.data.probeId === 'string'
+      ? msg.data.probeId
+      : undefined;
+    for (const [jobId, reservation] of [...st.dispatchReservations]) {
+      if (reservation.targetInstanceId !== entry.instanceId) continue;
+      if (probeId !== undefined && reservation.probeId !== probeId) continue;
+      tryDispatchPinnedJob(jobId, reservation.generation);
+    }
+    flushWaiting({ targetInstanceId: entry.instanceId, ...(probeId !== undefined && { probeId }) });
   };
 
   /**
@@ -1306,7 +1503,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // UNCONDITIONALLY here, mutating the array in place before `finish()`'s own guard
       // ever got a chance to see it, so a late chunk corrupted `replyFrames` regardless
       // of that guard. Never touch `replyFrames` for a terminal job, never re-run
-      // finish()/advanceQueue a second time — count + log only, "discarded" stays true.
+      // finish/drain a second time — count + log only, "discarded" stays true.
       job.lateReplyCount = (job.lateReplyCount ?? 0) + 1;
       log(`late reply frame for terminal job ${job.jobId} (${job.state}) discarded, ` +
         `${Buffer.byteLength(rawText, 'utf8')} bytes (lateReplyCount=${job.lateReplyCount})`);
@@ -1322,7 +1519,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         const ok = replyOk(job.replyFrames);
         st.jobs.finish(job.jobId, ok, job.replyFrames);
         recordContention(job);
-        advanceQueue(job);
+        drainFileQueue(job.fileSlug, job.jobId);
       }
     }
     if (final) {
@@ -1364,6 +1561,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     }
 
     if (mode === 'cancel') {
+      const reservation = st.dispatchReservations.get(jobId);
+      if (reservation) {
+        const ok = settleDispatchReservation(jobId, reservation.generation, { state: 'cancelled' });
+        sendReplyOk(ws, msg.id, ok ? { ok: true } : { ok: false, reason: 'job is no longer queued for dispatch' });
+        return;
+      }
       const result = st.jobs.cancelQueued(jobId);
       // Stage-4 fix round (BLOCKER 1) — `cancelQueued` only marks the RECORD `cancelled`;
       // it does not touch the file's own QueueState. Without this, the job stayed in
@@ -1386,6 +1589,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (rec === 'unknown') { sendReplyOk(ws, msg.id, { ok: false, reason: `no such job '${jobId}'` }); return; }
       if (rec === 'expired') { sendReplyOk(ws, msg.id, { ok: false, reason: `job '${jobId}' already expired — nothing to release` }); return; }
       const q = st.queues.get(rec.fileSlug);
+      const reservedReason = reservedForceReleaseReason(jobId, rec.state, q?.running ?? null);
+      if (reservedReason !== null) {
+        sendReplyOk(ws, msg.id, {
+          ok: false,
+          reason: reservedReason,
+        });
+        return;
+      }
       if (!q || q.running !== jobId) {
         sendReplyOk(ws, msg.id, { ok: false, reason: `job '${jobId}' is not the one blocking "${rec.fileSlug}"'s mutation slot` });
         return;
@@ -1423,7 +1634,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // (below) keeps the late frame out of the poll result regardless.
       st.pending.delete(rec.requestId);
       st.dispatchedTo.delete(rec.requestId);
-      advanceQueue(rec);
+      drainFileQueue(rec.fileSlug, rec.jobId);
       // Audited: every force-release (allowed-wedged or `--force` override) logs WHO asked
       // and WHY, never silently — the requester's own `activity` label on this request.
       log(buildForceReleaseAuditLine(jobId, rec.cmd, rec.fileSlug, override, msg.activity));
@@ -1505,11 +1716,16 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       return;
     }
     if (transition.state === 'paused') {
+      for (const [jobId, reservation] of [...st.dispatchReservations]) {
+        if (reservation.targetFileKey !== fileKey) continue;
+        settleDispatchReservation(jobId, reservation.generation,
+          failedReservation('E_MUTATIONS_PAUSED', `mutations are paused for fileKey ${JSON.stringify(fileKey)}`));
+      }
       const q = st.queues.get(fileKey);
       for (const jobId of [...(q?.waiting ?? [])]) {
         const job = st.jobs.byId(jobId);
         if (job !== 'unknown' && job !== 'expired') {
-          cancelQueuedForGate(job, 'E_MUTATIONS_PAUSED', `mutations are paused for fileKey ${JSON.stringify(fileKey)}`);
+          settleWaitingJob(job, 'E_MUTATIONS_PAUSED', `mutations are paused for fileKey ${JSON.stringify(fileKey)}`, 'cancelled');
         }
       }
     }
@@ -1543,12 +1759,17 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const pinLive = pin !== null && st.registry.getByInstanceId(pin)?.ws.readyState === WebSocket.OPEN;
     const filter = resolveRouteFilter(msg.expectedFile, currentFilter(), msg.expectedInstance, pinLive ? pin : null);
     const hits = st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind });
-    const target = hits[0] ?? null;
+    const target = selectDispatchTarget(filter, hits);
     if (!target) {
       // No plugin to watch at all — cowork has nothing to wait ON, unlike an ordinary
       // command (which can park for a not-yet-connected plugin). Fails fast rather than
       // silently waiting out the full budget for a file that was never open.
       sendReplyErr(ws, msg.id, 'E_NO_PLUGIN', noPluginMessage(st.registry, filter));
+      return;
+    }
+    if (!isAppReady(target)) {
+      sendReplyErr(ws, msg.id, 'E_APP_UNREADY',
+        `the plugin open in "${target.scene.fileName ?? '?'}" is transport-connected but application-unready; focus the file and retry cowork`);
       return;
     }
 
@@ -1587,28 +1808,16 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       const client = st.pending.get(id);
       const msg = 'Figma plugin disconnected mid-request';
       if (client) sendReplyErr(client, id, 'E_NO_PLUGIN', msg);
-      // Concurrency & jobs — finish the JOB too (not just reply the client that's still
-      // waiting): this is the ONLY place a dispatched job's plugin target vanishing is
-      // discovered, so a poll must get a real answer instead of hanging forever.
-      //
-      // Stage-4 fix round (BLOCKER 2, reviewer ruling Q2: FAIL + DEQUEUE, no reconnect-
-      // hold window) — `dispatchedTo` is set at ADMISSION for every job (queued or
-      // running), so this loop also catches a job whose pinned target disconnected while
-      // it was STILL QUEUED, never yet dispatched. `advanceQueue` only does anything for
-      // the file's CURRENTLY RUNNING job (`completeQueue`'s own no-op guard on a
-      // running-id mismatch) — for a queued one it silently did nothing, leaving the
-      // now-failed entry sitting in `q.waiting` until a LATER completion popped and
-      // resurrected it (dispatching a mutation whose CLI already got E_NO_PLUGIN). Ruled:
-      // no reconnect grace window — a re-admitted CLI retry re-enters cleanly. So: the
-      // RUNNING job still goes through `advanceQueue` (pops + dispatches next); a STILL-
-      // QUEUED one is instead removed directly from that file's queue.
+      // Actual-send jobs own a `dispatchedTo` route. Finish the record for polling and
+      // drain only if it owns the active FIFO slot; ordinary queued jobs are handled by
+      // the pinned reservation/waiting-list scans after registry removal below.
       const job = st.jobs.byRequestId(id);
       if (job) {
         st.jobs.finish(job.jobId, false, [errReplyFrame(id, 'E_NO_PLUGIN', msg)]);
         recordContention(job);
         const q = st.queues.get(job.fileSlug);
         if (q && q.running === job.jobId) {
-          advanceQueue(job);
+          drainFileQueue(job.fileSlug, job.jobId);
         } else if (q) {
           st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
         }
@@ -1618,6 +1827,24 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     }
     const removedId = st.registry.removeByWs(ws);
     if (removedId !== null) {
+      for (const [jobId, reservation] of [...st.dispatchReservations]) {
+        if (reservation.targetInstanceId !== removedId) continue;
+        settleDispatchReservation(jobId, reservation.generation,
+          failedReservation('E_NO_PLUGIN', 'Figma plugin disconnected while this job was queued'));
+      }
+      for (const q of st.queues.values()) {
+        for (const jobId of [...q.waiting]) {
+          const job = st.jobs.byId(jobId);
+          if (job === 'unknown' || job === 'expired' || job.targetInstanceId !== removedId) continue;
+          settleWaitingJob(job, 'E_NO_PLUGIN', 'Figma plugin disconnected while this job was queued');
+        }
+      }
+      const survivingParked: ParkedRequest[] = [];
+      for (const request of st.waiting) {
+        if (request.targetInstanceId !== removedId) { survivingParked.push(request); continue; }
+        sendReplyErr(request.from, request.id, 'E_NO_PLUGIN', 'Figma plugin disconnected while waiting for application readiness');
+      }
+      st.waiting = survivingParked;
       const remaining = st.registry.size();
       log(`plugin [${removedId}] disconnected (${remaining} still connected)`);
       // #35 P2: a pin must never keep pointing at a plugin that just left — Law 1 applies
@@ -1676,6 +1903,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // this is the APP-liveness sensor (zombie-watchdog observability), distinct from
     // the transport-only `touch` the raw WS 'pong' handler below uses.
     const isPlugin = st.registry.touchApp(ws);
+    if (isPlugin) resumeReadiness(ws, msg);
     if (isChunkMsg(msg)) {
       // Reply-side chunks (plugin → broker) pass straight to routeFromPlugin, which now
       // accumulates every frame onto the job record itself (concurrency & jobs, backlog
@@ -1764,12 +1992,20 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         // is the cheapest correct place to also answer it — main.ts gates
         // `setRelaunchData` on this flag instead of writing to every unbound document.
         sendEvent(ws, 'SYNC_CONFIG', { idleMs: helloBound ? readIdleMsFor(helloBound) : idleMs, bound: Boolean(helloBound) });
-        flushWaiting(); // deliver any requests parked during the reconnect gap
+        flushWaiting({ targetInstanceId: instanceId }); // HELLO is fresh app evidence
         broadcastPeers();
+      } else if (msg.type === 'APP_PROBE_ACK') {
+        // touchApp + resumeReadiness above own the correlated wake-up. The ACK is
+        // broker-local control traffic and is never broadcast to CLI clients.
       } else if (msg.type === 'PING') {
         // App-level heartbeat from the plugin — answer so it knows the socket lives.
         if (isPlugin) {
-          try { if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'PONG', data: { t: Date.now() } } satisfies EventMsg)); }
+          try {
+            if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({
+              type: 'PONG',
+              data: { t: Date.now(), ...(typeof msg.data.probeId === 'string' && { probeId: msg.data.probeId }) },
+            } satisfies EventMsg));
+          }
           catch { /* plugin vanished */ }
         }
       } else if (msg.type === 'FILE_INFO') {
@@ -1784,7 +2020,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           // The UI relay can register before main's first FILE_INFO carries its raw key.
           // A valid scene-identity update is therefore another exact-target readiness
           // transition, after the existing broadcast/promotion/persistence side effects.
-          flushWaiting();
+          const instanceId = st.registry.getByWs(ws)?.instanceId;
+          if (instanceId !== undefined) flushWaiting({ targetInstanceId: instanceId });
         }
       } else if (msg.type === 'DOC_CHANGE') {
         // Live-sync capture: append the plugin's coalesced batch to the change log.
@@ -1915,7 +2152,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // purpose (see `JobTable.summaryFor`'s own doc for why that distinction matters).
   const jobStatusFor = (fileSlug: string): { runningJob: JobInfo | null; queueDepth: number } => {
     const q = st.queues.get(fileSlug) ?? emptyQueue();
-    const { running, queueDepth } = st.jobs.summaryFor(fileSlug, q.running);
+    const { running, queueDepth } = st.jobs.summaryFor(fileSlug, {
+      slotOwnerId: q.running,
+      waitingDepth: q.waiting.length,
+    });
     return { runningJob: running, queueDepth };
   };
 
@@ -2018,6 +2258,13 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // caller; a sweep that never runs breaks it silently.
     st.jobs.sweep();
     sweepAbandonedChunks(st.pendingChunks, now, PARK_SWEEP_INTERVAL_MS);
+    for (const [jobId, reservation] of [...st.dispatchReservations]) {
+      if (reservation.deadline === undefined || now <= reservation.deadline) continue;
+      settleDispatchReservation(jobId, reservation.generation, failedReservation(
+        'E_APP_UNREADY',
+        `the pinned plugin stayed application-unready beyond the ${PLUGIN_WAIT_TIMEOUT_MS}ms readiness deadline`,
+      ));
+    }
     // auto-connect slice 3 — same "must run every tick, unconditionally" reasoning as
     // the two calls above: cowork waits are the UNCOMMON case, so gating this behind
     // `st.waiting`'s own early-return would make it effectively dead code too.
@@ -2037,17 +2284,19 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const survivors: ParkedRequest[] = [];
     for (const req of st.waiting) {
       if (req.from.readyState !== WebSocket.OPEN) continue; // CLI gone — drop silently
-      if (now >= req.deadline) {
+      if (req.awaitingReadiness === true ? now > req.deadline : now >= req.deadline) {
         // The request's OWN filter, not the env pin — otherwise a timed-out --file
         // request blames FIGMA_AGENT_FILE (or prints the generic message) instead of
         // naming the flag the caller actually used.
         sendReplyErr(
           req.from,
           req.id,
-          'E_NO_PLUGIN',
-          req.targetFileKey === undefined
-            ? noPluginMessage(st.registry, req.filter)
-            : `no plugin matching targetFileKey ${JSON.stringify(req.targetFileKey)} connected before the wait deadline`,
+          req.awaitingReadiness === true ? 'E_APP_UNREADY' : 'E_NO_PLUGIN',
+          req.awaitingReadiness === true
+            ? `the pinned plugin stayed application-unready beyond the ${PLUGIN_WAIT_TIMEOUT_MS}ms readiness deadline`
+            : req.requestedTargetFileKey === undefined
+              ? noPluginMessage(st.registry, req.filter)
+              : `no plugin matching targetFileKey ${JSON.stringify(req.requestedTargetFileKey)} connected before the wait deadline`,
         );
       } else {
         survivors.push(req);
@@ -2073,7 +2322,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.jobs.finish(job.jobId, false, [errReplyFrame(job.requestId, 'E_TIMEOUT', msg)]);
       recordContention(job);
       log(`watchdog: job ${job.jobId} (${job.cmd}) timed out — slot for "${job.fileSlug}" stays blocked`);
-      // Deliberately NO advanceQueue(job) here — see the comment above.
+      // Deliberately do not drain here — see the comment above.
     }
   }, Math.min(30_000, Math.max(1_000, Math.floor(WATCHDOG_TIMEOUT_MS / 4))));
 

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -1615,7 +1615,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // unless the requester passes `--force`: freeing its slot while its script may still
       // be mid-mutation lets the NEXT queued mutation dispatch into the same file while the
       // first is still executing — genuinely concurrent writes. A watchdog-wedged job
-      // (`state !== 'running'`, because the watchdog already called `finish()`) is not
+      // (`state !== 'running'`, because the watchdog already called `finishHeld()`) is not
       // healthy and keeps unwedging with a bare `--force-release`, exactly as before.
       const now = Date.now();
       const override = params?.override === true;
@@ -1633,12 +1633,14 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // still `running` (the watchdog may not have fired yet), then advance the queue —
       // never automatic, and the message states plainly that a later reply is discarded.
       if (rec.state === 'running') {
-        rec.forceReleased = true;
-        st.jobs.finish(jobId, false, [errReplyFrame(rec.requestId, 'E_TIMEOUT',
-          'force-released — the script may still be running; its result (if any) is discarded and unverified')]);
+        if (!st.jobs.finishHeld(jobId, false, [errReplyFrame(rec.requestId, 'E_TIMEOUT',
+          'force-released — the script may still be running; its result (if any) is discarded and unverified')])) {
+          const reason = `job '${jobId}' could not be recorded as a held terminal before release`;
+          log(`invariant failure: ${reason}`);
+          sendReplyErr(ws, msg.id, 'E_PLUGIN_ERROR', reason);
+          return;
+        }
         recordContention(rec);
-      } else if (rec.state !== 'outcome-unknown') {
-        rec.forceReleased = true;
       }
       // Stage-4 fix round (M4, ruling Q1) — "discarded means discarded": if the wedged
       // script DOES eventually reply, `routeFromPlugin` must not forward it to a CLI that
@@ -1654,6 +1656,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // bounded retention applies.
       if (priorState === 'outcome-unknown' && !st.jobs.settleOutcomeUnknownRelease(jobId)) {
         const reason = `job '${jobId}' slot was released, but unknown-outcome retention settlement failed`;
+        log(`invariant failure: ${reason}`);
+        sendReplyErr(ws, msg.id, 'E_PLUGIN_ERROR', reason);
+        return;
+      }
+      if (priorState !== 'outcome-unknown' && !st.jobs.settleHeldTerminalRelease(jobId)) {
+        const reason = `job '${jobId}' slot was released, but terminal retention settlement failed`;
         log(`invariant failure: ${reason}`);
         sendReplyErr(ws, msg.id, 'E_PLUGIN_ERROR', reason);
         return;
@@ -1859,7 +1867,21 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // the pinned reservation/waiting-list scans after registry removal below.
       const job = st.jobs.byRequestId(id);
       if (job) {
-        if (job.state === 'running' && !job.readOnly) {
+        if (job.retentionHeld === true) {
+          if (client) sendReplyErr(client, id, 'E_NO_PLUGIN', msg);
+          const q = st.queues.get(job.fileSlug);
+          if (q?.running !== job.jobId) {
+            log(`invariant failure: held job ${job.jobId} disconnected without owning "${job.fileSlug}"'s mutation slot`);
+          } else {
+            // The watchdog already recorded this job's E_TIMEOUT and contention once.
+            // Close is the second, audited release path: remove the live queue owner
+            // first, then make the preserved evidence retention-eligible from now.
+            drainFileQueue(job.fileSlug, job.jobId);
+            if (!st.jobs.settleHeldTerminalRelease(job.jobId)) {
+              log(`invariant failure: held job ${job.jobId} disconnected after queue release but retention settlement failed`);
+            }
+          }
+        } else if (job.state === 'running' && !job.readOnly) {
           const reason = 'plugin transport disconnected after dispatch';
           if (st.jobs.markOutcomeUnknown(job.jobId, reason)) {
             recordContention(job);
@@ -2388,7 +2410,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (job.startedAt === undefined || now - job.startedAt < WATCHDOG_TIMEOUT_MS) continue;
       const msg = `no reply within ${WATCHDOG_TIMEOUT_MS}ms — the script may still be running; ` +
         `this file's mutation slot stays blocked until 'figma-agent job ${job.jobId} --force-release'`;
-      st.jobs.finish(job.jobId, false, [errReplyFrame(job.requestId, 'E_TIMEOUT', msg)]);
+      st.jobs.finishHeld(job.jobId, false, [errReplyFrame(job.requestId, 'E_TIMEOUT', msg)]);
       recordContention(job);
       log(`watchdog: job ${job.jobId} (${job.cmd}) timed out — slot for "${job.fileSlug}" stays blocked`);
       // Deliberately do not drain here — see the comment above.

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -13,8 +13,8 @@ import WebSocket, { WebSocketServer } from 'ws';
 import {
   BROKER_FILE, BROKER_IDLE_SHUTDOWN_MS, COWORK_MAX_TIMEOUT_MS, EXEC_JS_MAX_TIMEOUT_MS, HEARTBEAT_INTERVAL_MS,
   LOOPBACK_HOST, PLUGIN_PONG_TIMEOUT_MS, PLUGIN_WAIT_MS, PORT_RANGE_END, PORT_RANGE_START, PROTOCOL_VERSION,
-  type BrokerAdvertisement, type ErrorCode, type EventMsg, type JobInfo, type ReplyErr, type ReplyOk, type RequestMsg,
-  type WireMsg,
+  type BrokerAdvertisement, type ErrorCode, type EventMsg, type JobInfo, type JobRecovery, type ReplyErr, type ReplyOk,
+  type RequestMsg, type WireMsg,
 } from '../../../shared/protocol.ts';
 import {
   cleanupOrphanedAdvertisementTempFiles, isPidAlive, readAdvertisement, selfBuildMtime, writeAdvertisement,
@@ -49,7 +49,8 @@ import {
   resolveProjectDir, writeBindCache, writeBindMarker, type Binding,
 } from './project-bind.ts';
 import {
-  JobTable, isFinishedState, isHealthyRunningJob, isReplyFromDispatchedInstance, toJobInfo, type JobRecord,
+  JobTable, isFinishedState, isHealthyRunningJob, isReplyDiscardState, isReplyFromDispatchedInstance, toJobInfo,
+  type JobRecord,
 } from './job-table.ts';
 import { createWaiter as createCoworkWaiter, onEdits as feedCoworkWaiter, tick as tickCoworkWaiter, type CoworkWaiterState } from './cowork-waiter.ts';
 import {
@@ -273,8 +274,14 @@ function replyOk(frames: readonly string[]): boolean {
   }
 }
 
-function sendReplyErr(ws: WebSocket, id: string, code: ErrorCode, message: string): void {
-  const reply: ReplyErr = { id, ok: false, error: { code, message } };
+function sendReplyErr(
+  ws: WebSocket,
+  id: string,
+  code: ErrorCode,
+  message: string,
+  details?: { jobId?: string; recovery?: JobRecovery },
+): void {
+  const reply: ReplyErr = { id, ok: false, error: { code, message, ...details } };
   try {
     if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(reply));
   } catch { /* client already gone */ }
@@ -299,9 +306,10 @@ function sendReplyOk(ws: WebSocket, id: string, result: unknown): void {
  */
 export function buildForceReleaseAuditLine(
   jobId: string, cmd: string, fileSlug: string, override: boolean, activity: string | undefined,
+  priorState?: JobInfo['state'],
 ): string {
   const requester = activity ?? 'unlabeled request';
-  return `job ${jobId} (${cmd}) force-released${override ? ' via --force override' : ''} — requested by "${requester}" — "${fileSlug}"'s mutation slot freed; any later reply from that script is discarded`;
+  return `job ${jobId} (${cmd})${priorState ? ` [${priorState}]` : ''} force-released${override ? ' via --force override' : ''} — requested by "${requester}" — "${fileSlug}"'s mutation slot freed; any later reply from that script is discarded`;
 }
 
 /** A FIFO slot owner that has not sent is cancelled, never force-released. */
@@ -1496,7 +1504,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (client && client.readyState === WebSocket.OPEN) {
       try { client.send(rawText); } catch { /* requester vanished */ }
     }
-    if (job && isFinishedState(job.state)) {
+    if (job && isReplyDiscardState(job.state)) {
       // Closing round (R1+R2 unified, reviewer Q1) — this job is ALREADY terminal
       // (force-released, watchdog-timed-out, or a genuine prior finish): this frame is
       // the actual pollution site the old code had — `job.replyFrames.push(rawText)` ran
@@ -1617,15 +1625,18 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
         });
         return;
       }
+      const priorState = rec.state;
       // The audited exit from a BLOCKED slot (phase 01's watchdog leaves it held on
       // purpose): record the override on the job, finish it for reporting if it was
       // still `running` (the watchdog may not have fired yet), then advance the queue —
       // never automatic, and the message states plainly that a later reply is discarded.
-      rec.forceReleased = true;
       if (rec.state === 'running') {
+        rec.forceReleased = true;
         st.jobs.finish(jobId, false, [errReplyFrame(rec.requestId, 'E_TIMEOUT',
           'force-released — the script may still be running; its result (if any) is discarded and unverified')]);
         recordContention(rec);
+      } else if (rec.state !== 'outcome-unknown') {
+        rec.forceReleased = true;
       }
       // Stage-4 fix round (M4, ruling Q1) — "discarded means discarded": if the wedged
       // script DOES eventually reply, `routeFromPlugin` must not forward it to a CLI that
@@ -1635,9 +1646,19 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.pending.delete(rec.requestId);
       st.dispatchedTo.delete(rec.requestId);
       drainFileQueue(rec.fileSlug, rec.jobId);
+      // Unknown evidence becomes retention-eligible only AFTER the synchronous drain
+      // removed q.running. Before this line TTL/cap/frame shedding cannot erase the live
+      // slot holder; after it, the consumed recovery command is removed and normal
+      // bounded retention applies.
+      if (priorState === 'outcome-unknown' && !st.jobs.settleOutcomeUnknownRelease(jobId)) {
+        const reason = `job '${jobId}' slot was released, but unknown-outcome retention settlement failed`;
+        log(`invariant failure: ${reason}`);
+        sendReplyErr(ws, msg.id, 'E_PLUGIN_ERROR', reason);
+        return;
+      }
       // Audited: every force-release (allowed-wedged or `--force` override) logs WHO asked
       // and WHY, never silently — the requester's own `activity` label on this request.
-      log(buildForceReleaseAuditLine(jobId, rec.cmd, rec.fileSlug, override, msg.activity));
+      log(buildForceReleaseAuditLine(jobId, rec.cmd, rec.fileSlug, override, msg.activity, priorState));
       sendReplyOk(ws, msg.id, { ok: true });
       return;
     }
@@ -1682,7 +1703,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
           ...(rec.resultDropped === true && { resultDropped: true }),
           ...(rec.lateReplyCount !== undefined && rec.lateReplyCount > 0 && { lateReplyCount: rec.lateReplyCount }),
         }
-      : { job: info });
+      : {
+          job: info,
+          ...(rec.lateReplyCount !== undefined && rec.lateReplyCount > 0 && { lateReplyCount: rec.lateReplyCount }),
+        });
   };
 
   /** Broker-terminal durable pause/open control. It intentionally uses only the raw
@@ -1807,20 +1831,42 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (target !== ws) continue;
       const client = st.pending.get(id);
       const msg = 'Figma plugin disconnected mid-request';
-      if (client) sendReplyErr(client, id, 'E_NO_PLUGIN', msg);
       // Actual-send jobs own a `dispatchedTo` route. Finish the record for polling and
       // drain only if it owns the active FIFO slot; ordinary queued jobs are handled by
       // the pinned reservation/waiting-list scans after registry removal below.
       const job = st.jobs.byRequestId(id);
       if (job) {
-        st.jobs.finish(job.jobId, false, [errReplyFrame(id, 'E_NO_PLUGIN', msg)]);
-        recordContention(job);
-        const q = st.queues.get(job.fileSlug);
-        if (q && q.running === job.jobId) {
-          drainFileQueue(job.fileSlug, job.jobId);
-        } else if (q) {
-          st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
+        if (job.state === 'running' && !job.readOnly) {
+          const reason = 'plugin transport disconnected after dispatch';
+          if (st.jobs.markOutcomeUnknown(job.jobId, reason)) {
+            recordContention(job);
+            if (client) {
+              sendReplyErr(
+                client,
+                id,
+                'E_OUTCOME_UNKNOWN',
+                `${reason}; the canvas may or may not have changed. Inspect the canvas, then force-release the held slot.`,
+                { jobId: job.jobId, recovery: job.recovery },
+              );
+            }
+          }
+        } else {
+          if (client) sendReplyErr(client, id, 'E_NO_PLUGIN', msg);
+          if (job.state === 'queued') {
+            st.jobs.settleQueued(job.jobId, 'failed', [errReplyFrame(id, 'E_NO_PLUGIN', msg)]);
+          } else {
+            st.jobs.finish(job.jobId, false, [errReplyFrame(id, 'E_NO_PLUGIN', msg)]);
+          }
+          recordContention(job);
+          const q = st.queues.get(job.fileSlug);
+          if (q && q.running === job.jobId) {
+            drainFileQueue(job.fileSlug, job.jobId);
+          } else if (q) {
+            st.queues.set(job.fileSlug, removeFromQueue(q, job.jobId));
+          }
         }
+      } else if (client) {
+        sendReplyErr(client, id, 'E_NO_PLUGIN', msg);
       }
       st.pending.delete(id);
       st.dispatchedTo.delete(id);

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -917,6 +917,10 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   };
 
   const nextReadinessProbeId = (): string => `ap_${++readinessProbeCounter}_${Date.now()}`;
+  const parseRequestedTargetFileKey = (targetFileKey: unknown): string | undefined | null =>
+    targetFileKey === undefined
+      ? undefined
+      : exactTargetFileKey(typeof targetFileKey === 'string' ? targetFileKey : null);
   const pluginFileKey = (entry: PluginEntry<WebSocket>): string | null =>
     durableFileKey((entry.scene.fileKey as string | null | undefined) ?? null);
   const isAppReady = (entry: PluginEntry<WebSocket>): boolean =>
@@ -1121,9 +1125,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       log(`refused duplicate request id ${id}${duplicateJob ? ` (job ${duplicateJob.jobId})` : ' (parked)'}`);
       return;
     }
-    const requestedTargetFileKey = targetFileKey === undefined
-      ? undefined
-      : exactTargetFileKey(typeof targetFileKey === 'string' ? targetFileKey : null);
+    const requestedTargetFileKey = parseRequestedTargetFileKey(targetFileKey);
     if (targetFileKey !== undefined && requestedTargetFileKey === null) {
       sendReplyErr(from, id, 'E_INVALID_ARGS', 'targetFileKey must be a nonempty unpadded raw Figma fileKey');
       return;
@@ -1764,11 +1766,12 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
 
   /**
    * auto-connect slice 3 — `figma-agent cowork`. Broker-terminal (same precedent as
-   * PROJECT_BIND/JOB): resolves a target plugin ONCE using the SAME routing filter
-   * `admitRequest` uses (envelope `expectedFile`/`expectedInstance`, the standing
-   * runtime pin), registers a waiter keyed to that instance's file identity, and
-   * returns immediately — the actual reply is sent later, from `resolveCoworkWaiters`
-   * (piggybacked on the park-sweep interval) once the wait fires or expires.
+   * PROJECT_BIND/JOB): resolves a target plugin ONCE using the SAME selectors
+   * `admitRequest` uses (exact raw key, envelope `expectedFile`/`expectedInstance`,
+   * or the standing runtime pin), registers a waiter keyed to that instance's file
+   * identity, and returns immediately — the actual reply is sent later, from
+   * `resolveCoworkWaiters` (piggybacked on the park-sweep interval) once the wait
+   * fires or expires.
    */
   const handleCowork = (ws: WebSocket, msg: RequestMsg): void => {
     const params = msg.params as { waitMs?: unknown; timeoutMs?: unknown } | null;
@@ -1779,16 +1782,36 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     const requestedTimeoutMs = typeof params?.timeoutMs === 'number' && params.timeoutMs > 0 ? params.timeoutMs : 600_000;
     const timeoutMs = Math.min(requestedTimeoutMs, COWORK_MAX_TIMEOUT_MS);
 
+    const requestedTargetFileKey = parseRequestedTargetFileKey(msg.targetFileKey);
+    if (msg.targetFileKey !== undefined && requestedTargetFileKey === null) {
+      sendReplyErr(ws, msg.id, 'E_INVALID_ARGS', 'targetFileKey must be a nonempty unpadded raw Figma fileKey');
+      return;
+    }
+    if (requestedTargetFileKey !== undefined && (msg.expectedFile !== undefined || msg.expectedInstance !== undefined)) {
+      sendReplyErr(ws, msg.id, 'E_INVALID_ARGS', 'targetFileKey is mutually exclusive with expectedFile and expectedInstance');
+      return;
+    }
+
     const pin = targetInstancePin;
     const pinLive = pin !== null && st.registry.getByInstanceId(pin)?.ws.readyState === WebSocket.OPEN;
-    const filter = resolveRouteFilter(msg.expectedFile, currentFilter(), msg.expectedInstance, pinLive ? pin : null);
-    const hits = st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind });
-    const target = selectDispatchTarget(filter, hits);
+    const filter: RouteFilter = requestedTargetFileKey === undefined
+      ? resolveRouteFilter(msg.expectedFile, currentFilter(), msg.expectedInstance, pinLive ? pin : null)
+      : { value: null, exact: true, source: 'none', kind: 'name' };
+    const target = requestedTargetFileKey === undefined
+      ? selectDispatchTarget(filter, st.registry.matching(filter.value, { exact: filter.exact, kind: filter.kind }))
+      : st.registry.liveEntries().find((entry) => pluginFileKey(entry) === requestedTargetFileKey) ?? null;
     if (!target) {
       // No plugin to watch at all — cowork has nothing to wait ON, unlike an ordinary
       // command (which can park for a not-yet-connected plugin). Fails fast rather than
       // silently waiting out the full budget for a file that was never open.
-      sendReplyErr(ws, msg.id, 'E_NO_PLUGIN', noPluginMessage(st.registry, filter));
+      sendReplyErr(
+        ws,
+        msg.id,
+        'E_NO_PLUGIN',
+        requestedTargetFileKey === undefined
+          ? noPluginMessage(st.registry, filter)
+          : `no live plugin matches targetFileKey ${JSON.stringify(requestedTargetFileKey)}`,
+      );
       return;
     }
     if (!isAppReady(target)) {

--- a/cli/src/transport/broker-peek.ts
+++ b/cli/src/transport/broker-peek.ts
@@ -4,7 +4,10 @@
 // if one looks live, asks that broker ONE short question with its own deadline.
 import {
   BROKER_FILE,
+  APP_READINESS_VERSION,
   PROTOCOL_VERSION,
+  type AppHeartbeatMode,
+  type AppState,
   type MutationGateRow,
   type MutationGateStoreHealth,
   type PluginStatusEntry,
@@ -22,6 +25,10 @@ export interface PeekPluginEntry {
   protocolV?: number;
   versionMatch: boolean | null;
   protocolMatch: boolean | null;
+  appReady: boolean | null;
+  appState: AppState;
+  appHeartbeatMode: AppHeartbeatMode;
+  appReadinessAge: number | null;
 }
 
 export interface PeekResult {
@@ -32,7 +39,15 @@ export interface PeekResult {
   idle?: true;
   reason?: string;
   degraded?: string;
-  broker: { port: number; pid: number; protocolVersion?: number; uptimeMs?: number; targetFileKeyAdmissionV?: 1 } | null;
+  broker: {
+    port: number;
+    pid: number;
+    protocolVersion?: number;
+    uptimeMs?: number;
+    targetFileKeyAdmissionV?: 1;
+    appReadinessVersion?: number;
+    appReadinessVersionMatch?: boolean | null;
+  } | null;
   plugins?: PeekPluginEntry[];
   cliVersion: string;
   versionMatch?: boolean | null;
@@ -44,6 +59,20 @@ export interface PeekResult {
 /** `undefined` (the field was never sent) is UNKNOWN, not a mismatch. */
 function matchOrNull(actual: string | number | undefined, expected: string | number): boolean | null {
   return actual === undefined ? null : actual === expected;
+}
+
+/** Readiness is additive: an old or unsupported broker must never be guessed ready. */
+export function projectReadiness(
+  plugin: Pick<PluginStatusEntry, 'appReady' | 'appState' | 'appHeartbeatMode' | 'appReadinessAge'>,
+  brokerVersion: number | undefined,
+): Pick<PeekPluginEntry, 'appReady' | 'appState' | 'appHeartbeatMode' | 'appReadinessAge'> {
+  const supported = brokerVersion === APP_READINESS_VERSION;
+  return {
+    appReady: supported && typeof plugin.appReady === 'boolean' ? plugin.appReady : null,
+    appState: supported && plugin.appState !== undefined ? plugin.appState : 'unknown',
+    appHeartbeatMode: supported && plugin.appHeartbeatMode !== undefined ? plugin.appHeartbeatMode : 'unknown',
+    appReadinessAge: supported && typeof plugin.appReadinessAge === 'number' ? plugin.appReadinessAge : null,
+  };
 }
 
 function describeError(err: unknown): string {
@@ -116,6 +145,8 @@ export async function peek(opts?: { path?: string; queryMs?: number }): Promise<
     };
   }
   const hello = outcome.value;
+  const rawReadinessVersion = typeof hello.appReadinessV === 'number' ? hello.appReadinessV : undefined;
+  const readinessSupported = rawReadinessVersion === APP_READINESS_VERSION;
 
   const rawPlugins = Array.isArray(hello.plugins) ? (hello.plugins as PluginStatusEntry[]) : [];
   const plugins: PeekPluginEntry[] = rawPlugins.map((p) => ({
@@ -126,6 +157,7 @@ export async function peek(opts?: { path?: string; queryMs?: number }): Promise<
     ...(p.protocolV !== undefined && { protocolV: p.protocolV }),
     versionMatch: matchOrNull(p.pluginVersion, CLI_VERSION),
     protocolMatch: matchOrNull(p.protocolV, PROTOCOL_VERSION),
+    ...projectReadiness(p, rawReadinessVersion),
   }));
 
   const activeFileName = (hello.activePlugin as string | null | undefined) ?? null;
@@ -139,6 +171,8 @@ export async function peek(opts?: { path?: string; queryMs?: number }): Promise<
       protocolVersion: (hello.protocolV as number | undefined) ?? PROTOCOL_VERSION,
       uptimeMs: (hello.uptimeMs as number | undefined) ?? undefined,
       ...(hello.targetFileKeyAdmissionV === 1 && { targetFileKeyAdmissionV: 1 as const }),
+      ...(rawReadinessVersion !== undefined && { appReadinessVersion: rawReadinessVersion }),
+      appReadinessVersionMatch: rawReadinessVersion === undefined ? null : readinessSupported,
     },
     plugins,
     cliVersion: CLI_VERSION,

--- a/cli/src/transport/broker-status.ts
+++ b/cli/src/transport/broker-status.ts
@@ -2,7 +2,7 @@
 // (`figma-agent status` reads it) and the E_NO_PLUGIN message. Kept out of
 // broker-daemon.ts so both are unit-testable without a live socket.
 import type { PluginRegistry, RegistrySocket } from './plugin-registry.ts';
-import type { JobInfo, MutationGateRow, MutationGateStoreHealth, PluginStatusEntry } from '../../../shared/protocol.ts';
+import { APP_READINESS_VERSION, type JobInfo, type MutationGateRow, type MutationGateStoreHealth, type PluginStatusEntry } from '../../../shared/protocol.ts';
 import type { RouteFilter } from './route-filter.ts';
 import { fileIdentity } from './file-identity.ts';
 
@@ -82,6 +82,7 @@ export function buildBrokerHelloData(
     port: meta.port,
     pid: meta.pid,
     protocolV: meta.protocolV,
+    appReadinessV: APP_READINESS_VERSION,
     // Capability, not a protocol-version bump: a bundled current broker can enforce an
     // exact `targetFileKey` admission assertion while older brokers simply omit it.
     targetFileKeyAdmissionV: 1,

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -48,7 +48,7 @@ function recoveryFor(jobId: string): JobRecovery {
 /**
  * Whether a job is a HEALTHY, still-running slot holder — the watchdog has not (yet)
  * declared it wedged. A job the watchdog already timed out has `state !== 'running'`
- * (the watchdog calls `finish()`) even though it may still hold its file's mutation
+ * (the watchdog calls `finishHeld()`) even though it may still hold its file's mutation
  * slot; that job is NOT healthy, and force-releasing it is the legitimate unwedge path.
  * Only a job still genuinely `running`, with a `startedAt` inside the watchdog window,
  * counts as healthy — the one case `job --force-release` (without `--force`) must refuse.
@@ -124,8 +124,12 @@ export interface JobRecord extends JobInfo {
    * *why* the result is gone rather than returning nothing.
    */
   resultDropped?: boolean;
-  /** Set by `job <id> --force-release` (phase 02) — an audited override, never automatic. */
+  /** Set after an audited command or transport-close path safely releases the held slot. */
   forceReleased?: boolean;
+  /** Internal only: terminal evidence for a mutation slot that remains live. It is not
+   *  retention-eligible until the daemon's audited release has synchronously removed
+   *  that slot from its file queue. */
+  retentionHeld?: boolean;
   /** Internal only (never serialized onto the wire — see `toJobInfo`): when this record
    *  was created, the basis `queuedMs` is measured from. */
   createdAt: number;
@@ -302,6 +306,39 @@ export class JobTable {
     this.finishedOrder.push(jobId);
     this.enforceFinishedCap();
     this.enforceByteBudget();
+  }
+
+  /**
+   * Record a watchdog timeout (or an explicit override) while the file queue still owns
+   * this job. The terminal outcome remains pollable, but cannot enter TTL/cap/frame
+   * retention yet: evicting it would orphan the queue's live owner id. Only the daemon's
+   * audited release may call `settleHeldTerminalRelease` after draining that queue.
+   */
+  finishHeld(jobId: string, ok: boolean, rawReply: string[]): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.state !== 'running') return false;
+    rec.state = ok ? 'done' : 'failed';
+    rec.finishedAt = this.now();
+    rec.replyFrames = rawReply;
+    rec.retentionHeld = true;
+    delete rec.dispatchState;
+    return true;
+  }
+
+  /**
+   * Enroll a previously-held terminal record only after its queue owner was synchronously
+   * released. TTL starts here rather than at the watchdog/override observation time.
+   */
+  settleHeldTerminalRelease(jobId: string): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.retentionHeld !== true || !isFinishedState(rec.state)) return false;
+    rec.forceReleased = true;
+    rec.finishedAt = this.now();
+    delete rec.retentionHeld;
+    this.finishedOrder.push(jobId);
+    this.enforceFinishedCap();
+    this.enforceByteBudget();
+    return true;
   }
 
   /** Refuses a RUNNING job — the sandbox cannot interrupt a live `eval`. */

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -12,7 +12,7 @@
 // The daemon (broker-daemon.ts) owns the single instance and is the only caller that
 // ever touches a real WebSocket.
 import type WebSocket from 'ws';
-import type { JobInfo } from '../../../shared/protocol.ts';
+import type { JobInfo, JobRecovery } from '../../../shared/protocol.ts';
 
 export const JOB_TTL_MS = 10 * 60_000;               // finished results stay retrievable this long — BEST EFFORT
 export const JOB_FINISHED_CAP = 200;                 // hard cap on FINISHED records; live jobs are NEVER capped
@@ -26,6 +26,23 @@ const FINISHED_STATES = new Set<JobInfo['state']>(['done', 'failed', 'cancelled'
  *  comparison is written once, not re-derived at each call site. */
 export function isFinishedState(state: JobInfo['state']): boolean {
   return FINISHED_STATES.has(state);
+}
+
+export function isPollSettledState(state: JobInfo['state']): boolean {
+  return isFinishedState(state) || state === 'outcome-unknown';
+}
+
+export function isReplyDiscardState(state: JobInfo['state']): boolean {
+  return isPollSettledState(state);
+}
+
+function recoveryFor(jobId: string): JobRecovery {
+  return {
+    kind: 'inspect-and-force-release',
+    command: `figma-agent job ${jobId} --force-release`,
+    requiresCanvasInspection: true,
+    retryAllowed: false,
+  };
 }
 
 /**
@@ -135,6 +152,8 @@ export function toJobInfo(rec: JobRecord): JobInfo {
   if (rec.startedAt !== undefined) info.startedAt = rec.startedAt;
   if (rec.finishedAt !== undefined) info.finishedAt = rec.finishedAt;
   if (rec.dispatchState !== undefined) info.dispatchState = rec.dispatchState;
+  if (rec.uncertaintyReason !== undefined) info.uncertaintyReason = rec.uncertaintyReason;
+  if (rec.recovery !== undefined) info.recovery = rec.recovery;
   return info;
 }
 
@@ -227,6 +246,32 @@ export class JobTable {
     this.transitionQueuedToRunning(jobId);
   }
 
+  /** Only an actually-running dispatch can lose a reply channel after execution may start. */
+  markOutcomeUnknown(jobId: string, reason: string): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.state !== 'running') return false;
+    rec.state = 'outcome-unknown';
+    rec.uncertaintyReason = reason;
+    rec.recovery = recoveryFor(jobId);
+    return true;
+  }
+
+  /**
+   * Make an inspected unknown outcome retention-eligible after its queue slot is released.
+   * The daemon must call this only after synchronously removing the live queue pointer.
+   */
+  settleOutcomeUnknownRelease(jobId: string): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.state !== 'outcome-unknown' || rec.forceReleased === true) return false;
+    rec.forceReleased = true;
+    rec.finishedAt = this.now();
+    delete rec.recovery;
+    this.finishedOrder.push(jobId);
+    this.enforceFinishedCap();
+    this.enforceByteBudget();
+    return true;
+  }
+
   /**
    * Store the verbatim reply and finish the job — called even when no CLI is listening.
    *
@@ -246,7 +291,7 @@ export class JobTable {
   finish(jobId: string, ok: boolean, rawReply: string[]): void {
     const rec = this.jobs.get(jobId);
     if (!rec) return;
-    if (FINISHED_STATES.has(rec.state)) {
+    if (isReplyDiscardState(rec.state)) {
       rec.lateReplyCount = (rec.lateReplyCount ?? 0) + 1;
       return;
     }

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -94,6 +94,10 @@ export interface JobRecord extends JobInfo {
    * it waited.
    */
   targetInstanceId: string;
+  /** Immutable raw identity and gate revision captured at admission for mutation
+   *  revalidation when this job eventually owns the FIFO slot. */
+  targetFileKey?: string;
+  admissionRevision?: number;
   /** Reply frame(s), verbatim and in order (a chunked reply arrives as many). */
   replyFrames: string[];
   readOnly: boolean;
@@ -130,6 +134,7 @@ export function toJobInfo(rec: JobRecord): JobInfo {
   if (rec.queuedMs !== undefined) info.queuedMs = rec.queuedMs;
   if (rec.startedAt !== undefined) info.startedAt = rec.startedAt;
   if (rec.finishedAt !== undefined) info.finishedAt = rec.finishedAt;
+  if (rec.dispatchState !== undefined) info.dispatchState = rec.dispatchState;
   return info;
 }
 
@@ -148,6 +153,8 @@ export interface CreateJobInput {
   requestFrames: string[];
   from: WebSocket | null;
   targetInstanceId: string;
+  targetFileKey?: string;
+  admissionRevision?: number;
 }
 
 export class JobTable {
@@ -182,6 +189,8 @@ export class JobTable {
       requestFrames: input.requestFrames,
       from: input.from,
       targetInstanceId: input.targetInstanceId,
+      ...(input.targetFileKey !== undefined && { targetFileKey: input.targetFileKey }),
+      ...(input.admissionRevision !== undefined && { admissionRevision: input.admissionRevision }),
       replyFrames: [],
       readOnly: input.readOnly,
       createdAt: this.now(),
@@ -193,13 +202,29 @@ export class JobTable {
 
   /** Stamps `queuedMs` from `createdAt` — the evidence for the subtree-lock upgrade
    *  trigger (locked decision 6: revisit only when this measures > 5 min/day for real). */
-  markRunning(jobId: string): void {
+  markDispatchReserved(jobId: string): boolean {
     const rec = this.jobs.get(jobId);
-    if (!rec) return;
+    if (!rec || rec.state !== 'queued') return false;
+    rec.dispatchState = 'queued-not-dispatched-readiness-wait';
+    delete rec.queuePosition;
+    return true;
+  }
+
+  transitionQueuedToRunning(jobId: string): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.state !== 'queued') return false;
     rec.state = 'running';
     rec.startedAt = this.now();
     rec.queuedMs = rec.startedAt - rec.createdAt;
     delete rec.queuePosition;
+    delete rec.dispatchState;
+    return true;
+  }
+
+  /** Compatibility wrapper for existing callers/tests; new daemon dispatch paths use
+   *  the guarded boolean transition directly. */
+  markRunning(jobId: string): void {
+    this.transitionQueuedToRunning(jobId);
   }
 
   /**
@@ -228,6 +253,7 @@ export class JobTable {
     rec.state = ok ? 'done' : 'failed';
     rec.finishedAt = this.now();
     rec.replyFrames = rawReply;
+    delete rec.dispatchState;
     this.finishedOrder.push(jobId);
     this.enforceFinishedCap();
     this.enforceByteBudget();
@@ -241,15 +267,23 @@ export class JobTable {
       return { ok: false, reason: 'the plugin sandbox cannot interrupt a running script — only a QUEUED job can be cancelled' };
     }
     if (rec.state !== 'queued') return { ok: false, reason: `job is already ${rec.state}` };
-    rec.state = 'cancelled';
+    return this.settleQueued(jobId, 'cancelled', replyFrames) ? { ok: true } : { ok: false, reason: `job is already ${rec.state}` };
+  }
+
+  /** Known-not-dispatched settlement. It can never overwrite running or terminal work. */
+  settleQueued(jobId: string, state: 'failed' | 'cancelled', replyFrames: string[]): boolean {
+    const rec = this.jobs.get(jobId);
+    if (!rec || rec.state !== 'queued') return false;
+    rec.state = state;
     rec.finishedAt = this.now();
     rec.queuedMs = rec.finishedAt - rec.createdAt;
     rec.replyFrames = replyFrames;
     delete rec.queuePosition;
+    delete rec.dispatchState;
     this.finishedOrder.push(jobId);
     this.enforceFinishedCap();
     this.enforceByteBudget();
-    return { ok: true };
+    return true;
   }
 
   /** Three answers, not two: `'expired'` (aged out / capped) is a different fact from
@@ -280,13 +314,16 @@ export class JobTable {
    * Wire-safe (`toJobInfo`) — `running` must never carry the record's own `from`
    * WebSocket onto a JSON envelope.
    */
-  summaryFor(fileSlug: string, runningJobId: string | null): { running: JobInfo | null; queueDepth: number } {
-    const runningRec = runningJobId !== null ? this.jobs.get(runningJobId) : undefined;
-    let queueDepth = 0;
-    for (const rec of this.jobs.values()) {
-      if (rec.fileSlug === fileSlug && rec.state === 'queued') queueDepth++;
-    }
-    return { running: runningRec ? toJobInfo(runningRec) : null, queueDepth };
+  summaryFor(
+    _fileSlug: string,
+    queue: { slotOwnerId: string | null; waitingDepth: number } | string | null,
+  ): { running: JobInfo | null; queueDepth: number } {
+    const slotOwnerId = typeof queue === 'object' && queue !== null ? queue.slotOwnerId : queue;
+    const runningRec = slotOwnerId !== null ? this.jobs.get(slotOwnerId) : undefined;
+    const waitingDepth = typeof queue === 'object' && queue !== null
+      ? queue.waitingDepth
+      : [...this.jobs.values()].filter((rec) => rec.fileSlug === _fileSlug && rec.state === 'queued' && rec.jobId !== slotOwnerId).length;
+    return { running: runningRec ? toJobInfo(runningRec) : null, queueDepth: waitingDepth };
   }
 
   /** Every currently RUNNING job, across all files — the watchdog's own sweep target

--- a/cli/src/transport/plugin-registry.ts
+++ b/cli/src/transport/plugin-registry.ts
@@ -4,7 +4,13 @@
 // evict each other on every PLUGIN_HELLO (the connect/disconnect flapping bug).
 // Nothing here touches a socket beyond reading `readyState`, so the whole routing
 // / cull / status contract is pure and unit-testable with fake sockets.
-import type { PluginScene, PluginStatusEntry } from '../../../shared/protocol.ts';
+import {
+  PLUGIN_PONG_TIMEOUT_MS,
+  type AppHeartbeatMode,
+  type AppState,
+  type PluginScene,
+  type PluginStatusEntry,
+} from '../../../shared/protocol.ts';
 import { fileMatches } from '../../../shared/file-match.ts';
 import { envMs } from './protocol-helpers.ts';
 import type { FilterKind } from './route-filter.ts';
@@ -83,10 +89,48 @@ export interface PluginEntry<S extends RegistrySocket = RegistrySocket> {
   // computed versionMatch/protocolMatch comparison lives in broker-peek.ts.
   pluginVersion?: string;
   protocolV?: number;
+  /** Readiness capabilities as advertised by this HELLO. Kept separate from scene
+   *  identity so capability negotiation cannot accidentally influence file matching. */
+  appHeartbeatMode: AppHeartbeatMode;
 }
 
 // HELLO payload keys that are protocol plumbing, not scene identity.
 const PROTOCOL_KEYS = new Set(['instanceId', 'pluginVersion', 'protocolV']);
+
+function heartbeatMode(data: Record<string, unknown>): AppHeartbeatMode {
+  const caps = Array.isArray(data.caps) ? data.caps.filter((cap): cap is string => typeof cap === 'string') : [];
+  const correlated = caps.includes('correlatedHeartbeatV1');
+  const probe = caps.includes('appProbeV1');
+  if (!correlated && !probe) return 'legacy';
+  return correlated && probe ? 'correlated' : 'unknown';
+}
+
+export interface AppReadinessProjection {
+  appReady: boolean | null;
+  appState: AppState;
+  appHeartbeatMode: AppHeartbeatMode;
+  appReadinessAge: number;
+}
+
+/** Pure readiness projection. Equality stays ready: Phase 1 expires only after its
+ *  deadline has passed, so the broker uses the same exact boundary. */
+export function appReadiness<S extends RegistrySocket>(
+  entry: PluginEntry<S>,
+  now: number,
+  leaseMs: number = PLUGIN_PONG_TIMEOUT_MS,
+): AppReadinessProjection {
+  const appReadinessAge = Math.max(0, now - entry.lastAppFrameAt);
+  if (entry.appHeartbeatMode === 'unknown') {
+    return { appReady: null, appState: 'unknown', appHeartbeatMode: 'unknown', appReadinessAge };
+  }
+  const appReady = appReadinessAge <= leaseMs;
+  return {
+    appReady,
+    appState: appReady ? 'ready' : 'unready',
+    appHeartbeatMode: entry.appHeartbeatMode,
+    appReadinessAge,
+  };
+}
 
 /** Strip protocol keys from a HELLO/FILE_INFO payload → the scene subset. */
 export function extractScene(data: Record<string, unknown> | null | undefined): PluginScene {
@@ -186,6 +230,7 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
       // version, never a stale one left over from the superseded socket.
       pluginVersion: typeof data.pluginVersion === 'string' ? data.pluginVersion : undefined,
       protocolV: typeof data.protocolV === 'number' ? data.protocolV : undefined,
+      appHeartbeatMode: heartbeatMode(data),
     });
     return { instanceId: id, replaced: existing !== undefined, superseded };
   }
@@ -351,6 +396,13 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
     return this.matching(filter, opts)[0] ?? null;
   }
 
+  /** Dispatch-only selection: explicit callers resolve identity with `selectTarget`,
+   *  while an unfiltered request may choose only a currently ready entry. */
+  selectReadyTarget(): PluginEntry<S> | null {
+    const now = this.now();
+    return this.matching().find((entry) => appReadiness(entry, now).appReady === true) ?? null;
+  }
+
   /** The per-file list for BROKER_HELLO / `figma-agent status`, most-recent first. */
   statusList(): PluginStatusEntry[] {
     const now = this.now();
@@ -358,6 +410,7 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
       .sort((a, b) => b.lastSeenAt - a.lastSeenAt)
       .map((e) => {
         const reason = zombieReason(e, now, FROZEN_AFTER_MS);
+        const readiness = appReadiness(e, now);
         return {
           instanceId: e.instanceId,
           fileName: (e.scene.fileName as string | undefined) ?? null,
@@ -378,6 +431,7 @@ export class PluginRegistry<S extends RegistrySocket = RegistrySocket> {
           // contract as reHelloCount/suspectedZombie above.
           ...(e.pluginVersion !== undefined && { pluginVersion: e.pluginVersion }),
           ...(e.protocolV !== undefined && { protocolV: e.protocolV }),
+          ...readiness,
         };
       });
   }

--- a/cli/src/transport/protocol-helpers.ts
+++ b/cli/src/transport/protocol-helpers.ts
@@ -6,6 +6,7 @@ import {
   type ChunkMsg,
   type ErrorCode,
   type EventMsg,
+  type JobRecovery,
   type ReplyMsg,
   type RequestMsg,
   type WireMsg,
@@ -24,12 +25,14 @@ export class CliError extends Error {
    * retrievable (`figma-agent job <id>`) — retrying would double-dispatch instead.
    */
   readonly jobId?: string;
-  constructor(code: ErrorCode, message: string, opts?: { rolledBack?: boolean; jobId?: string }) {
+  readonly recovery?: JobRecovery;
+  constructor(code: ErrorCode, message: string, opts?: { rolledBack?: boolean; jobId?: string; recovery?: JobRecovery }) {
     super(message);
     this.name = 'CliError';
     this.code = code;
     if (opts?.rolledBack) this.rolledBack = opts.rolledBack;
     if (opts?.jobId !== undefined) this.jobId = opts.jobId;
+    if (opts?.recovery !== undefined) this.recovery = opts.recovery;
   }
 }
 

--- a/cli/src/util/json-out.ts
+++ b/cli/src/util/json-out.ts
@@ -39,6 +39,7 @@ export function printErrorJson(err: unknown, fileContext?: FileContext): never {
           // E_TIMEOUT that confirmed a real job exists, so a caller (or a script driving
           // this CLI) can poll `figma-agent job <id>` without re-parsing the message.
           ...(err.jobId !== undefined ? { jobId: err.jobId } : {}),
+          ...(err.recovery !== undefined ? { recovery: err.recovery } : {}),
         }
       : { code: 'E_INTERNAL', message: err instanceof Error ? err.message : String(err) };
   const payload = fileContext ? { error, fileContext } : { error };

--- a/plugin/src/ui/heartbeat-driver.ts
+++ b/plugin/src/ui/heartbeat-driver.ts
@@ -1,0 +1,98 @@
+import {
+  reduceHeartbeatLease,
+  startHeartbeatLease,
+  type HeartbeatLeaseConfig,
+  type HeartbeatLeaseDecision,
+  type HeartbeatLeaseState,
+  type HeartbeatMode,
+} from './heartbeat-lease';
+
+export interface HeartbeatDriverPorts {
+  now: () => number;
+  nextProbeId: () => string;
+  schedule: (callback: () => void, intervalMs: number) => unknown;
+  cancel: (handle: unknown) => void;
+  sendProbe: (probeId: string, mode: HeartbeatMode) => void;
+  teardown: (reason: string) => void;
+  emitConnected: () => void;
+}
+
+export interface HeartbeatDriver {
+  start(mode: HeartbeatMode): void;
+  stop(): void;
+  receivePong(probeId?: string): boolean;
+}
+
+export function createHeartbeatDriver(
+  ports: HeartbeatDriverPorts,
+  config: HeartbeatLeaseConfig,
+): HeartbeatDriver {
+  let scheduleHandle: unknown;
+  let generation = 0;
+  let lease: HeartbeatLeaseState | null = null;
+  let connectedEmitted = false;
+
+  function stop(): void {
+    generation += 1;
+    lease = null;
+    connectedEmitted = false;
+    if (scheduleHandle !== undefined) {
+      ports.cancel(scheduleHandle);
+      scheduleHandle = undefined;
+    }
+  }
+
+  function apply(decision: HeartbeatLeaseDecision): boolean {
+    lease = decision.state;
+    let accepted = false;
+    for (const effect of decision.effects) {
+      if (effect.type === 'send-challenge') {
+        try {
+          ports.sendProbe(effect.probeId, decision.state.mode);
+        } catch {
+          stop();
+          ports.teardown('ping failed — reconnecting…');
+          break;
+        }
+      } else if (effect.type === 'accepted-current') {
+        accepted = true;
+        if (!connectedEmitted) {
+          connectedEmitted = true;
+          ports.emitConnected();
+        }
+      } else {
+        stop();
+        ports.teardown('heartbeat lost — reconnecting…');
+        break;
+      }
+    }
+    return accepted;
+  }
+
+  return {
+    start(mode) {
+      stop();
+      const started = startHeartbeatLease(mode, ports.now(), ports.nextProbeId(), config);
+      apply(started);
+      if (lease === null) return;
+      const activeGeneration = generation;
+      scheduleHandle = ports.schedule(() => {
+        if (activeGeneration !== generation || lease === null) return;
+        apply(reduceHeartbeatLease(lease, {
+          type: 'tick',
+          now: ports.now(),
+          nextProbeId: ports.nextProbeId(),
+        }, config));
+      }, config.intervalMs);
+    },
+    stop,
+    receivePong(probeId) {
+      if (lease === null) return false;
+      return apply(reduceHeartbeatLease(lease, {
+        type: 'pong',
+        now: ports.now(),
+        probeId,
+      }, config));
+    },
+  };
+}

--- a/plugin/src/ui/heartbeat-lease.ts
+++ b/plugin/src/ui/heartbeat-lease.ts
@@ -1,0 +1,111 @@
+export type HeartbeatMode = 'correlated' | 'legacy';
+export type HeartbeatLeasePhase = 'probing' | 'ready' | 'suspect';
+
+export interface HeartbeatLeaseState {
+  mode: HeartbeatMode;
+  phase: HeartbeatLeasePhase;
+  currentProbeId: string | null;
+  sentAt: number | null;
+  deadline: number | null;
+  lastTickAt: number;
+}
+
+export interface HeartbeatLeaseConfig {
+  intervalMs: number;
+  timeoutMs: number;
+}
+
+export type HeartbeatLeaseEffect =
+  | { type: 'send-challenge'; probeId: string }
+  | { type: 'accepted-current' }
+  | { type: 'teardown' };
+
+export type HeartbeatLeaseEvent =
+  | { type: 'tick'; now: number; nextProbeId: string }
+  | { type: 'pong'; now: number; probeId?: string };
+
+export interface HeartbeatLeaseDecision {
+  state: HeartbeatLeaseState;
+  effects: HeartbeatLeaseEffect[];
+}
+
+function challenge(
+  state: HeartbeatLeaseState,
+  now: number,
+  probeId: string,
+  timeoutMs: number,
+  phase: HeartbeatLeasePhase,
+): HeartbeatLeaseDecision {
+  return {
+    state: {
+      ...state,
+      phase,
+      currentProbeId: probeId,
+      sentAt: now,
+      deadline: now + timeoutMs,
+      lastTickAt: now,
+    },
+    effects: [{ type: 'send-challenge', probeId }],
+  };
+}
+
+export function startHeartbeatLease(
+  mode: HeartbeatMode,
+  now: number,
+  probeId: string,
+  config: HeartbeatLeaseConfig,
+): HeartbeatLeaseDecision {
+  return challenge({
+    mode,
+    phase: 'probing',
+    currentProbeId: null,
+    sentAt: null,
+    deadline: null,
+    lastTickAt: now,
+  }, now, probeId, config.timeoutMs, 'probing');
+}
+
+export function reduceHeartbeatLease(
+  state: HeartbeatLeaseState,
+  event: HeartbeatLeaseEvent,
+  config: HeartbeatLeaseConfig,
+): HeartbeatLeaseDecision {
+  if (event.type === 'pong') {
+    const accepted = state.currentProbeId !== null && (
+      state.mode === 'correlated'
+        ? event.probeId === state.currentProbeId
+        : event.probeId === undefined
+    );
+    if (!accepted) return { state, effects: [] };
+    return {
+      state: {
+        ...state,
+        phase: 'ready',
+        currentProbeId: null,
+        sentAt: null,
+        deadline: null,
+      },
+      effects: [{ type: 'accepted-current' }],
+    };
+  }
+
+  const schedulerWasSuspended = event.now - state.lastTickAt > config.timeoutMs;
+  if (schedulerWasSuspended) {
+    return challenge(state, event.now, event.nextProbeId, config.timeoutMs, 'suspect');
+  }
+  if (state.phase === 'ready') {
+    return challenge(state, event.now, event.nextProbeId, config.timeoutMs, 'probing');
+  }
+
+  const expired = state.deadline !== null && event.now > state.deadline;
+  if (!expired) {
+    return { state: { ...state, lastTickAt: event.now }, effects: [] };
+  }
+  if (state.phase === 'probing') {
+    return challenge(state, event.now, event.nextProbeId, config.timeoutMs, 'suspect');
+  }
+  return {
+    state: { ...state, lastTickAt: event.now },
+    effects: [{ type: 'teardown' }],
+  };
+}

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -12,16 +12,19 @@
 // its opening transition below — otherwise the panel would miss the first PROBE.
 import './panel-ui';
 import {
-  CHUNK_LIMIT, PLUGIN_HEARTBEAT_INTERVAL_MS, PLUGIN_PONG_TIMEOUT_MS,
+  CHUNK_LIMIT, PLUGIN_CAPABILITIES, PLUGIN_HEARTBEAT_INTERVAL_MS, PLUGIN_PONG_TIMEOUT_MS,
   PORT_RANGE_END, PORT_RANGE_START, PROTOCOL_VERSION,
   RECONNECT_BACKOFF_MAX_MS, RECONNECT_BACKOFF_MIN_MS,
   makeStatePayload, nextBackoff, reduceConnState,
+  type BrokerHelloData,
   type ChunkMsg, type CommandName, type ConnectionEvent, type ConnectionState, type ConnectionStatePayload,
   type ErrorCode, type FileContext, type ReplyMsg, type RequestMsg, type WireError,
 } from '../../../shared/protocol';
 import { renderHtmlToPayload } from './render-host';
 import { renderGradientToPng, GradientRenderError } from './gradient-host';
 import { summarizeError, summarizeResult } from './activity-summary';
+import { createHeartbeatDriver } from './heartbeat-driver';
+import type { HeartbeatMode } from './heartbeat-lease';
 
 const PLUGIN_VERSION = '0.1.0';
 const PORT_PROBE_TIMEOUT_MS = 1200; // a real broker greets in <50ms; short = fast scan
@@ -38,8 +41,9 @@ const INSTANCE_ID: string =
 
 let ws: WebSocket | null = null;
 let backoffBase = 0; // grows via nextBackoff; reset to 0 (→ min) on a successful connect
-let heartbeatTimer: ReturnType<typeof setInterval> | null = null;
-let lastPongAt = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+let heartbeatMode: HeartbeatMode = 'legacy';
+let heartbeatProbeCounter = 0;
 let connState: ConnectionState = 'disconnected';
 let fileInfo: Record<string, unknown> = {}; // FILE_INFO from main (fileName, fileKey…)
 const chunkBuffers = new Map<string, string[]>(); // requestId → chunk slices
@@ -186,7 +190,18 @@ function handleWireData(raw: string): void {
   } catch {
     return; // malformed frame — ignore
   }
-  if (msg.type === 'PONG') { lastPongAt = Date.now(); return; } // heartbeat ack
+  if (msg.type === 'PONG') {
+    const data = (msg.data as Record<string, unknown> | undefined) ?? {};
+    heartbeatDriver.receivePong(typeof data.probeId === 'string' ? data.probeId : undefined);
+    return;
+  }
+  if (msg.type === 'APP_PROBE') {
+    const data = (msg.data as Record<string, unknown> | undefined) ?? {};
+    if (heartbeatMode === 'correlated' && typeof data.probeId === 'string') {
+      wsSend({ type: 'APP_PROBE_ACK', data: { probeId: data.probeId } });
+    }
+    return;
+  }
   // Live-sync (spec 004 P4). SYNC_CONFIG → main's idle timer; SYNC_RESULT → the panel.
   if (msg.type === 'SYNC_CONFIG') {
     parent.postMessage({ pluginMessage: { type: 'SYNC_CONFIG', data: msg.data ?? {} } }, '*');
@@ -421,29 +436,41 @@ window.addEventListener('message', (ev: MessageEvent) => {
 });
 
 // ─── App-level heartbeat: PING the broker, reconnect on a missed PONG ─
-function stopHeartbeat(): void {
-  if (heartbeatTimer !== null) { clearInterval(heartbeatTimer); heartbeatTimer = null; }
-}
-
-function startHeartbeat(socket: WebSocket): void {
-  stopHeartbeat();
-  lastPongAt = Date.now();
-  heartbeatTimer = setInterval(() => {
-    if (ws !== socket) { stopHeartbeat(); return; }
-    if (Date.now() - lastPongAt > PLUGIN_PONG_TIMEOUT_MS) {
-      teardown(socket, 'heartbeat lost — reconnecting…'); // half-open socket → recover
-      return;
-    }
-    try { socket.send(JSON.stringify({ type: 'PING', data: { t: Date.now() } })); }
-    catch { teardown(socket, 'ping failed — reconnecting…'); }
-  }, PLUGIN_HEARTBEAT_INTERVAL_MS);
-}
+const heartbeatDriver = createHeartbeatDriver({
+  now: Date.now,
+  nextProbeId: () => `hb_${INSTANCE_ID}_${++heartbeatProbeCounter}_${Date.now()}`,
+  schedule: (callback, intervalMs) => setInterval(callback, intervalMs),
+  cancel: (handle) => clearInterval(handle as ReturnType<typeof setInterval>),
+  sendProbe: (probeId, mode) => {
+    if (!ws || ws.readyState !== WebSocket.OPEN) throw new Error('socket unavailable');
+    ws.send(JSON.stringify({
+      type: 'PING',
+      data: { t: Date.now(), ...(mode === 'correlated' ? { probeId } : {}) },
+    }));
+  },
+  teardown: (reason) => {
+    if (ws) teardown(ws, reason);
+  },
+  emitConnected: () => {
+    if (!ws) return;
+    const { url, port } = socketConnectionInfo(ws);
+    transition('READY', {
+      detail: `broker at ${url} · protocol v${PROTOCOL_VERSION}`,
+      brokerUrl: url,
+      port,
+      appState: 'ready',
+    });
+  },
+}, {
+  intervalMs: PLUGIN_HEARTBEAT_INTERVAL_MS,
+  timeoutMs: PLUGIN_PONG_TIMEOUT_MS,
+});
 
 /** Tear one socket down once, then re-enter the reconnect loop. Idempotent per socket. */
 function teardown(socket: WebSocket, reason: string): void {
   if (ws !== socket) return; // already replaced / torn down
   ws = null;
-  stopHeartbeat();
+  heartbeatDriver.stop();
   transition('LOST', { detail: reason });
   try {
     socket.onclose = null; socket.onerror = null; socket.onmessage = null;
@@ -455,7 +482,12 @@ function teardown(socket: WebSocket, reason: string): void {
 // ─── Broker discovery: probe each port until BROKER_HELLO ───────────
 // Use a dedicated `.localhost` hostname. Figma Desktop can fail bare
 // `ws://localhost`, while its manifest rejects literal IP-address domains.
-function probePort(port: number, host: string): Promise<WebSocket | null> {
+interface BrokerProbe {
+  socket: WebSocket;
+  hello: BrokerHelloData;
+}
+
+function probePort(port: number, host: string): Promise<BrokerProbe | null> {
   return new Promise((resolve) => {
     let settled = false;
     let socket: WebSocket;
@@ -465,7 +497,7 @@ function probePort(port: number, host: string): Promise<WebSocket | null> {
       resolve(null);
       return;
     }
-    const finish = (result: WebSocket | null) => {
+    const finish = (result: BrokerProbe | null) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
@@ -478,7 +510,9 @@ function probePort(port: number, host: string): Promise<WebSocket | null> {
     socket.onmessage = (ev) => {
       try {
         const msg = JSON.parse(String(ev.data));
-        if (msg?.type === 'BROKER_HELLO') finish(socket);
+        if (msg?.type === 'BROKER_HELLO') {
+          finish({ socket, hello: (msg.data as BrokerHelloData | undefined) ?? {} });
+        }
       } catch { /* not the greeting — keep waiting until timeout */ }
     };
     socket.onerror = () => finish(null);
@@ -486,24 +520,38 @@ function probePort(port: number, host: string): Promise<WebSocket | null> {
   });
 }
 
-async function scanForBroker(): Promise<WebSocket | null> {
+async function scanForBroker(): Promise<BrokerProbe | null> {
   for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
     transition('PROBE', { detail: `probing figma-agent.localhost:${port}…`, port });
-    const socket = await probePort(port, 'figma-agent.localhost');
-    if (socket) return socket;
+    const probe = await probePort(port, 'figma-agent.localhost');
+    if (probe) return probe;
   }
   return null;
 }
 
-function adoptSocket(socket: WebSocket): void {
-  ws = socket;
-  backoffBase = 0; // reset backoff on a live connection
-  chunkBuffers.clear();
+function socketConnectionInfo(socket: WebSocket): { url: string; port?: number } {
   const url = socket.url.replace(/\/$/, '');
   const portMatch = /:(\d+)/.exec(url);
-  const port = portMatch ? Number(portMatch[1]) : undefined;
+  return { url, port: portMatch ? Number(portMatch[1]) : undefined };
+}
 
-  transition('FOUND', { detail: `broker at ${url}`, brokerUrl: url, port });
+function adoptSocket(probe: BrokerProbe): void {
+  const { socket, hello } = probe;
+  if (ws !== null) {
+    if (ws !== socket) try { socket.close(); } catch { /* superseded probe */ }
+    return;
+  }
+  ws = socket;
+  if (reconnectTimer !== null) {
+    clearTimeout(reconnectTimer);
+    reconnectTimer = null;
+  }
+  backoffBase = 0; // reset backoff on a live connection
+  chunkBuffers.clear();
+  heartbeatMode = hello.appReadinessV === 1 ? 'correlated' : 'legacy';
+  const { url, port } = socketConnectionInfo(socket);
+
+  transition('FOUND', { detail: `broker at ${url}`, brokerUrl: url, port, appState: 'probing' });
   socket.onmessage = (ev) => handleWireData(String(ev.data));
   socket.onerror = () => { /* onclose fires next and drives the reconnect */ };
   socket.onclose = () => teardown(socket, 'broker connection lost — reconnecting…');
@@ -512,33 +560,37 @@ function adoptSocket(socket: WebSocket): void {
   // instanceId is stable across reconnects so the broker updates this file's slot
   // instead of spawning a duplicate. `caps` advertises the guards this bundle honours —
   // the broker refuses to route a `--file` request to a plugin that predates `fileGuard`.
-  wsSend({ type: 'PLUGIN_HELLO', data: { ...fileInfo, instanceId: INSTANCE_ID, caps: ['fileGuard'],
+  wsSend({ type: 'PLUGIN_HELLO', data: { ...fileInfo, instanceId: INSTANCE_ID, caps: [...PLUGIN_CAPABILITIES],
                                           pluginVersion: PLUGIN_VERSION, protocolV: PROTOCOL_VERSION } });
   // `fileInfo` is normally populated by main's own FILE_INFO push, but that race is not
   // guaranteed to have landed yet — ask explicitly so an iframe-originated error raised
   // before the first push still has an identity to attach (see localFileContext above).
   if (Object.keys(fileInfo).length === 0) parent.postMessage({ pluginMessage: { type: 'UI_READY' } }, '*');
-  startHeartbeat(socket);
-  transition('READY', { detail: `broker at ${url} · protocol v${PROTOCOL_VERSION}`, brokerUrl: url, port });
+  heartbeatDriver.start(heartbeatMode);
 }
 
 function scheduleReconnect(): void {
+  if (ws !== null || reconnectTimer !== null) return;
   const { base, delay } = nextBackoff(backoffBase, BACKOFF_OPTS);
   backoffBase = base;
-  setTimeout(() => void connectLoop(), delay);
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void connectLoop();
+  }, delay);
 }
 
 async function connectLoop(): Promise<void> {
+  if (ws !== null) return;
   try {
-    const socket = await scanForBroker();
-    if (!socket) {
+    const probe = await scanForBroker();
+    if (!probe) {
       transition('PROBE', {
         detail: `no broker on :${PORT_RANGE_START}-${PORT_RANGE_END} — is a CLI command running? retrying…`,
       });
       scheduleReconnect();
       return;
     }
-    adoptSocket(socket);
+    adoptSocket(probe);
   } catch (err) {
     transition('LOST', { detail: err instanceof Error ? err.message : String(err) });
     scheduleReconnect();

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -986,6 +986,11 @@ body { overflow: hidden; }
 (() => {
   // shared/protocol.ts
   var PROTOCOL_VERSION = 1;
+  var PLUGIN_CAPABILITIES = [
+    "fileGuard",
+    "correlatedHeartbeatV1",
+    "appProbeV1"
+  ];
   var PORT_RANGE_START = 9410;
   var PORT_RANGE_END = 9419;
   var CHUNK_LIMIT = 512 * 1024;
@@ -2651,7 +2656,7 @@ body { overflow: hidden; }
     }, 4e3);
     render();
   });
-  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "e945a9d" : "dev"}`;
+  el("fga-version").textContent = `v0.1.0 \xB7 ${true ? "1b4fed6" : "dev"}`;
   replaceIcon(targetRailBtn, "files");
   replaceIcon(syncRailBtn, "refresh-cw");
   replaceIcon(toggleBtn, "chevron-down");
@@ -4247,6 +4252,134 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     return oneLine.length > MAX_ERROR_CHARS ? `${oneLine.slice(0, MAX_ERROR_CHARS - 1)}\u2026` : oneLine;
   }
 
+  // plugin/src/ui/heartbeat-lease.ts
+  function challenge(state, now, probeId, timeoutMs, phase) {
+    return {
+      state: {
+        ...state,
+        phase,
+        currentProbeId: probeId,
+        sentAt: now,
+        deadline: now + timeoutMs,
+        lastTickAt: now
+      },
+      effects: [{ type: "send-challenge", probeId }]
+    };
+  }
+  function startHeartbeatLease(mode, now, probeId, config) {
+    return challenge({
+      mode,
+      phase: "probing",
+      currentProbeId: null,
+      sentAt: null,
+      deadline: null,
+      lastTickAt: now
+    }, now, probeId, config.timeoutMs, "probing");
+  }
+  function reduceHeartbeatLease(state, event, config) {
+    if (event.type === "pong") {
+      const accepted = state.currentProbeId !== null && (state.mode === "correlated" ? event.probeId === state.currentProbeId : event.probeId === void 0);
+      if (!accepted) return { state, effects: [] };
+      return {
+        state: {
+          ...state,
+          phase: "ready",
+          currentProbeId: null,
+          sentAt: null,
+          deadline: null
+        },
+        effects: [{ type: "accepted-current" }]
+      };
+    }
+    const schedulerWasSuspended = event.now - state.lastTickAt > config.timeoutMs;
+    if (schedulerWasSuspended) {
+      return challenge(state, event.now, event.nextProbeId, config.timeoutMs, "suspect");
+    }
+    if (state.phase === "ready") {
+      return challenge(state, event.now, event.nextProbeId, config.timeoutMs, "probing");
+    }
+    const expired = state.deadline !== null && event.now > state.deadline;
+    if (!expired) {
+      return { state: { ...state, lastTickAt: event.now }, effects: [] };
+    }
+    if (state.phase === "probing") {
+      return challenge(state, event.now, event.nextProbeId, config.timeoutMs, "suspect");
+    }
+    return {
+      state: { ...state, lastTickAt: event.now },
+      effects: [{ type: "teardown" }]
+    };
+  }
+
+  // plugin/src/ui/heartbeat-driver.ts
+  function createHeartbeatDriver(ports, config) {
+    let scheduleHandle;
+    let generation = 0;
+    let lease = null;
+    let connectedEmitted = false;
+    function stop() {
+      generation += 1;
+      lease = null;
+      connectedEmitted = false;
+      if (scheduleHandle !== void 0) {
+        ports.cancel(scheduleHandle);
+        scheduleHandle = void 0;
+      }
+    }
+    function apply(decision) {
+      lease = decision.state;
+      let accepted = false;
+      for (const effect of decision.effects) {
+        if (effect.type === "send-challenge") {
+          try {
+            ports.sendProbe(effect.probeId, decision.state.mode);
+          } catch {
+            stop();
+            ports.teardown("ping failed \u2014 reconnecting\u2026");
+            break;
+          }
+        } else if (effect.type === "accepted-current") {
+          accepted = true;
+          if (!connectedEmitted) {
+            connectedEmitted = true;
+            ports.emitConnected();
+          }
+        } else {
+          stop();
+          ports.teardown("heartbeat lost \u2014 reconnecting\u2026");
+          break;
+        }
+      }
+      return accepted;
+    }
+    return {
+      start(mode) {
+        stop();
+        const started = startHeartbeatLease(mode, ports.now(), ports.nextProbeId(), config);
+        apply(started);
+        if (lease === null) return;
+        const activeGeneration = generation;
+        scheduleHandle = ports.schedule(() => {
+          if (activeGeneration !== generation || lease === null) return;
+          apply(reduceHeartbeatLease(lease, {
+            type: "tick",
+            now: ports.now(),
+            nextProbeId: ports.nextProbeId()
+          }, config));
+        }, config.intervalMs);
+      },
+      stop,
+      receivePong(probeId) {
+        if (lease === null) return false;
+        return apply(reduceHeartbeatLease(lease, {
+          type: "pong",
+          now: ports.now(),
+          probeId
+        }, config));
+      }
+    };
+  }
+
   // plugin/src/ui/ui-relay.ts
   var PLUGIN_VERSION = "0.1.0";
   var PORT_PROBE_TIMEOUT_MS = 1200;
@@ -4254,8 +4387,9 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
   var INSTANCE_ID = typeof crypto !== "undefined" && typeof crypto.randomUUID === "function" ? crypto.randomUUID() : `inst_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
   var ws = null;
   var backoffBase = 0;
-  var heartbeatTimer = null;
-  var lastPongAt = 0;
+  var reconnectTimer = null;
+  var heartbeatMode = "legacy";
+  var heartbeatProbeCounter = 0;
   var connState = "disconnected";
   var fileInfo = {};
   var chunkBuffers = /* @__PURE__ */ new Map();
@@ -4360,7 +4494,15 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
       return;
     }
     if (msg.type === "PONG") {
-      lastPongAt = Date.now();
+      const data = msg.data ?? {};
+      heartbeatDriver.receivePong(typeof data.probeId === "string" ? data.probeId : void 0);
+      return;
+    }
+    if (msg.type === "APP_PROBE") {
+      const data = msg.data ?? {};
+      if (heartbeatMode === "correlated" && typeof data.probeId === "string") {
+        wsSend({ type: "APP_PROBE_ACK", data: { probeId: data.probeId } });
+      }
       return;
     }
     if (msg.type === "SYNC_CONFIG") {
@@ -4545,35 +4687,39 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
       emitActivity(pm.requestId, pm.ok === true, pm.ok === true ? pm.result : pm.error);
     }
   });
-  function stopHeartbeat() {
-    if (heartbeatTimer !== null) {
-      clearInterval(heartbeatTimer);
-      heartbeatTimer = null;
+  var heartbeatDriver = createHeartbeatDriver({
+    now: Date.now,
+    nextProbeId: () => `hb_${INSTANCE_ID}_${++heartbeatProbeCounter}_${Date.now()}`,
+    schedule: (callback, intervalMs) => setInterval(callback, intervalMs),
+    cancel: (handle) => clearInterval(handle),
+    sendProbe: (probeId, mode) => {
+      if (!ws || ws.readyState !== WebSocket.OPEN) throw new Error("socket unavailable");
+      ws.send(JSON.stringify({
+        type: "PING",
+        data: { t: Date.now(), ...mode === "correlated" ? { probeId } : {} }
+      }));
+    },
+    teardown: (reason) => {
+      if (ws) teardown(ws, reason);
+    },
+    emitConnected: () => {
+      if (!ws) return;
+      const { url, port } = socketConnectionInfo(ws);
+      transition("READY", {
+        detail: `broker at ${url} \xB7 protocol v${PROTOCOL_VERSION}`,
+        brokerUrl: url,
+        port,
+        appState: "ready"
+      });
     }
-  }
-  function startHeartbeat(socket) {
-    stopHeartbeat();
-    lastPongAt = Date.now();
-    heartbeatTimer = setInterval(() => {
-      if (ws !== socket) {
-        stopHeartbeat();
-        return;
-      }
-      if (Date.now() - lastPongAt > PLUGIN_PONG_TIMEOUT_MS) {
-        teardown(socket, "heartbeat lost \u2014 reconnecting\u2026");
-        return;
-      }
-      try {
-        socket.send(JSON.stringify({ type: "PING", data: { t: Date.now() } }));
-      } catch {
-        teardown(socket, "ping failed \u2014 reconnecting\u2026");
-      }
-    }, PLUGIN_HEARTBEAT_INTERVAL_MS);
-  }
+  }, {
+    intervalMs: PLUGIN_HEARTBEAT_INTERVAL_MS,
+    timeoutMs: PLUGIN_PONG_TIMEOUT_MS
+  });
   function teardown(socket, reason) {
     if (ws !== socket) return;
     ws = null;
-    stopHeartbeat();
+    heartbeatDriver.stop();
     transition("LOST", { detail: reason });
     try {
       socket.onclose = null;
@@ -4610,7 +4756,9 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
       socket.onmessage = (ev) => {
         try {
           const msg = JSON.parse(String(ev.data));
-          if (msg?.type === "BROKER_HELLO") finish(socket);
+          if (msg?.type === "BROKER_HELLO") {
+            finish({ socket, hello: msg.data ?? {} });
+          }
         } catch {
         }
       };
@@ -4621,19 +4769,35 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
   async function scanForBroker() {
     for (let port = PORT_RANGE_START; port <= PORT_RANGE_END; port++) {
       transition("PROBE", { detail: `probing figma-agent.localhost:${port}\u2026`, port });
-      const socket = await probePort(port, "figma-agent.localhost");
-      if (socket) return socket;
+      const probe = await probePort(port, "figma-agent.localhost");
+      if (probe) return probe;
     }
     return null;
   }
-  function adoptSocket(socket) {
-    ws = socket;
-    backoffBase = 0;
-    chunkBuffers.clear();
+  function socketConnectionInfo(socket) {
     const url = socket.url.replace(/\/$/, "");
     const portMatch = /:(\d+)/.exec(url);
-    const port = portMatch ? Number(portMatch[1]) : void 0;
-    transition("FOUND", { detail: `broker at ${url}`, brokerUrl: url, port });
+    return { url, port: portMatch ? Number(portMatch[1]) : void 0 };
+  }
+  function adoptSocket(probe) {
+    const { socket, hello } = probe;
+    if (ws !== null) {
+      if (ws !== socket) try {
+        socket.close();
+      } catch {
+      }
+      return;
+    }
+    ws = socket;
+    if (reconnectTimer !== null) {
+      clearTimeout(reconnectTimer);
+      reconnectTimer = null;
+    }
+    backoffBase = 0;
+    chunkBuffers.clear();
+    heartbeatMode = hello.appReadinessV === 1 ? "correlated" : "legacy";
+    const { url, port } = socketConnectionInfo(socket);
+    transition("FOUND", { detail: `broker at ${url}`, brokerUrl: url, port, appState: "probing" });
     socket.onmessage = (ev) => handleWireData(String(ev.data));
     socket.onerror = () => {
     };
@@ -4641,30 +4805,34 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     wsSend({ type: "PLUGIN_HELLO", data: {
       ...fileInfo,
       instanceId: INSTANCE_ID,
-      caps: ["fileGuard"],
+      caps: [...PLUGIN_CAPABILITIES],
       pluginVersion: PLUGIN_VERSION,
       protocolV: PROTOCOL_VERSION
     } });
     if (Object.keys(fileInfo).length === 0) parent.postMessage({ pluginMessage: { type: "UI_READY" } }, "*");
-    startHeartbeat(socket);
-    transition("READY", { detail: `broker at ${url} \xB7 protocol v${PROTOCOL_VERSION}`, brokerUrl: url, port });
+    heartbeatDriver.start(heartbeatMode);
   }
   function scheduleReconnect() {
+    if (ws !== null || reconnectTimer !== null) return;
     const { base, delay } = nextBackoff(backoffBase, BACKOFF_OPTS);
     backoffBase = base;
-    setTimeout(() => void connectLoop(), delay);
+    reconnectTimer = setTimeout(() => {
+      reconnectTimer = null;
+      void connectLoop();
+    }, delay);
   }
   async function connectLoop() {
+    if (ws !== null) return;
     try {
-      const socket = await scanForBroker();
-      if (!socket) {
+      const probe = await scanForBroker();
+      if (!probe) {
         transition("PROBE", {
           detail: `no broker on :${PORT_RANGE_START}-${PORT_RANGE_END} \u2014 is a CLI command running? retrying\u2026`
         });
         scheduleReconnect();
         return;
       }
-      adoptSocket(socket);
+      adoptSocket(probe);
     } catch (err) {
       transition("LOST", { detail: err instanceof Error ? err.message : String(err) });
       scheduleReconnect();

--- a/shared/protocol.ts
+++ b/shared/protocol.ts
@@ -3,6 +3,35 @@
 // relatively; esbuild inlines it per bundle.
 
 export const PROTOCOL_VERSION = 1;
+export const APP_READINESS_VERSION = 1;
+
+export const PLUGIN_CAPABILITIES = [
+  'fileGuard',
+  'correlatedHeartbeatV1',
+  'appProbeV1',
+] as const;
+export type PluginCapability = (typeof PLUGIN_CAPABILITIES)[number];
+export type AppHeartbeatMode = 'correlated' | 'legacy' | 'unknown';
+export type AppState = 'probing' | 'ready' | 'suspect' | 'unready' | 'unknown';
+
+export interface BrokerHelloData {
+  appReadinessV?: typeof APP_READINESS_VERSION;
+  [key: string]: unknown;
+}
+
+export interface PluginHelloData {
+  caps?: readonly PluginCapability[];
+  [key: string]: unknown;
+}
+
+export interface HeartbeatData {
+  t: number;
+  probeId?: string;
+}
+
+export interface AppProbeData {
+  probeId: string;
+}
 
 // Broker binds the first free port in this range (broker model: ONE daemon owns
 // the port; plugin + every CLI invocation connect as WS clients).
@@ -194,11 +223,20 @@ export interface ReplyOk {
   fileContext?: FileContext;
 }
 
+export interface JobRecovery {
+  kind: 'inspect-and-force-release';
+  command: string;
+  requiresCanvasInspection: true;
+  retryAllowed: false;
+}
+
 /** Reply error payload. `rolledBack` is set by EXEC_JS --undo-group. */
 export interface WireError {
   code: ErrorCode;
   message: string;
   rolledBack?: boolean;
+  jobId?: string;
+  recovery?: JobRecovery;
 }
 
 export interface ReplyErr {
@@ -228,7 +266,7 @@ export type ReplyMsg = ReplyOk | ReplyErr;
 // even time out.
 export interface JobInfo {
   jobId: string;
-  state: 'queued' | 'running' | 'done' | 'failed' | 'cancelled';
+  state: 'queued' | 'running' | 'done' | 'failed' | 'cancelled' | 'outcome-unknown';
   cmd: string;
   activity?: string;
   fileSlug: string;       // which file's per-file FIFO queue it belongs to
@@ -236,6 +274,9 @@ export interface JobInfo {
   queuedMs?: number;      // time spent waiting — the evidence for the subtree-lock upgrade trigger
   startedAt?: number;
   finishedAt?: number;
+  dispatchState?: 'queued-not-dispatched-readiness-wait';
+  uncertaintyReason?: string;
+  recovery?: JobRecovery;
 }
 
 export type MutationGateState = 'paused' | 'open';
@@ -302,6 +343,7 @@ export interface EventMsg {
   // its own jobId. `data` is a `JobInfo`.
   type:
     | 'BROKER_HELLO' | 'PLUGIN_HELLO' | 'FILE_INFO' | 'PLUGIN_GONE' | 'PING' | 'PONG'
+    | 'APP_PROBE' | 'APP_PROBE_ACK'
     | 'DOC_CHANGE' | 'SYNC_CONFIG' | 'SYNC_REQUEST' | 'SYNC_RESULT' | 'PEERS' | 'EDIT_FEED'
     | 'JOB_STATE' | 'SET_TARGET' | 'CLEAR_TARGET';
   data: Record<string, unknown>;
@@ -377,6 +419,11 @@ export interface PluginStatusEntry {
    */
   pluginVersion?: string;
   protocolV?: number;
+  /** Additive application-readiness facts; absent means an older broker. */
+  appReady?: boolean | null;
+  appState?: AppState;
+  appHeartbeatMode?: AppHeartbeatMode;
+  appReadinessAge?: number | null;
 }
 
 // Chunked transport for payloads > CHUNK_LIMIT (both directions).
@@ -428,6 +475,8 @@ export type ErrorCode =
   | 'E_MUTATION_GATE_UNAVAILABLE'
   | 'E_FILE_KEY_UNAVAILABLE'
   | 'E_STALE_ADMISSION'
+  | 'E_APP_UNREADY'
+  | 'E_OUTCOME_UNKNOWN'
   // #35 P2 — a no-flag command with a standing `targetInstancePin` set, whose pinned
   // instance has disconnected. Never falls through to the env pin or recency (Law 1: a
   // standing pin never silently re-points at another plugin) — the caller re-targets via
@@ -576,6 +625,8 @@ export interface ConnectionStatePayload {
   port?: number;
   /** ms since the last broker PONG, present while `connected`. */
   lastPongAge?: number;
+  /** Additive application-heartbeat state; absent preserves the legacy payload. */
+  appState?: AppState;
   protocolVersion: number;
 }
 

--- a/skills/figma-agent/SKILL.md
+++ b/skills/figma-agent/SKILL.md
@@ -56,7 +56,7 @@ exactly one JSON object to stdout and exits 0, or `{error:{code,message}}` and e
 - `bind` — --file "<name>" --dir <projectDir>   bind a file to a project for panel/idle sync (refuses to guess otherwise) [--list] [--unbind]
 - `get-selection` — Serialize the current selection [--depth 1]
 - `inspect` — [nodeId|--node id] [--out file.png --scale 1 --timeout ms]
-- `job` — <jobId> [--wait] [--wait-timeout 60000] | --list [--file name] | <jobId> --cancel (queued only) | <jobId> --force-release [--force]   poll/wait/cancel/list a job the CLI stopped waiting for (backlog 1.1+2.6+4.3) — --force-release refuses a HEALTHY still-running job unless --force is also passed — --force overrides the guard and discards its result, unverified; a watchdog-wedged job still unwedges without --force
+- `job` — <jobId> [--wait] [--wait-timeout 60000] | --list [--file name] | <jobId> --cancel (queued only) | <jobId> --force-release [--force]   poll/wait/cancel/list a job the CLI stopped waiting for (backlog 1.1+2.6+4.3) — --force-release refuses a HEALTHY still-running job unless --force is also passed — --force overrides the guard and discards its result, unverified; a watchdog-wedged job still unwedges without --force. An outcome-unknown job requires canvas inspection, then a bare --force-release; never retry it automatically.
 - `scan-design-system` — Components/variables/styles registry [--out file.json --timeout ms]
 - `scan-node` — [SPIKE] Reverse-walk one node → FigmaExportNode spec <nodeId> [--timeout ms]
 - `mirror-verify` — Prove one node round-trips: scan → rebuild → scan → diff <nodeId> [--parent id --keep --timeout ms]

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -39,6 +39,7 @@ type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts')
 
 const WATCHDOG_MS_KEY = 'FIGMA_AGENT_WATCHDOG_MS';
 const PLUGIN_WAIT_MS_KEY = 'FIGMA_AGENT_PLUGIN_WAIT_MS';
+const APP_READINESS_MS_KEY = 'FIGMA_AGENT_APP_READINESS_MS';
 const CHANGES_DIR_KEY = 'FIGMA_AGENT_CHANGES_DIR';
 const BINDS_FILE_KEY = 'FIGMA_AGENT_BINDS_FILE';
 const UNBOUND_DIR_KEY = 'FIGMA_AGENT_UNBOUND_DIR';
@@ -69,6 +70,7 @@ let advertisePath: string;
 let scratchLogFile: string;
 let sockets: WebSocket[];
 let priorPluginWaitMs: string | undefined;
+let priorAppReadinessMs: string | undefined;
 
 /** Load `broker-daemon.ts` fresh, AFTER the given env vars are set — required for the
  *  module-load-time `envMs(...)` constants (see file header). */
@@ -179,10 +181,13 @@ async function waitFor(
   }
 }
 
-async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null): Promise<void> {
+async function helloPlugin(
+  ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null,
+  caps: string[] = ['fileGuard'],
+): Promise<void> {
   ws.send(JSON.stringify({
     type: 'PLUGIN_HELLO',
-    data: { instanceId, fileName, fileKey, caps: ['fileGuard'] },
+    data: { instanceId, fileName, fileKey, caps },
   } satisfies EventMsg));
   // BROKER_HELLO arrives on connect, before HELLO is even processed — SYNC_CONFIG is the
   // registration ack this test waits on, so it never races the plugin being registered.
@@ -201,16 +206,53 @@ function sendFileInfo(ws: WebSocket, fileName: string, fileKey: string): void {
 /** Send a mutating request and wait for its JOB_STATE — returns the minted jobId, whether
  *  it started running immediately or was queued behind another job on the same file. */
 async function sendMutatingJob(ws: WebSocket, reqId: string): Promise<string> {
+  const jobStatePromise = nextFrame<EventMsg>(ws, (m) => (m as EventMsg).type === 'JOB_STATE');
   ws.send(JSON.stringify(makeRequestFrame(reqId, 'SET_TEXT', { nodeId: '1:1', text: 'x' })));
-  const jobState = await nextFrame<EventMsg>(ws, (m) => (m as EventMsg).type === 'JOB_STATE');
+  const jobState = await jobStatePromise;
   return (jobState.data as unknown as JobInfo).jobId;
 }
 
 async function pollJob(ws: WebSocket, jobId: string, reqId: string): Promise<{ job: JobInfo; resultFrames?: string[]; resultDropped?: boolean; lateReplyCount?: number }> {
+  const replyPromise = nextFrame<ReplyOk | ReplyErr>(ws, (m) => (m as ReplyOk | ReplyErr).id === reqId);
   ws.send(JSON.stringify(makeRequestFrame(reqId, 'JOB', { mode: 'poll', jobId })));
-  const reply = await nextFrame<ReplyOk | ReplyErr>(ws, (m) => (m as ReplyOk | ReplyErr).id === reqId);
+  const reply = await replyPromise;
   if (!reply.ok) throw new Error(`poll failed: ${JSON.stringify(reply.error)}`);
   return reply.result as { job: JobInfo; resultFrames?: string[]; resultDropped?: boolean; lateReplyCount?: number };
+}
+
+async function createReservedHead(prefix: string): Promise<{
+  port: number;
+  plugin: WebSocket;
+  pluginFrames: { frames: WireMsg[] };
+  cliB: WebSocket;
+  cliC: WebSocket;
+  jobB: string;
+  jobC: string;
+  probeId: string;
+}> {
+  const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '500' });
+  const plugin = await connectSocket(port);
+  await helloPlugin(plugin, `${prefix}-plugin`, `${prefix} File`, `${prefix}-raw`, ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+  const pluginFrames = collectFrames(plugin);
+  const cliA = await connectSocket(port);
+  const jobA = await sendMutatingJob(cliA, `${prefix}-a`);
+  await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === `${prefix}-a`));
+  const cliB = await connectSocket(port);
+  const jobB = await sendMutatingJob(cliB, `${prefix}-b`);
+  const cliC = await connectSocket(port);
+  const jobC = await sendMutatingJob(cliC, `${prefix}-c`);
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  const release = nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === `${prefix}-release-a`);
+  cliA.send(JSON.stringify(makeRequestFrame(`${prefix}-release-a`, 'JOB', {
+    mode: 'force-release', jobId: jobA, override: true,
+  })));
+  await release;
+  await waitFor(() => pluginFrames.frames.some((frame) => (frame as EventMsg).type === 'APP_PROBE'));
+  const probe = pluginFrames.frames.find((frame) => (frame as EventMsg).type === 'APP_PROBE') as EventMsg;
+  return {
+    port, plugin, pluginFrames, cliB, cliC, jobB, jobC,
+    probeId: (probe.data as { probeId: string }).probeId,
+  };
 }
 
 interface EditInputLike {
@@ -263,6 +305,7 @@ async function bindProject(
 
 beforeEach(() => {
   priorPluginWaitMs = process.env[PLUGIN_WAIT_MS_KEY];
+  priorAppReadinessMs = process.env[APP_READINESS_MS_KEY];
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-broker-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
   scratchLogFile = join(scratchDir, 'broker.log');
@@ -283,6 +326,8 @@ afterEach(async () => {
   rmSync(scratchDir, { recursive: true, force: true });
   if (priorPluginWaitMs === undefined) delete process.env[PLUGIN_WAIT_MS_KEY];
   else process.env[PLUGIN_WAIT_MS_KEY] = priorPluginWaitMs;
+  if (priorAppReadinessMs === undefined) delete process.env[APP_READINESS_MS_KEY];
+  else process.env[APP_READINESS_MS_KEY] = priorAppReadinessMs;
 });
 
 describe('daemon harness — mutation admission', () => {
@@ -1382,6 +1427,207 @@ describe('daemon harness — admitRequest with an `--instance` (expectedInstance
 // exercises the real `handleJobCommand`/`advanceQueue` closures via a real in-process
 // broker, isolated from a live plugin session's broker discovery the same way as above.
 describe('daemon harness — force-release refuses a HEALTHY running job, allows `--force`, never regresses the wedged-unwedge path', () => {
+  it('unfiltered routing sends to older ready A instead of newer stale B without probing B', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '500' });
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'plugin-ready-first-a', 'Ready First A', 'Raw-Ready-A', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'plugin-ready-first-b', 'Ready First B', 'Raw-Ready-B', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    // Parsed ACK renews A's app lease without changing the routing-recency order: B
+    // remains newer, so only ready-first selection can choose A.
+    pluginA.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: 'ready-first-renew-a' } } satisfies EventMsg));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const cli = await connectSocket(port);
+    cli.send(JSON.stringify(makeRequestFrame('req-ready-first', 'GET_SELECTION', {})));
+    await waitFor(() => framesA.frames.some((frame) => (frame as { id?: string }).id === 'req-ready-first')
+      || framesB.frames.some((frame) => (frame as EventMsg).type === 'APP_PROBE'));
+
+    expect(framesA.frames.filter((frame) => (frame as { id?: string }).id === 'req-ready-first')).toHaveLength(1);
+    expect(framesB.frames.filter((frame) => (frame as { id?: string }).id === 'req-ready-first')).toHaveLength(0);
+    expect(framesB.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(0);
+  });
+
+  it('ACK wins before later cancel: one send, cancel refusal, one normal completion drain', async () => {
+    const setup = await createReservedHead('race-ack-cancel');
+    setup.plugin.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: setup.probeId } } satisfies EventMsg));
+    await waitFor(() => setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-ack-cancel-b'));
+    expect(setup.pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'race-ack-cancel-b')).toHaveLength(1);
+
+    const cancel = nextFrame<ReplyOk>(setup.cliB, (frame) => (frame as ReplyOk).id === 'race-ack-cancel-late');
+    setup.cliB.send(JSON.stringify(makeRequestFrame('race-ack-cancel-late', 'JOB', { mode: 'cancel', jobId: setup.jobB })));
+    expect((await cancel).result).toMatchObject({ ok: false });
+    expect((await pollJob(setup.cliB, setup.jobB, 'race-ack-cancel-poll-running')).job.state).toBe('running');
+
+    setup.plugin.send(JSON.stringify({ id: 'race-ack-cancel-b', ok: true, result: {} } satisfies ReplyOk));
+    await waitFor(() => setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-ack-cancel-c'));
+    expect(setup.pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'race-ack-cancel-c')).toHaveLength(1);
+    expect((await pollJob(setup.cliB, setup.jobB, 'race-ack-cancel-poll-done')).job.state).toBe('done');
+    expect((await pollJob(setup.cliC, setup.jobC, 'race-ack-cancel-poll-c')).job.state).toBe('running');
+  });
+
+  it('target close beats ACK: both pinned queued jobs settle once and a stale ACK cannot resurrect either', async () => {
+    const setup = await createReservedHead('race-close-ack');
+    const failedB = nextFrame<ReplyErr>(setup.cliB, (frame) => (frame as ReplyErr).id === 'race-close-ack-b');
+    const failedC = nextFrame<ReplyErr>(setup.cliC, (frame) => (frame as ReplyErr).id === 'race-close-ack-c');
+    setup.plugin.terminate();
+    expect((await failedB).error.code).toBe('E_NO_PLUGIN');
+    expect((await failedC).error.code).toBe('E_NO_PLUGIN');
+
+    const replacement = await connectSocket(setup.port);
+    await helloPlugin(replacement, 'race-close-ack-plugin', 'race-close-ack File', 'race-close-ack-raw', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const replacementFrames = collectFrames(replacement);
+    replacement.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: setup.probeId } } satisfies EventMsg));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(replacementFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-close-ack-b')).toBe(false);
+    expect(replacementFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-close-ack-c')).toBe(false);
+    expect((await pollJob(setup.cliB, setup.jobB, 'race-close-ack-poll-b')).job.state).toBe('failed');
+    expect((await pollJob(setup.cliC, setup.jobC, 'race-close-ack-poll-c')).job.state).toBe('failed');
+  });
+
+  it('target close beats deadline: expiry callback is stale, with zero frames and no second transition', async () => {
+    const setup = await createReservedHead('race-close-deadline');
+    const failedB = nextFrame<ReplyErr>(setup.cliB, (frame) => (frame as ReplyErr).id === 'race-close-deadline-b');
+    const failedC = nextFrame<ReplyErr>(setup.cliC, (frame) => (frame as ReplyErr).id === 'race-close-deadline-c');
+    setup.plugin.terminate();
+    expect((await failedB).error.code).toBe('E_NO_PLUGIN');
+    expect((await failedC).error.code).toBe('E_NO_PLUGIN');
+    await new Promise((resolve) => setTimeout(resolve, 650));
+    expect((await pollJob(setup.cliB, setup.jobB, 'race-close-deadline-poll-b')).job.state).toBe('failed');
+    expect((await pollJob(setup.cliC, setup.jobC, 'race-close-deadline-poll-c')).job.state).toBe('failed');
+    expect(setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-close-deadline-b')).toBe(false);
+    expect(setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-close-deadline-c')).toBe(false);
+  });
+
+  it('gate denial beats ACK: typed failures drain once and the old generation cannot send', async () => {
+    const setup = await createReservedHead('race-gate-ack');
+    const failedB = nextFrame<ReplyErr>(setup.cliB, (frame) => (frame as ReplyErr).id === 'race-gate-ack-b');
+    const failedC = nextFrame<ReplyErr>(setup.cliC, (frame) => (frame as ReplyErr).id === 'race-gate-ack-c');
+    const paused = nextFrame<ReplyOk>(setup.cliB, (frame) => (frame as ReplyOk).id === 'race-gate-ack-pause');
+    setup.cliB.send(JSON.stringify(makeRequestFrame('race-gate-ack-pause', 'MUTATION_GATE', {
+      mode: 'pause', fileKey: 'race-gate-ack-raw',
+    })));
+    expect((await paused).result).toMatchObject({ state: 'paused' });
+    expect((await failedB).error.code).toBe('E_MUTATIONS_PAUSED');
+    expect((await failedC).error.code).toBe('E_MUTATIONS_PAUSED');
+    setup.plugin.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: setup.probeId } } satisfies EventMsg));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-gate-ack-b')).toBe(false);
+    expect(setup.pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'race-gate-ack-c')).toBe(false);
+    expect((await pollJob(setup.cliB, setup.jobB, 'race-gate-ack-poll-b')).job.state).toBe('failed');
+    expect((await pollJob(setup.cliC, setup.jobC, 'race-gate-ack-poll-c')).job.state).toBe('failed');
+  });
+
+  it('exact unready safe reads probe only the pinned instance, then dispatch once or time out still connected', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '500' });
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'plugin-ready-a', 'Ready A', 'Raw-A', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'plugin-unready-b', 'Unready B', 'Raw-B', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    pluginA.send(JSON.stringify({ type: 'FILE_INFO', data: { fileName: 'Ready A', fileKey: 'Raw-A', page: 'Page 1' } } satisfies EventMsg));
+
+    const cli = await connectSocket(port);
+    cli.send(JSON.stringify(makeRequestFrame(
+      'req-ready-exact', 'GET_SELECTION', {}, undefined, undefined, undefined, undefined, undefined, undefined, 'Raw-B',
+    )));
+    await waitFor(() => framesB.frames.some((frame) => (frame as EventMsg).type === 'APP_PROBE'));
+    const probe = framesB.frames.find((frame) => (frame as EventMsg).type === 'APP_PROBE') as EventMsg;
+    expect(framesA.frames.some((frame) => (frame as { id?: string }).id === 'req-ready-exact')).toBe(false);
+    pluginB.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: (probe.data as { probeId: string }).probeId } } satisfies EventMsg));
+    await waitFor(() => framesB.frames.some((frame) => (frame as { id?: string }).id === 'req-ready-exact'));
+    expect(framesB.frames.filter((frame) => (frame as { id?: string }).id === 'req-ready-exact')).toHaveLength(1);
+
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    const timedOut = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'req-unready-timeout');
+    cli.send(JSON.stringify(makeRequestFrame(
+      'req-unready-timeout', 'GET_SELECTION', {}, undefined, undefined, undefined, undefined, undefined, undefined, 'Raw-B',
+    )));
+    expect((await timedOut).error.code).toBe('E_APP_UNREADY');
+    expect(framesA.frames.some((frame) => (frame as { id?: string }).id === 'req-unready-timeout')).toBe(false);
+    expect(framesB.frames.some((frame) => (frame as { id?: string }).id === 'req-unready-timeout')).toBe(false);
+
+    const { hello } = await connectAndAwaitBrokerHello(port);
+    expect(hello.data).toMatchObject({ pluginConnected: true });
+  });
+
+  it('a valid completion renews app readiness and sends the next mutation once through the final dispatch path', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200' });
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-completion-ready', 'Completion Ready', 'Raw-Completion', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginFrames = collectFrames(plugin);
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-completion-a');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-completion-a'));
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-completion-b');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    expect((await pollJob(cliA, jobA, 'req-completion-poll-a')).job.state).toBe('running');
+    expect((await pollJob(cliB, jobB, 'req-completion-poll-b')).job.state).toBe('queued');
+
+    plugin.send(JSON.stringify({ id: 'req-completion-a', ok: true, result: {} } satisfies ReplyOk));
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-completion-b'));
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-completion-b')).toHaveLength(1);
+    expect((await pollJob(cliB, jobB, 'req-completion-poll-b2')).job.state).toBe('running');
+  });
+
+  it('force-release reserves once; cancel beats deadline and stale-generation ACK while the next deadline drains once', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '100' });
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-reserved', 'Reserved File', 'Raw-Reserved', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginFrames = collectFrames(plugin);
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-reserved-a');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-reserved-a'));
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-reserved-b');
+    const cliC = await connectSocket(port);
+    const jobC = await sendMutatingJob(cliC, 'req-reserved-c');
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    cliA.send(JSON.stringify(makeRequestFrame('req-reserved-release-a', 'JOB', {
+      mode: 'force-release', jobId: jobA, override: true,
+    })));
+    await nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === 'req-reserved-release-a');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as EventMsg).type === 'APP_PROBE'));
+    const probeB = pluginFrames.frames.find((frame) => (frame as EventMsg).type === 'APP_PROBE') as EventMsg;
+    const reservedB = await pollJob(cliB, jobB, 'req-reserved-poll-b');
+    expect(reservedB.job).toMatchObject({ state: 'queued', dispatchState: 'queued-not-dispatched-readiness-wait' });
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-reserved-b')).toBe(false);
+
+    const { hello } = await connectAndAwaitBrokerHello(port);
+    const rows = (hello.data as { plugins: Array<{ runningJob?: JobInfo; queueDepth: number }> }).plugins;
+    expect(rows[0]).toMatchObject({ runningJob: { jobId: jobB, state: 'queued' }, queueDepth: 1 });
+
+    for (const override of [false, true]) {
+      const releaseId = `req-reserved-release-b-${String(override)}`;
+      cliB.send(JSON.stringify(makeRequestFrame(releaseId, 'JOB', { mode: 'force-release', jobId: jobB, override })));
+      const refusal = await nextFrame<ReplyOk>(cliB, (frame) => (frame as ReplyOk).id === releaseId);
+      expect(refusal.result).toEqual({
+        ok: false,
+        reason: `job '${jobB}' is queued and has not been dispatched; use: figma-agent job ${jobB} --cancel`,
+      });
+    }
+    expect((await pollJob(cliB, jobB, 'req-reserved-poll-b2')).job).toMatchObject({
+      state: 'queued', dispatchState: 'queued-not-dispatched-readiness-wait',
+    });
+
+    const failedC = nextFrame<ReplyErr>(cliC, (frame) => (frame as ReplyErr).id === 'req-reserved-c');
+    cliB.send(JSON.stringify(makeRequestFrame('req-reserved-cancel-b', 'JOB', { mode: 'cancel', jobId: jobB })));
+    await nextFrame<ReplyOk>(cliB, (frame) => (frame as ReplyOk).id === 'req-reserved-cancel-b');
+    plugin.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: (probeB.data as { probeId: string }).probeId } } satisfies EventMsg));
+    expect((await failedC).error.code).toBe('E_APP_UNREADY');
+    expect((await pollJob(cliB, jobB, 'req-reserved-poll-b3')).job.state).toBe('cancelled');
+    expect((await pollJob(cliC, jobC, 'req-reserved-poll-c')).job.state).toBe('failed');
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-reserved-b')).toBe(false);
+    expect(pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-reserved-c')).toBe(false);
+  });
+
   it('a bare `--force-release` on a job still `running` inside the watchdog window is REFUSED — the slot stays held, nothing advances', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -837,15 +837,15 @@ describe('daemon harness — cancel-then-complete never dispatches the cancelled
   });
 });
 
-describe('daemon harness — plugin disconnect fails a queued job, reconnect never re-dispatches it (BLOCKER 2)', () => {
-  it('E_NO_PLUGIN reaches the CLI for both the running and queued job; a same-instanceId reconnect gets nothing', async () => {
+describe('daemon harness — actual transport loss preserves dispatched mutation uncertainty', () => {
+  it('holds the unknown slot, fails queued work, discards late reply, then bare force-release advances once', async () => {
     const port = await startTestBroker();
     const plugin = await connectSocket(port);
     await helloPlugin(plugin, 'plugin-2', 'F2', 'RawF2');
     const pluginFrames = collectFrames(plugin);
 
     const cliA = await connectSocket(port);
-    await sendMutatingJob(cliA, 'req-a2'); // dispatched immediately — RUNNING
+    const jobA = await sendMutatingJob(cliA, 'req-a2'); // dispatched immediately — RUNNING
     await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-a2'));
 
     const cliB = await connectSocket(port);
@@ -856,13 +856,28 @@ describe('daemon harness — plugin disconnect fails a queued job, reconnect nev
     plugin.terminate(); // the disconnect
     const [replyA, replyB] = await Promise.all([errA, errB]);
     expect(replyA.ok).toBe(false);
-    expect(replyA.error.code).toBe('E_NO_PLUGIN');
+    expect(replyA.error).toEqual({
+      code: 'E_OUTCOME_UNKNOWN',
+      message: expect.stringContaining('canvas may or may not have changed'),
+      jobId: jobA,
+      recovery: {
+        kind: 'inspect-and-force-release',
+        command: `figma-agent job ${jobA} --force-release`,
+        requiresCanvasInspection: true,
+        retryAllowed: false,
+      },
+    });
     expect(replyB.ok).toBe(false);
     expect(replyB.error.code).toBe('E_NO_PLUGIN');
 
     // Job B's own record reads 'failed' — never left dangling in a resurrectable state.
     const polledB = await pollJob(cliB, jobB, 'req-poll-b2');
     expect(polledB.job.state).toBe('failed');
+    const polledA = await pollJob(cliA, jobA, 'req-poll-a2');
+    expect(polledA.job).toMatchObject({
+      state: 'outcome-unknown', jobId: jobA,
+      recovery: { command: `figma-agent job ${jobA} --force-release`, retryAllowed: false },
+    });
 
     // Reconnect with the SAME instanceId — no parked/queued work exists to flush.
     const plugin2 = await connectSocket(port);
@@ -871,6 +886,60 @@ describe('daemon harness — plugin disconnect fails a queued job, reconnect nev
     await new Promise((resolve) => setTimeout(resolve, 200));
     const dispatched = plugin2Frames.frames.filter((f) => 'cmd' in (f as Record<string, unknown>));
     expect(dispatched).toHaveLength(0);
+    const { hello: heldStatus } = await connectAndAwaitBrokerHello(port);
+    const heldPlugin = (heldStatus.data as { plugins: Array<{ instanceId: string; runningJob?: JobInfo }> })
+      .plugins.find((entry) => entry.instanceId === 'plugin-2');
+    expect(heldPlugin?.runningJob).toMatchObject({ jobId: jobA, state: 'outcome-unknown' });
+
+    const cliC = await connectSocket(port);
+    const jobC = await sendMutatingJob(cliC, 'req-c2');
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(plugin2Frames.frames.some((frame) => (frame as { id?: string }).id === 'req-c2')).toBe(false);
+
+    plugin2.send(JSON.stringify({ id: 'req-a2', ok: true, result: { late: true } } satisfies ReplyOk));
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect((await pollJob(cliA, jobA, 'req-poll-a2-late')).lateReplyCount).toBe(1);
+    expect((await pollJob(cliC, jobC, 'req-poll-c2')).job.state).toBe('queued');
+
+    const releasePending = nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === 'req-release-a2');
+    cliA.send(JSON.stringify(makeRequestFrame('req-release-a2', 'JOB', {
+      mode: 'force-release', jobId: jobA, override: false,
+    }, 'Inspect then force-release')));
+    expect((await releasePending).result).toEqual({ ok: true });
+    await waitFor(() => plugin2Frames.frames.some((frame) => (frame as { id?: string }).id === 'req-c2'));
+    expect(plugin2Frames.frames.filter((frame) => (frame as { id?: string }).id === 'req-c2')).toHaveLength(1);
+    const releasedA = await pollJob(cliA, jobA, 'req-poll-a2-released');
+    expect(releasedA.job).toMatchObject({
+      jobId: jobA, state: 'outcome-unknown', finishedAt: expect.any(Number),
+      uncertaintyReason: 'plugin transport disconnected after dispatch',
+    });
+    expect(releasedA.job).not.toHaveProperty('recovery');
+    expect((await pollJob(cliC, jobC, 'req-poll-c2-owner')).job.state).toBe('running');
+    const secondReleasePending = nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === 'req-release-a2-again');
+    cliA.send(JSON.stringify(makeRequestFrame('req-release-a2-again', 'JOB', {
+      mode: 'force-release', jobId: jobA, override: false,
+    }, 'Duplicate release')));
+    expect((await secondReleasePending).result).toMatchObject({ ok: false });
+    expect(plugin2Frames.frames.filter((frame) => (frame as { id?: string }).id === 'req-c2')).toHaveLength(1);
+  });
+
+  it('keeps a dispatched broker-safe read as a normal E_NO_PLUGIN failure', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-read-loss', 'Read Loss', 'RawReadLoss');
+    const pluginFrames = collectFrames(plugin);
+    const cli = await connectSocket(port);
+    const statePending = nextFrame<EventMsg>(cli, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    cli.send(JSON.stringify(makeRequestFrame('req-read-loss', 'GET_SELECTION', {})));
+    const jobId = ((await statePending).data as unknown as JobInfo).jobId;
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-read-loss'));
+
+    const failurePending = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'req-read-loss');
+    plugin.terminate();
+    expect((await failurePending).error).toEqual({
+      code: 'E_NO_PLUGIN', message: 'Figma plugin disconnected mid-request',
+    });
+    expect((await pollJob(cli, jobId, 'req-read-loss-poll')).job.state).toBe('failed');
   });
 });
 
@@ -1574,6 +1643,9 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-completion-b'));
     expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-completion-b')).toHaveLength(1);
     expect((await pollJob(cliB, jobB, 'req-completion-poll-b2')).job.state).toBe('running');
+    const completedA = await pollJob(cliA, jobA, 'req-completion-poll-a2');
+    expect(completedA.job.state).toBe('done');
+    expect(completedA.lateReplyCount).toBeUndefined();
   });
 
   it('force-release reserves once; cancel beats deadline and stale-generation ACK while the next deadline drains once', async () => {

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -1520,6 +1520,29 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     expect(framesB.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(0);
   });
 
+  it('unfiltered routing with two unready plugins probes one deterministic target and returns bounded E_APP_UNREADY', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '500' });
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'plugin-all-unready-a', 'All Unready A', 'Raw-All-Unready-A', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'plugin-all-unready-b', 'All Unready B', 'Raw-All-Unready-B', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const framesA = collectFrames(pluginA);
+    const framesB = collectFrames(pluginB);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+
+    const cli = await connectSocket(port);
+    const startedAt = Date.now();
+    const timedOut = nextFrame<ReplyErr>(cli, (frame) => (frame as ReplyErr).id === 'req-all-unready');
+    cli.send(JSON.stringify(makeRequestFrame('req-all-unready', 'GET_SELECTION', {})));
+
+    expect((await timedOut).error.code).toBe('E_APP_UNREADY');
+    expect(Date.now() - startedAt).toBeLessThan(HARNESS_WAIT_TIMEOUT_MS);
+    expect(framesA.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(0);
+    expect(framesB.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(1);
+    expect(framesA.frames.filter((frame) => (frame as { id?: string }).id === 'req-all-unready')).toHaveLength(0);
+    expect(framesB.frames.filter((frame) => (frame as { id?: string }).id === 'req-all-unready')).toHaveLength(0);
+  });
+
   it('ACK wins before later cancel: one send, cancel refusal, one normal completion drain', async () => {
     const setup = await createReservedHead('race-ack-cancel');
     setup.plugin.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: setup.probeId } } satisfies EventMsg));

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -28,6 +28,7 @@ import WebSocket from 'ws';
 import { makeRequestFrame } from '../shared/protocol.ts';
 import type { EventMsg, JobInfo, ReplyErr, ReplyOk, WireMsg } from '../shared/protocol.ts';
 import type { ContentionStore } from '../cli/src/transport/contention-log.ts';
+import { JOB_TTL_MS } from '../cli/src/transport/job-table.ts';
 import { envMs } from '../cli/src/transport/protocol-helpers.ts';
 
 // Scoped to THIS file only (vitest's own default 5_000ms stays the ceiling everywhere
@@ -980,6 +981,58 @@ describe('daemon harness — a watchdog-failed job answered late returns the tim
     expect(parsed.ok).toBe(false);
     expect(parsed.error.code).toBe('E_TIMEOUT');
   });
+
+  it('releases a watchdog-held slot once on transport close without fabricating a late reply, then expires it from release time', async () => {
+    let controlledNow = 1_000_000;
+    const dateNow = vi.spyOn(Date, 'now').mockImplementation(() => controlledNow);
+    try {
+      const port = await startTestBroker({ [WATCHDOG_MS_KEY]: '150', [PLUGIN_WAIT_MS_KEY]: '800' });
+      const plugin = await connectSocket(port);
+      await helloPlugin(plugin, 'plugin-watchdog-close', 'Watchdog Close', 'RawWatchdogClose');
+      const pluginFrames = collectFrames(plugin);
+      const cliA = await connectSocket(port);
+      const jobA = await sendMutatingJob(cliA, 'req-watchdog-close-a');
+      await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-watchdog-close-a'));
+
+      const cliB = await connectSocket(port);
+      const jobB = await sendMutatingJob(cliB, 'req-watchdog-close-b');
+      controlledNow += 151;
+      await waitFor(async () => (await pollJob(cliA, jobA, 'req-watchdog-close-watchdog')).job.state === 'failed');
+
+      const held = await pollJob(cliA, jobA, 'req-watchdog-close-held');
+      expect(held.resultFrames).toHaveLength(1);
+      expect(JSON.parse(held.resultFrames![0]!) as ReplyErr).toMatchObject({
+        ok: false,
+        error: { code: 'E_TIMEOUT' },
+      });
+      expect(held.lateReplyCount).toBeUndefined();
+
+      const closeA = nextFrame<ReplyErr>(cliA, (m) => (m as ReplyErr).id === 'req-watchdog-close-a');
+      const closeB = nextFrame<ReplyErr>(cliB, (m) => (m as ReplyErr).id === 'req-watchdog-close-b');
+      plugin.terminate();
+      expect((await closeA).error.code).toBe('E_NO_PLUGIN');
+      expect((await closeB).error.code).toBe('E_NO_PLUGIN');
+
+      const afterClose = await pollJob(cliA, jobA, 'req-watchdog-close-after');
+      expect(afterClose.resultFrames).toEqual(held.resultFrames);
+      expect(afterClose.lateReplyCount).toBeUndefined();
+      expect((await pollJob(cliB, jobB, 'req-watchdog-close-b-after')).job.state).toBe('failed');
+      expect(pluginFrames.frames.filter((f) => (f as { id?: string }).id === 'req-watchdog-close-b')).toHaveLength(0);
+
+      const contentionPath = join(scratchDir, 'figma-contention.json');
+      await waitFor(() => existsSync(contentionPath));
+      const contention = JSON.parse(readFileSync(contentionPath, 'utf8')) as ContentionStore;
+      expect(Object.values(contention.RawWatchdogClose!)[0]!.jobCount).toBe(2);
+
+      controlledNow += JOB_TTL_MS + 1;
+      await new Promise((resolve) => setTimeout(resolve, 250));
+      const expired = nextFrame<ReplyErr>(cliA, (m) => (m as ReplyErr).id === 'req-watchdog-close-expired');
+      cliA.send(JSON.stringify(makeRequestFrame('req-watchdog-close-expired', 'JOB', { mode: 'poll', jobId: jobA })));
+      expect((await expired).error.code).toBe('E_JOB_EXPIRED');
+    } finally {
+      dateNow.mockRestore();
+    }
+  });
 });
 
 describe('daemon harness — EDIT_FEED routes through the binding index, never the broker\'s spawn cwd (backlog 5.7)', () => {
@@ -1521,7 +1574,15 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
   });
 
   it('unfiltered routing with two unready plugins probes one deterministic target and returns bounded E_APP_UNREADY', async () => {
-    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '500' });
+    const readinessLeaseMs = 200;
+    const pluginWaitMs = 500;
+    // The response is driven by the broker's readiness waiter, not this harness's
+    // unrelated 20s observation ceiling. Retain room for one contended event-loop turn.
+    const schedulingToleranceMs = 3_000;
+    const port = await startTestBroker({
+      [APP_READINESS_MS_KEY]: String(readinessLeaseMs),
+      [PLUGIN_WAIT_MS_KEY]: String(pluginWaitMs),
+    });
     const pluginA = await connectSocket(port);
     await helloPlugin(pluginA, 'plugin-all-unready-a', 'All Unready A', 'Raw-All-Unready-A', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
     const pluginB = await connectSocket(port);
@@ -1536,7 +1597,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     cli.send(JSON.stringify(makeRequestFrame('req-all-unready', 'GET_SELECTION', {})));
 
     expect((await timedOut).error.code).toBe('E_APP_UNREADY');
-    expect(Date.now() - startedAt).toBeLessThan(HARNESS_WAIT_TIMEOUT_MS);
+    expect(Date.now() - startedAt).toBeLessThanOrEqual(pluginWaitMs + schedulingToleranceMs);
     expect(framesA.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(0);
     expect(framesB.frames.filter((frame) => (frame as EventMsg).type === 'APP_PROBE')).toHaveLength(1);
     expect(framesA.frames.filter((frame) => (frame as { id?: string }).id === 'req-all-unready')).toHaveLength(0);
@@ -1671,6 +1732,49 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     expect(completedA.lateReplyCount).toBeUndefined();
   });
 
+  it('keeps a dispatched mutation running after its open socket readiness lease expires, then accepts the pinned reply and advances once', async () => {
+    const readinessLeaseMs = 200;
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: String(readinessLeaseMs) });
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'plugin-open-socket-expiry', 'Open Socket Expiry', 'Raw-Open-Socket-Expiry', [
+      'fileGuard', 'correlatedHeartbeatV1', 'appProbeV1',
+    ]);
+    const pluginFrames = collectFrames(plugin);
+    const cliA = await connectSocket(port);
+    const jobA = await sendMutatingJob(cliA, 'req-open-socket-expiry-a');
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-a'));
+    const cliB = await connectSocket(port);
+    const jobB = await sendMutatingJob(cliB, 'req-open-socket-expiry-b');
+
+    // No WebSocket close: application readiness may age out, but its in-flight reply
+    // route remains pinned to this still-open plugin instance.
+    await new Promise((resolve) => setTimeout(resolve, readinessLeaseMs + 50));
+    const { hello: staleHello } = await connectAndAwaitBrokerHello(port);
+    const stalePlugin = (staleHello.data as { plugins: Array<{ instanceId: string; state: string; appReadinessAge: number; runningJob?: JobInfo }> })
+      .plugins.find((entry) => entry.instanceId === 'plugin-open-socket-expiry');
+    expect(stalePlugin).toMatchObject({
+      state: 'connected', runningJob: { jobId: jobA, state: 'running' },
+    });
+    expect(stalePlugin?.appReadinessAge).toBeGreaterThan(readinessLeaseMs);
+    expect((await pollJob(cliA, jobA, 'req-open-socket-expiry-poll-a-stale')).job.state).toBe('running');
+    expect((await pollJob(cliB, jobB, 'req-open-socket-expiry-poll-b-stale')).job.state).toBe('queued');
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-a')).toHaveLength(1);
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-b')).toHaveLength(0);
+
+    const completed = nextFrame<ReplyOk>(cliA, (frame) => (frame as ReplyOk).id === 'req-open-socket-expiry-a');
+    plugin.send(JSON.stringify({ id: 'req-open-socket-expiry-a', ok: true, result: { settled: true } } satisfies ReplyOk));
+    expect((await completed).result).toEqual({ settled: true });
+    await waitFor(() => pluginFrames.frames.some((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-b'));
+
+    const settledA = await pollJob(cliA, jobA, 'req-open-socket-expiry-poll-a-settled');
+    expect(settledA.job).toMatchObject({ jobId: jobA, state: 'done' });
+    expect(settledA.job.state).not.toBe('outcome-unknown');
+    expect(settledA.lateReplyCount).toBeUndefined();
+    expect((await pollJob(cliB, jobB, 'req-open-socket-expiry-poll-b-running')).job.state).toBe('running');
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-a')).toHaveLength(1);
+    expect(pluginFrames.frames.filter((frame) => (frame as { id?: string }).id === 'req-open-socket-expiry-b')).toHaveLength(1);
+  });
+
   it('force-release reserves once; cancel beats deadline and stale-generation ACK while the next deadline drains once', async () => {
     const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200', [PLUGIN_WAIT_MS_KEY]: '100' });
     const plugin = await connectSocket(port);
@@ -1780,6 +1884,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     const polledA = await pollJob(cliA, jobA, 'req-fr2-poll-a');
     expect(polledA.job.state).toBe('failed');
     await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr2-b'));
+    expect(pluginFrames.frames.filter((f) => (f as { id?: string }).id === 'req-fr2-b')).toHaveLength(1);
     const polledB = await pollJob(cliB, jobB, 'req-fr2-poll-b');
     expect(polledB.job.state).toBe('running');
   });
@@ -1804,6 +1909,11 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
 
     const cliB = await connectSocket(port);
     const jobB = await sendMutatingJob(cliB, 'req-fr3-b'); // QUEUED — slot still held by wedged job A
+    expect((await pollJob(cliA, jobA, 'req-fr3-poll-held')).job).toMatchObject({
+      jobId: jobA,
+      state: 'failed',
+    });
+    expect((await pollJob(cliB, jobB, 'req-fr3-poll-queued')).job.state).toBe('queued');
 
     cliA.send(JSON.stringify(makeRequestFrame('req-fr3-release', 'JOB', { mode: 'force-release', jobId: jobA })));
     const reply = await nextFrame<ReplyOk>(cliA, (m) => (m as ReplyOk).id === 'req-fr3-release');
@@ -1811,6 +1921,7 @@ describe('daemon harness — force-release refuses a HEALTHY running job, allows
     expect((reply.result as { ok: boolean }).ok).toBe(true); // allowed WITHOUT --force — the legitimate unwedge path, unregressed
 
     await waitFor(() => pluginFrames.frames.some((f) => (f as { id?: string }).id === 'req-fr3-b'));
+    expect(pluginFrames.frames.filter((f) => (f as { id?: string }).id === 'req-fr3-b')).toHaveLength(1);
     const polledB = await pollJob(cliB, jobB, 'req-fr3-poll-b');
     expect(polledB.job.state).toBe('running');
   });

--- a/tests/broker-status.test.ts
+++ b/tests/broker-status.test.ts
@@ -33,6 +33,20 @@ describe('buildBrokerHelloData — plugins list + activePlugin', () => {
     expect(d).toMatchObject({ port: 9410, pid: 4242, protocolV: 1, uptimeMs: 5000 });
   });
 
+  it('advertises readiness v1 while preserving connected transport for a stale app', () => {
+    let t = 1_000;
+    const reg = new PluginRegistry<RegistrySocket>(() => t);
+    reg.register(sock(), { instanceId: 'legacy', fileName: 'Idle', caps: ['fileGuard'] });
+    t += 25_001;
+    const d = buildBrokerHelloData(reg, META, null, () => t);
+    expect(d.appReadinessV).toBe(1);
+    expect(d.pluginConnected).toBe(true);
+    expect(d.pluginState).toBe('connected');
+    expect((d.plugins as Array<Record<string, unknown>>)[0]).toMatchObject({
+      state: 'connected', appReady: false, appState: 'unready', appHeartbeatMode: 'legacy', appReadinessAge: 25_001,
+    });
+  });
+
   it('two files → both listed; activePlugin + legacy mirror track the most-recent', () => {
     let t = 1_000;
     const reg = new PluginRegistry<RegistrySocket>(() => t);

--- a/tests/connection-state.test.ts
+++ b/tests/connection-state.test.ts
@@ -3,7 +3,7 @@
 // through; the payload shape is the contract the P2 panel redesign consumes.
 import { describe, it, expect } from 'vitest';
 import {
-  makeStatePayload, reduceConnState, PROTOCOL_VERSION,
+  makeStatePayload, PLUGIN_CAPABILITIES, reduceConnState, PROTOCOL_VERSION,
   type ConnectionState,
 } from '../shared/protocol.ts';
 
@@ -36,6 +36,11 @@ describe('reduceConnState — disconnected→probing→handshake→connected', (
 });
 
 describe('makeStatePayload — the UI contract', () => {
+  it('keeps protocol v1 while advertising additive heartbeat capabilities', () => {
+    expect(PROTOCOL_VERSION).toBe(1);
+    expect(PLUGIN_CAPABILITIES).toEqual(['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+  });
+
   it('stamps type + protocolVersion and echoes the state', () => {
     const p = makeStatePayload('connected', { brokerUrl: 'ws://localhost:9410', port: 9410 });
     expect(p.type).toBe('CONN_STATE');
@@ -51,5 +56,21 @@ describe('makeStatePayload — the UI contract', () => {
     const p = makeStatePayload('probing', { detail: 'probing localhost:9411…' });
     expect(p.since).toBeGreaterThanOrEqual(before);
     expect(p.detail).toBe('probing localhost:9411…');
+  });
+
+  it('carries additive application state through handshake and readiness', () => {
+    expect(makeStatePayload('handshake', { appState: 'probing' }).appState).toBe('probing');
+    expect(makeStatePayload('connected', { appState: 'ready' }).appState).toBe('ready');
+  });
+
+  it('preserves the legacy payload shape when application state is omitted', () => {
+    const payload = makeStatePayload('handshake', { since: 123, brokerUrl: 'ws://localhost:9410' });
+    expect(payload).toEqual({
+      type: 'CONN_STATE',
+      state: 'handshake',
+      since: 123,
+      protocolVersion: PROTOCOL_VERSION,
+      brokerUrl: 'ws://localhost:9410',
+    });
   });
 });

--- a/tests/cowork-harness.test.ts
+++ b/tests/cowork-harness.test.ts
@@ -112,9 +112,16 @@ function sendEditFeed(
   } satisfies EventMsg));
 }
 
-function sendCowork(ws: WebSocket, reqId: string, opts: { waitMs: number; timeoutMs: number; expectedFile?: string }): void {
+function sendCowork(
+  ws: WebSocket,
+  reqId: string,
+  opts: { waitMs: number; timeoutMs: number; expectedFile?: string; targetFileKey?: string },
+): void {
   ws.send(JSON.stringify(
-    makeRequestFrame(reqId, 'COWORK', { waitMs: opts.waitMs, timeoutMs: opts.timeoutMs }, undefined, opts.expectedFile),
+    makeRequestFrame(
+      reqId, 'COWORK', { waitMs: opts.waitMs, timeoutMs: opts.timeoutMs },
+      undefined, opts.expectedFile, undefined, undefined, undefined, undefined, opts.targetFileKey,
+    ),
   ));
 }
 
@@ -139,6 +146,27 @@ afterEach(async () => {
 });
 
 describe('cowork — application readiness is checked before waiter creation', () => {
+  it('an exact raw-key cowork watches only B even when A is newer and ready', async () => {
+    const port = await startTestBroker();
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-cw-raw-b', 'Cowork Raw B', 'raw-cowork-b');
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-cw-newer-a', 'Cowork Newer A', 'raw-cowork-a');
+    const cli = await connectSocket(port);
+    const replyPromise = nextFrame<ReplyOk | ReplyErr>(cli, (frame) =>
+      (frame as ReplyOk | ReplyErr).id === 'req-cw-raw-b');
+
+    sendCowork(cli, 'req-cw-raw-b', { waitMs: 30, timeoutMs: 500, targetFileKey: 'raw-cowork-b' });
+    sendEditFeed(pluginA, [ownerEdit('newer-a:1')], { fileKey: 'raw-cowork-a', fileName: 'Cowork Newer A' });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    sendEditFeed(pluginB, [ownerEdit('raw-b:1')], { fileKey: 'raw-cowork-b', fileName: 'Cowork Raw B' });
+
+    expect(await replyPromise).toMatchObject({
+      ok: true,
+      result: { cycles: 1, file: 'Cowork Raw B', edits: [{ nodeId: 'raw-b:1' }] },
+    });
+  });
+
   it('unfiltered cowork watches the older ready plugin instead of failing on a newer stale plugin', async () => {
     const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200' });
     const pluginA = await connectSocket(port);
@@ -174,6 +202,89 @@ describe('cowork — application readiness is checked before waiter creation', (
     expect(collected.replies[0]).toMatchObject({ ok: false, error: { code: 'E_APP_UNREADY' } });
 
     sendEditFeed(plugin, [ownerEdit('unready:1')], { fileKey: 'raw-cowork', fileName: 'Cowork Unready', source: 'gapfill' });
+    await new Promise((resolve) => setTimeout(resolve, 130));
+    expect(collected.replies).toHaveLength(1);
+  });
+
+  it('fails an exact raw-key unready target before waiter creation even while another file is ready', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '30' });
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-cw-ready-other', 'Cowork Ready Other', 'raw-cowork-ready', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginC = await connectSocket(port);
+    await helloPlugin(pluginC, 'inst-cw-unready-raw-c', 'Cowork Unready Raw C', 'raw-cowork-c', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    pluginA.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: 'cowork-ready-other' } } satisfies EventMsg));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const cli = await connectSocket(port);
+    const collected = { replies: [] as Array<ReplyOk | ReplyErr> };
+    cli.on('message', (raw) => {
+      const frame = JSON.parse(raw.toString()) as ReplyOk | ReplyErr;
+      if (frame.id === 'req-cw-unready-raw-c') collected.replies.push(frame);
+    });
+
+    sendCowork(cli, 'req-cw-unready-raw-c', {
+      waitMs: 30, timeoutMs: 100, targetFileKey: 'raw-cowork-c',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(collected.replies).toHaveLength(1);
+    expect(collected.replies[0]).toMatchObject({ ok: false, error: { code: 'E_APP_UNREADY' } });
+
+    sendEditFeed(pluginC, [ownerEdit('unready-raw-c:1')], {
+      fileKey: 'raw-cowork-c', fileName: 'Cowork Unready Raw C', source: 'gapfill',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 130));
+    expect(collected.replies).toHaveLength(1);
+  });
+});
+
+describe('cowork — raw target validation and missing-target refusal', () => {
+  it('rejects blank, padded, non-string, and selector-conflicting targetFileKey values', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-cw-validation', 'Cowork Validation', 'raw-cowork-validation');
+    const cli = await connectSocket(port);
+    const invalidFrames = [
+      { id: 'req-cw-raw-blank', targetFileKey: '' },
+      { id: 'req-cw-raw-padded', targetFileKey: ' raw-cowork-validation ' },
+      { id: 'req-cw-raw-number', targetFileKey: 42 },
+      { id: 'req-cw-raw-file-conflict', targetFileKey: 'raw-cowork-validation', expectedFile: 'Cowork Validation' },
+      { id: 'req-cw-raw-instance-conflict', targetFileKey: 'raw-cowork-validation', expectedInstance: 'inst-cw-validation' },
+    ];
+
+    for (const frame of invalidFrames) {
+      const replyPromise = nextFrame<ReplyErr>(cli, (reply) => (reply as ReplyErr).id === frame.id);
+      cli.send(JSON.stringify({
+        id: frame.id,
+        cmd: 'COWORK',
+        params: { waitMs: 30, timeoutMs: 100 },
+        v: 1,
+        ...frame,
+      }));
+      expect((await replyPromise).error.code).toBe('E_INVALID_ARGS');
+    }
+  });
+
+  it('returns E_NO_PLUGIN for a missing exact raw key and creates no fallback waiter', async () => {
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-cw-present-a', 'Cowork Present A', 'raw-cowork-present-a');
+    const cli = await connectSocket(port);
+    const collected = { replies: [] as Array<ReplyOk | ReplyErr> };
+    cli.on('message', (raw) => {
+      const frame = JSON.parse(raw.toString()) as ReplyOk | ReplyErr;
+      if (frame.id === 'req-cw-missing-raw') collected.replies.push(frame);
+    });
+
+    sendCowork(cli, 'req-cw-missing-raw', {
+      waitMs: 30, timeoutMs: 100, targetFileKey: 'raw-cowork-missing',
+    });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(collected.replies).toHaveLength(1);
+    expect(collected.replies[0]).toMatchObject({ ok: false, error: { code: 'E_NO_PLUGIN' } });
+
+    sendEditFeed(plugin, [ownerEdit('present-a:1')], {
+      fileKey: 'raw-cowork-present-a', fileName: 'Cowork Present A',
+    });
     await new Promise((resolve) => setTimeout(resolve, 130));
     expect(collected.replies).toHaveLength(1);
   });

--- a/tests/cowork-harness.test.ts
+++ b/tests/cowork-harness.test.ts
@@ -17,16 +17,19 @@ type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts')
 const CHANGES_DIR_KEY = 'FIGMA_AGENT_CHANGES_DIR';
 const BINDS_FILE_KEY = 'FIGMA_AGENT_BINDS_FILE';
 const UNBOUND_DIR_KEY = 'FIGMA_AGENT_UNBOUND_DIR';
+const APP_READINESS_MS_KEY = 'FIGMA_AGENT_APP_READINESS_MS';
 
 let scratchDir: string;
 let advertisePath: string;
 let scratchLogFile: string;
 let sockets: WebSocket[];
+let priorAppReadinessMs: string | undefined;
 
-async function loadBrokerDaemon(): Promise<BrokerDaemonModule> {
+async function loadBrokerDaemon(env: Record<string, string> = {}): Promise<BrokerDaemonModule> {
   process.env[CHANGES_DIR_KEY] = scratchDir;
   process.env[BINDS_FILE_KEY] = join(scratchDir, 'binds.json');
   process.env[UNBOUND_DIR_KEY] = join(scratchDir, 'unbound-root');
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
   vi.resetModules();
   return import('../cli/src/transport/broker-daemon.ts');
 }
@@ -37,8 +40,8 @@ function testExit(): (code: number) => never {
   };
 }
 
-async function startTestBroker(): Promise<number> {
-  const mod = await loadBrokerDaemon();
+async function startTestBroker(env: Record<string, string> = {}): Promise<number> {
+  const mod = await loadBrokerDaemon(env);
   await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit(), logFile: scratchLogFile });
   const { readFileSync } = await import('node:fs');
   const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number };
@@ -54,8 +57,11 @@ function connectSocket(port: number): Promise<WebSocket> {
   });
 }
 
-async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null): Promise<void> {
-  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey, caps: ['fileGuard'] } }));
+async function helloPlugin(
+  ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null,
+  caps: string[] = ['fileGuard'],
+): Promise<void> {
+  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey, caps } }));
   await new Promise<void>((resolvePromise) => {
     const handler = (raw: WebSocket.RawData): void => {
       const msg = JSON.parse(raw.toString()) as { type?: string };
@@ -113,6 +119,7 @@ function sendCowork(ws: WebSocket, reqId: string, opts: { waitMs: number; timeou
 }
 
 beforeEach(() => {
+  priorAppReadinessMs = process.env[APP_READINESS_MS_KEY];
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-cowork-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
   scratchLogFile = join(scratchDir, 'broker.log');
@@ -120,8 +127,56 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  const shutdownSocket = sockets.find((ws) => ws.readyState === WebSocket.OPEN);
+  if (shutdownSocket) {
+    try { shutdownSocket.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' })); } catch { /* already closed */ }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
   for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
   rmSync(scratchDir, { recursive: true, force: true });
+  if (priorAppReadinessMs === undefined) delete process.env[APP_READINESS_MS_KEY];
+  else process.env[APP_READINESS_MS_KEY] = priorAppReadinessMs;
+});
+
+describe('cowork — application readiness is checked before waiter creation', () => {
+  it('unfiltered cowork watches the older ready plugin instead of failing on a newer stale plugin', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '200' });
+    const pluginA = await connectSocket(port);
+    await helloPlugin(pluginA, 'inst-cw-ready-a', 'Cowork Ready A', 'raw-cowork-a', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    const pluginB = await connectSocket(port);
+    await helloPlugin(pluginB, 'inst-cw-stale-b', 'Cowork Stale B', 'raw-cowork-b', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    pluginA.send(JSON.stringify({ type: 'APP_PROBE_ACK', data: { probeId: 'cowork-ready-a' } } satisfies EventMsg));
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    const cli = await connectSocket(port);
+    const reply = nextFrame<ReplyOk | ReplyErr>(cli, (frame) => (frame as ReplyOk | ReplyErr).id === 'req-cw-ready-first');
+    sendCowork(cli, 'req-cw-ready-first', { waitMs: 30, timeoutMs: 500 });
+    sendEditFeed(pluginA, [ownerEdit('ready-a:1')], { fileKey: 'raw-cowork-a', fileName: 'Cowork Ready A' });
+
+    expect(await reply).toMatchObject({ ok: true, result: { cycles: 1, file: 'Cowork Ready A' } });
+  });
+
+  it('fails an exact unready target immediately and a later gap-fill cannot arm a hidden waiter', async () => {
+    const port = await startTestBroker({ [APP_READINESS_MS_KEY]: '30' });
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'inst-cw-unready', 'Cowork Unready', 'raw-cowork', ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1']);
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    const cli = await connectSocket(port);
+    const collected = { replies: [] as Array<ReplyOk | ReplyErr> };
+    cli.on('message', (raw) => {
+      const frame = JSON.parse(raw.toString()) as ReplyOk | ReplyErr;
+      if (frame.id === 'req-cw-unready') collected.replies.push(frame);
+    });
+
+    sendCowork(cli, 'req-cw-unready', { waitMs: 30, timeoutMs: 100, expectedFile: 'Cowork Unready' });
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(collected.replies).toHaveLength(1);
+    expect(collected.replies[0]).toMatchObject({ ok: false, error: { code: 'E_APP_UNREADY' } });
+
+    sendEditFeed(plugin, [ownerEdit('unready:1')], { fileKey: 'raw-cowork', fileName: 'Cowork Unready', source: 'gapfill' });
+    await new Promise((resolve) => setTimeout(resolve, 130));
+    expect(collected.replies).toHaveLength(1);
+  });
 });
 
 describe('cowork — fires on a genuine owner cycle', () => {

--- a/tests/cowork-harness.test.ts
+++ b/tests/cowork-harness.test.ts
@@ -18,12 +18,14 @@ const CHANGES_DIR_KEY = 'FIGMA_AGENT_CHANGES_DIR';
 const BINDS_FILE_KEY = 'FIGMA_AGENT_BINDS_FILE';
 const UNBOUND_DIR_KEY = 'FIGMA_AGENT_UNBOUND_DIR';
 const APP_READINESS_MS_KEY = 'FIGMA_AGENT_APP_READINESS_MS';
+const PLUGIN_WAIT_MS_KEY = 'FIGMA_AGENT_PLUGIN_WAIT_MS';
 
 let scratchDir: string;
 let advertisePath: string;
 let scratchLogFile: string;
 let sockets: WebSocket[];
 let priorAppReadinessMs: string | undefined;
+let priorPluginWaitMs: string | undefined;
 
 async function loadBrokerDaemon(env: Record<string, string> = {}): Promise<BrokerDaemonModule> {
   process.env[CHANGES_DIR_KEY] = scratchDir;
@@ -81,6 +83,26 @@ function nextFrame<T extends WireMsg | EventMsg>(ws: WebSocket, predicate?: (m: 
   });
 }
 
+function nextFrameByDeadline<T extends WireMsg | EventMsg>(
+  ws: WebSocket, predicate: (m: WireMsg) => boolean, deadlineMs: number,
+): Promise<T | undefined> {
+  return new Promise((resolvePromise) => {
+    const handler = (raw: WebSocket.RawData): void => {
+      const msg = JSON.parse(raw.toString()) as WireMsg;
+      if (predicate(msg)) {
+        clearTimeout(timer);
+        ws.off('message', handler);
+        resolvePromise(msg as T);
+      }
+    };
+    const timer = setTimeout(() => {
+      ws.off('message', handler);
+      resolvePromise(undefined);
+    }, deadlineMs);
+    ws.on('message', handler);
+  });
+}
+
 interface EditInputLike {
   op: 'created' | 'updated' | 'deleted';
   nodeId: string;
@@ -127,6 +149,7 @@ function sendCowork(
 
 beforeEach(() => {
   priorAppReadinessMs = process.env[APP_READINESS_MS_KEY];
+  priorPluginWaitMs = process.env[PLUGIN_WAIT_MS_KEY];
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-cowork-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
   scratchLogFile = join(scratchDir, 'broker.log');
@@ -143,6 +166,8 @@ afterEach(async () => {
   rmSync(scratchDir, { recursive: true, force: true });
   if (priorAppReadinessMs === undefined) delete process.env[APP_READINESS_MS_KEY];
   else process.env[APP_READINESS_MS_KEY] = priorAppReadinessMs;
+  if (priorPluginWaitMs === undefined) delete process.env[PLUGIN_WAIT_MS_KEY];
+  else process.env[PLUGIN_WAIT_MS_KEY] = priorPluginWaitMs;
 });
 
 describe('cowork — application readiness is checked before waiter creation', () => {
@@ -239,7 +264,9 @@ describe('cowork — application readiness is checked before waiter creation', (
 
 describe('cowork — raw target validation and missing-target refusal', () => {
   it('rejects blank, padded, non-string, and selector-conflicting targetFileKey values', async () => {
-    const port = await startTestBroker();
+    // The broker's park sweep is min(500ms, pluginWait/8); 800ms gives a 100ms
+    // sweep, so the no-second-reply observation covers at least two intervals.
+    const port = await startTestBroker({ [PLUGIN_WAIT_MS_KEY]: '800' });
     const plugin = await connectSocket(port);
     await helloPlugin(plugin, 'inst-cw-validation', 'Cowork Validation', 'raw-cowork-validation');
     const cli = await connectSocket(port);
@@ -261,6 +288,17 @@ describe('cowork — raw target validation and missing-target refusal', () => {
         ...frame,
       }));
       expect((await replyPromise).error.code).toBe('E_INVALID_ARGS');
+
+      const noSecondReply = nextFrameByDeadline<ReplyErr>(
+        cli, (reply) => (reply as ReplyErr).id === frame.id, 250,
+      );
+      sendEditFeed(plugin, [ownerEdit(`${frame.id}:live`)], {
+        fileKey: 'raw-cowork-validation', fileName: 'Cowork Validation', source: 'live',
+      });
+      sendEditFeed(plugin, [ownerEdit(`${frame.id}:gapfill`)], {
+        fileKey: 'raw-cowork-validation', fileName: 'Cowork Validation', source: 'gapfill',
+      });
+      expect(await noSecondReply).toBeUndefined();
     }
   });
 

--- a/tests/file-queue.test.ts
+++ b/tests/file-queue.test.ts
@@ -36,6 +36,16 @@ describe('complete', () => {
     expect(r.q.waiting).toEqual(['job-c']);
   });
 
+  it('moves the next FIFO head into the slot owner without leaving it in waiting', () => {
+    let q: QueueState = emptyQueue();
+    ({ q } = enqueue(q, 'job-a'));
+    ({ q } = enqueue(q, 'job-b'));
+    ({ q } = enqueue(q, 'job-c'));
+    const r = complete(q, 'job-a');
+    expect(r.q).toEqual({ running: 'job-b', waiting: ['job-c'] });
+    expect(queuePosition(r.q, 'job-b')).toBeUndefined();
+  });
+
   it('reports next: null when nothing is waiting', () => {
     let q: QueueState = emptyQueue();
     ({ q } = enqueue(q, 'job-a'));

--- a/tests/force-release-guard.test.ts
+++ b/tests/force-release-guard.test.ts
@@ -41,4 +41,12 @@ describe('buildForceReleaseAuditLine — the requester is never silent', () => {
     expect(overridden).toContain('--force override');
     expect(bare).not.toContain('--force override');
   });
+
+  it('records outcome-unknown as the inspected prior state', () => {
+    const line = buildForceReleaseAuditLine(
+      'j_1_1', 'EXEC_JS', 'fileA', false, 'Inspect then force-release', 'outcome-unknown',
+    );
+    expect(line).toContain('[outcome-unknown]');
+    expect(line).toContain('Inspect then force-release');
+  });
 });

--- a/tests/force-release-guard.test.ts
+++ b/tests/force-release-guard.test.ts
@@ -6,7 +6,21 @@
 // mechanics, advanceQueue) is exercised by the daemon harness (tests/broker-daemon-
 // harness.test.ts) instead, since it needs the real closures.
 import { describe, expect, it } from 'vitest';
-import { buildForceReleaseAuditLine } from '../cli/src/transport/broker-daemon.ts';
+import { buildForceReleaseAuditLine, reservedForceReleaseReason } from '../cli/src/transport/broker-daemon.ts';
+
+describe('reservedForceReleaseReason', () => {
+  it('refuses a reserved queued head with the exact cancel command', () => {
+    expect(reservedForceReleaseReason('j_1_1', 'queued', 'j_1_1')).toBe(
+      "job 'j_1_1' is queued and has not been dispatched; use: figma-agent job j_1_1 --cancel",
+    );
+  });
+
+  it('does not classify waiting, running, or terminal jobs as reserved', () => {
+    expect(reservedForceReleaseReason('j_1_1', 'queued', 'j_other')).toBeNull();
+    expect(reservedForceReleaseReason('j_1_1', 'running', 'j_1_1')).toBeNull();
+    expect(reservedForceReleaseReason('j_1_1', 'failed', 'j_1_1')).toBeNull();
+  });
+});
 
 describe('buildForceReleaseAuditLine — the requester is never silent', () => {
   it('includes the requester\'s activity label', () => {

--- a/tests/heartbeat-driver.test.ts
+++ b/tests/heartbeat-driver.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { createHeartbeatDriver } from '../plugin/src/ui/heartbeat-driver.ts';
+
+describe('heartbeat driver effect ordering', () => {
+  it('challenges before teardown when a scheduled callback resumes after the stale threshold', () => {
+    let now = 0;
+    let scheduled: (() => void) | undefined;
+    const effects: string[] = [];
+    let probeCounter = 0;
+    const driver = createHeartbeatDriver({
+      now: () => now,
+      nextProbeId: () => `probe-${++probeCounter}`,
+      schedule: (callback) => { scheduled = callback; return 'timer'; },
+      cancel: () => { scheduled = undefined; },
+      sendProbe: (probeId) => { effects.push(`send:${probeId}`); },
+      teardown: () => { effects.push('teardown'); },
+      emitConnected: () => { effects.push('connected'); },
+    }, { intervalMs: 10_000, timeoutMs: 25_000 });
+
+    driver.start('correlated');
+    effects.length = 0;
+    now = 26_000;
+    scheduled?.();
+
+    expect(effects).toEqual(['send:probe-2']);
+    now = 36_000; scheduled?.();
+    now = 46_000; scheduled?.();
+    now = 56_000; scheduled?.();
+    expect(effects).toEqual(['send:probe-2', 'teardown']);
+  });
+
+  it('emits connected once and only for the current correlated response', () => {
+    let now = 0;
+    let scheduled: (() => void) | undefined;
+    const effects: string[] = [];
+    let probeCounter = 0;
+    const driver = createHeartbeatDriver({
+      now: () => now,
+      nextProbeId: () => `probe-${++probeCounter}`,
+      schedule: (callback) => { scheduled = callback; return callback; },
+      cancel: () => { scheduled = undefined; },
+      sendProbe: (probeId) => { effects.push(`send:${probeId}`); },
+      teardown: () => { effects.push('teardown'); },
+      emitConnected: () => { effects.push('connected'); },
+    }, { intervalMs: 10_000, timeoutMs: 25_000 });
+
+    driver.start('correlated');
+    expect(driver.receivePong('old-probe')).toBe(false);
+    expect(driver.receivePong('probe-1')).toBe(true);
+    expect(driver.receivePong('probe-1')).toBe(false);
+    expect(effects).toEqual(['send:probe-1', 'connected']);
+  });
+
+  it('accepts an uncorrelated response in legacy mode after probing', () => {
+    let scheduled: (() => void) | undefined;
+    const effects: string[] = [];
+    const driver = createHeartbeatDriver({
+      now: () => 0,
+      nextProbeId: () => 'legacy-probe',
+      schedule: (callback) => { scheduled = callback; return callback; },
+      cancel: () => { scheduled = undefined; },
+      sendProbe: (_probeId, mode) => { effects.push(`send:${mode}`); },
+      teardown: () => { effects.push('teardown'); },
+      emitConnected: () => { effects.push('connected'); },
+    }, { intervalMs: 10_000, timeoutMs: 25_000 });
+
+    driver.start('legacy');
+    expect(driver.receivePong()).toBe(true);
+    expect(effects).toEqual(['send:legacy', 'connected']);
+  });
+
+  it('cancels the old schedule when a new socket generation is adopted', () => {
+    let now = 0;
+    const scheduled: Array<() => void> = [];
+    const effects: string[] = [];
+    let probeCounter = 0;
+    const driver = createHeartbeatDriver({
+      now: () => now,
+      nextProbeId: () => `probe-${++probeCounter}`,
+      schedule: (callback) => { scheduled.push(callback); return callback; },
+      cancel: () => {},
+      sendProbe: (probeId) => { effects.push(`send:${probeId}`); },
+      teardown: () => { effects.push('teardown'); },
+      emitConnected: () => { effects.push('connected'); },
+    }, { intervalMs: 10_000, timeoutMs: 25_000 });
+
+    driver.start('correlated');
+    const staleCallback = scheduled[0];
+    driver.start('correlated');
+    effects.length = 0;
+    now = 26_000;
+    staleCallback?.();
+
+    expect(effects).toEqual([]);
+    expect(driver.receivePong('probe-1')).toBe(false);
+    expect(driver.receivePong('probe-2')).toBe(true);
+    expect(effects).toEqual(['connected']);
+  });
+});

--- a/tests/heartbeat-lease.test.ts
+++ b/tests/heartbeat-lease.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import {
+  reduceHeartbeatLease,
+  startHeartbeatLease,
+  type HeartbeatLeaseDecision,
+} from '../plugin/src/ui/heartbeat-lease.ts';
+
+const config = { intervalMs: 10_000, timeoutMs: 25_000 };
+
+function tick(decision: HeartbeatLeaseDecision, now: number, nextProbeId: string) {
+  return reduceHeartbeatLease(decision.state, { type: 'tick', now, nextProbeId }, config);
+}
+
+describe('heartbeat lease', () => {
+  it('starts with one correlated challenge and accepts only its response', () => {
+    const started = startHeartbeatLease('correlated', 0, 'probe-1', config);
+    expect(started.effects).toEqual([{ type: 'send-challenge', probeId: 'probe-1' }]);
+
+    const mismatched = reduceHeartbeatLease(started.state, {
+      type: 'pong', now: 1, probeId: 'probe-old',
+    }, config);
+    expect(mismatched.effects).toEqual([]);
+    expect(mismatched.state.phase).toBe('probing');
+
+    const accepted = reduceHeartbeatLease(started.state, {
+      type: 'pong', now: 2, probeId: 'probe-1',
+    }, config);
+    expect(accepted.effects).toEqual([{ type: 'accepted-current' }]);
+    expect(accepted.state.phase).toBe('ready');
+    expect(accepted.state.currentProbeId).toBeNull();
+  });
+
+  it('issues a fresh suspect challenge before closing after a normal missed deadline', () => {
+    let decision = startHeartbeatLease('correlated', 0, 'probe-1', config);
+    decision = tick(decision, 10_000, 'unused-1');
+    decision = tick(decision, 20_000, 'unused-2');
+    decision = tick(decision, 30_000, 'probe-2');
+    expect(decision.effects).toEqual([{ type: 'send-challenge', probeId: 'probe-2' }]);
+    expect(decision.state.phase).toBe('suspect');
+
+    decision = tick(decision, 40_000, 'unused-3');
+    decision = tick(decision, 50_000, 'unused-4');
+    decision = tick(decision, 60_000, 'unused-5');
+    expect(decision.effects).toEqual([{ type: 'teardown' }]);
+  });
+
+  it('treats a delayed scheduler callback as suspension and refreshes the challenge', () => {
+    let decision = startHeartbeatLease('correlated', 0, 'probe-1', config);
+    decision = tick(decision, 26_000, 'probe-2');
+    expect(decision.effects).toEqual([{ type: 'send-challenge', probeId: 'probe-2' }]);
+    expect(decision.state.deadline).toBe(51_000);
+
+    const stale = reduceHeartbeatLease(decision.state, {
+      type: 'pong', now: 27_000, probeId: 'probe-1',
+    }, config);
+    expect(stale.effects).toEqual([]);
+    expect(stale.state.phase).toBe('suspect');
+
+    decision = tick(stale, 36_000, 'unused-1');
+    decision = tick(decision, 46_000, 'unused-2');
+    decision = tick(decision, 56_000, 'unused-3');
+    expect(decision.effects).toEqual([{ type: 'teardown' }]);
+  });
+
+  it('accepts an uncorrelated response only in explicit legacy mode', () => {
+    const legacy = startHeartbeatLease('legacy', 0, 'legacy-probe', config);
+    expect(reduceHeartbeatLease(legacy.state, { type: 'pong', now: 1 }, config).effects)
+      .toEqual([{ type: 'accepted-current' }]);
+    expect(reduceHeartbeatLease(legacy.state, {
+      type: 'pong', now: 1, probeId: 'mismatched',
+    }, config).effects).toEqual([]);
+
+    const correlated = startHeartbeatLease('correlated', 0, 'correlated-probe', config);
+    expect(reduceHeartbeatLease(correlated.state, { type: 'pong', now: 1 }, config).effects)
+      .toEqual([]);
+  });
+});

--- a/tests/job-command.test.ts
+++ b/tests/job-command.test.ts
@@ -9,7 +9,7 @@ import { describe, expect, it, vi } from 'vitest';
 // implementation either (`waitForJob`'s tests inject their own poll/wait).
 vi.mock('../cli/src/transport/broker-client.ts', () => ({ runCommand: vi.fn() }));
 
-import { formatPoll, isTerminal, run, unwrapResult, waitForJob, type PollReply } from '../cli/src/commands/job.ts';
+import { formatPoll, isPollSettled, isTerminal, run, unwrapResult, waitForJob, type PollReply } from '../cli/src/commands/job.ts';
 import { runCommand } from '../cli/src/transport/broker-client.ts';
 import { parseArgs } from '../cli/src/arg-parse.ts';
 import { CliError } from '../cli/src/transport/protocol-helpers.ts';
@@ -20,10 +20,12 @@ function jobInfo(over: Partial<JobInfo> & { state: JobInfo['state'] }): JobInfo 
 }
 
 describe('isTerminal', () => {
-  it('done/failed/cancelled are terminal; queued/running are not', () => {
+  it('keeps known terminal states separate from poll-settled uncertainty', () => {
     expect(isTerminal('done')).toBe(true);
     expect(isTerminal('failed')).toBe(true);
     expect(isTerminal('cancelled')).toBe(true);
+    expect(isTerminal('outcome-unknown')).toBe(false);
+    expect(isPollSettled('outcome-unknown')).toBe(true);
     expect(isTerminal('queued')).toBe(false);
     expect(isTerminal('running')).toBe(false);
   });
@@ -107,6 +109,45 @@ describe('formatPoll', () => {
     expect(isTerminal(job.state)).toBe(false);
   });
 
+  it('reports uncertainty without claiming success/failure and gives the exact inspection recovery', () => {
+    const job = jobInfo({
+      state: 'outcome-unknown',
+      uncertaintyReason: 'plugin transport disconnected after dispatch',
+      recovery: {
+        kind: 'inspect-and-force-release',
+        command: 'figma-agent job j_1_1 --force-release',
+        requiresCanvasInspection: true,
+        retryAllowed: false,
+      },
+    });
+    expect(formatPoll({ job })).toEqual({
+      job,
+      error: {
+        code: 'E_OUTCOME_UNKNOWN',
+        message: 'plugin transport disconnected after dispatch; the canvas may or may not have changed. Inspect the canvas, then force-release the held slot.',
+        jobId: 'j_1_1',
+        recovery: job.recovery,
+      },
+    });
+  });
+
+  it('reports a released unknown as inspected/unblocked with no consumed recovery or retry', () => {
+    const job = jobInfo({
+      state: 'outcome-unknown',
+      uncertaintyReason: 'plugin transport disconnected after dispatch',
+      finishedAt: 123,
+    });
+    const out = formatPoll({ job }) as { job: JobInfo; error: Record<string, unknown> };
+    expect(out.job).toBe(job);
+    expect(out.error).toEqual({
+      code: 'E_OUTCOME_UNKNOWN',
+      message: 'plugin transport disconnected after dispatch; canvas inspection and slot release are complete. The slot is no longer held, the canvas outcome remains unknown, and automatic retry is forbidden.',
+      jobId: 'j_1_1',
+    });
+    expect(out.error).not.toHaveProperty('recovery');
+    expect(out.error.message).not.toContain('force-release');
+  });
+
   it('a terminal job with no resultFrames still just reports {job} (defensive)', () => {
     expect(formatPoll({ job: jobInfo({ state: 'done' }) })).toEqual({ job: jobInfo({ state: 'done' }) });
   });
@@ -138,6 +179,23 @@ describe('waitForJob — cadence + timeout composition (injected poll/wait, no l
     const out = await waitForJob('j_1_1', 60_000, poll, wait);
     expect(out).toEqual({ job: jobInfo({ state: 'done' }), result: 'x' });
     expect(wait).not.toHaveBeenCalled(); // done on the FIRST poll — never slept at all
+  });
+
+  it('returns immediately on outcome unknown without sleeping or polling again', async () => {
+    const recovery = {
+      kind: 'inspect-and-force-release' as const,
+      command: 'figma-agent job j_1_1 --force-release',
+      requiresCanvasInspection: true as const,
+      retryAllowed: false as const,
+    };
+    const poll = vi.fn(async (): Promise<PollReply> => ({
+      job: jobInfo({ state: 'outcome-unknown', uncertaintyReason: 'transport lost', recovery }),
+    }));
+    const wait = vi.fn(async () => {});
+    const out = await waitForJob('j_1_1', 60_000, poll, wait);
+    expect(out).toMatchObject({ error: { code: 'E_OUTCOME_UNKNOWN', jobId: 'j_1_1', recovery } });
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(wait).not.toHaveBeenCalled();
   });
 
   it('polls repeatedly while running, then resolves once terminal', async () => {

--- a/tests/job-command.test.ts
+++ b/tests/job-command.test.ts
@@ -101,6 +101,12 @@ describe('formatPoll', () => {
     expect(formatPoll({ job: jobInfo({ state: 'running' }) })).toEqual({ job: jobInfo({ state: 'running' }) });
   });
 
+  it('preserves reserved-head cancel guidance state without presenting it as running', () => {
+    const job = jobInfo({ state: 'queued', dispatchState: 'queued-not-dispatched-readiness-wait' });
+    expect(formatPoll({ job })).toEqual({ job });
+    expect(isTerminal(job.state)).toBe(false);
+  });
+
   it('a terminal job with no resultFrames still just reports {job} (defensive)', () => {
     expect(formatPoll({ job: jobInfo({ state: 'done' }) })).toEqual({ job: jobInfo({ state: 'done' }) });
   });

--- a/tests/job-table.test.ts
+++ b/tests/job-table.test.ts
@@ -83,6 +83,39 @@ describe('JobTable — the finished cap', () => {
     expect(t.byId(ids[ids.length - 1]!)).not.toBe('expired');
   });
 
+  it('does not cap-evict a watchdog-failed slot owner before its audited release', () => {
+    const t = new JobTable();
+    const held = t.create(input({ requestId: 'watchdog-held' }));
+    t.markRunning(held.jobId);
+    t.finishHeld(held.jobId, false, ['{"error":"E_TIMEOUT"}']);
+
+    for (let i = 0; i < JOB_FINISHED_CAP + 5; i++) {
+      const rec = t.create(input({ requestId: `finished-${i}` }));
+      t.finish(rec.jobId, true, ['{}']);
+    }
+
+    expect(t.byId(held.jobId)).toBe(held);
+    expect(t.summaryFor(held.fileSlug, held.jobId).running).toMatchObject({
+      jobId: held.jobId,
+      state: 'failed',
+    });
+  });
+
+  it('cap-evicts a released watchdog-failed record normally', () => {
+    const t = new JobTable();
+    const held = t.create(input({ requestId: 'watchdog-released' }));
+    t.markRunning(held.jobId);
+    t.finishHeld(held.jobId, false, ['{"error":"E_TIMEOUT"}']);
+    expect(t.settleHeldTerminalRelease(held.jobId)).toBe(true);
+
+    for (let i = 0; i < JOB_FINISHED_CAP; i++) {
+      const rec = t.create(input({ requestId: `finished-after-release-${i}` }));
+      t.finish(rec.jobId, true, ['{}']);
+    }
+
+    expect(t.byId(held.jobId)).toBe('expired');
+  });
+
   it('never evicts a queued or running job to enforce the cap', () => {
     const t = new JobTable();
     const running = t.create(input({ requestId: 'keep-me' }));
@@ -170,6 +203,31 @@ describe('JobTable — summaryFor (per-file view for `status`)', () => {
     const summaryIdle = t.summaryFor('fileC', null);
     expect(summaryIdle.running).toBeNull();
     expect(summaryIdle.queueDepth).toBe(0);
+  });
+
+  it('does not TTL-evict a watchdog-failed slot owner, then starts retention from audited release time', () => {
+    const c = clock(100);
+    const t = new JobTable(c.now);
+    const held = t.create(input({ requestId: 'watchdog-held' }));
+    t.markRunning(held.jobId);
+    t.finishHeld(held.jobId, false, ['{"error":"E_TIMEOUT"}']);
+
+    c.advance(JOB_TTL_MS * 2);
+    expect(t.sweep()).toBe(0);
+    expect(t.byId(held.jobId)).toBe(held);
+    expect(t.summaryFor(held.fileSlug, held.jobId).running).toMatchObject({
+      jobId: held.jobId,
+      state: 'failed',
+    });
+
+    const releasedAt = c.now();
+    expect(t.settleHeldTerminalRelease(held.jobId)).toBe(true);
+    expect(held.finishedAt).toBe(releasedAt);
+    c.advance(JOB_TTL_MS - 1);
+    expect(t.sweep()).toBe(0);
+    c.advance(2);
+    expect(t.sweep()).toBe(1);
+    expect(t.byId(held.jobId)).toBe('expired');
   });
 
   it('a watchdog-timed-out job (state now "failed") still reports as running when the CALLER\'s queue pointer says so', () => {

--- a/tests/job-table.test.ts
+++ b/tests/job-table.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   JobTable, JOB_TTL_MS, JOB_FINISHED_CAP, JOB_FRAME_BYTES_CAP, isHealthyRunningJob,
+  isPollSettledState, isReplyDiscardState,
   toJobInfo,
   type CreateJobInput,
 } from '../cli/src/transport/job-table.ts';
@@ -274,6 +275,123 @@ describe('JobTable — markRunning / finish', () => {
       t.finish(other.jobId, true, ['{}']);
       expect(t.byId(other.jobId)).not.toBe('expired'); // not wrongly evicted by phantom cap pressure
     });
+  });
+});
+
+describe('JobTable — unknown mutation outcome', () => {
+  it('transitions only a running job once and projects exact recovery metadata', () => {
+    const t = new JobTable(() => 123, () => 'j_unknown');
+    const rec = t.create(input());
+    expect(t.markOutcomeUnknown(rec.jobId, 'plugin transport disconnected')).toBe(false);
+    t.markRunning(rec.jobId);
+    expect(t.markOutcomeUnknown(rec.jobId, 'plugin transport disconnected')).toBe(true);
+    expect(t.markOutcomeUnknown(rec.jobId, 'second loss')).toBe(false);
+    expect(toJobInfo(rec)).toEqual({
+      jobId: 'j_unknown', state: 'outcome-unknown', cmd: 'EXEC_JS', fileSlug: 'fileA',
+      queuedMs: 0, startedAt: 123,
+      uncertaintyReason: 'plugin transport disconnected',
+      recovery: {
+        kind: 'inspect-and-force-release',
+        command: 'figma-agent job j_unknown --force-release',
+        requiresCanvasInspection: true,
+        retryAllowed: false,
+      },
+    });
+  });
+
+  it('is poll-settled and reply-discarding, but never watchdog-running or TTL/cap finished', () => {
+    const c = clock();
+    const t = new JobTable(c.now);
+    const rec = t.create(input());
+    t.markRunning(rec.jobId);
+    expect(t.markOutcomeUnknown(rec.jobId, 'transport lost')).toBe(true);
+    expect(isPollSettledState(rec.state)).toBe(true);
+    expect(isReplyDiscardState(rec.state)).toBe(true);
+    expect(t.runningJobs()).toEqual([]);
+
+    c.advance(JOB_TTL_MS * 10);
+    t.sweep();
+    expect(t.byId(rec.jobId)).toBe(rec);
+
+    for (let i = 0; i < JOB_FINISHED_CAP + 5; i++) {
+      const finished = t.create(input({ requestId: `finished-${i}` }));
+      t.finish(finished.jobId, true, ['{}']);
+    }
+    expect(t.byId(rec.jobId)).toBe(rec);
+  });
+
+  it('discards and counts a late finish without changing uncertainty or storing its payload', () => {
+    const t = new JobTable(() => 1, () => 'j_unknown');
+    const rec = t.create(input());
+    t.markRunning(rec.jobId);
+    t.markOutcomeUnknown(rec.jobId, 'transport lost');
+    t.finish(rec.jobId, true, ['{"late":true}']);
+    expect(rec.state).toBe('outcome-unknown');
+    expect(rec.replyFrames).toEqual([]);
+    expect(rec.lateReplyCount).toBe(1);
+    expect(rec.uncertaintyReason).toBe('transport lost');
+  });
+
+  it('settles an inspected release once, preserves uncertainty, and expires from the release time', () => {
+    const c = clock(100);
+    const t = new JobTable(c.now);
+    const rec = t.create(input());
+    t.markRunning(rec.jobId);
+    t.markOutcomeUnknown(rec.jobId, 'transport lost');
+    c.advance(JOB_TTL_MS * 2);
+    t.sweep();
+    expect(t.byId(rec.jobId)).toBe(rec); // held unknown is still pinned
+
+    const releasedAt = c.now();
+    expect(t.settleOutcomeUnknownRelease(rec.jobId)).toBe(true);
+    expect(t.settleOutcomeUnknownRelease(rec.jobId)).toBe(false);
+    expect(rec).toMatchObject({
+      state: 'outcome-unknown', uncertaintyReason: 'transport lost',
+      forceReleased: true, finishedAt: releasedAt,
+    });
+    expect(rec.recovery).toBeUndefined();
+
+    c.advance(JOB_TTL_MS - 1);
+    t.sweep();
+    expect(t.byId(rec.jobId)).toBe(rec);
+    c.advance(2);
+    expect(t.sweep()).toBe(1);
+    expect(t.byId(rec.jobId)).toBe('expired');
+  });
+
+  it('enrolls a released unknown in the finished cap exactly once', () => {
+    const t = new JobTable();
+    const rec = t.create(input({ requestId: 'unknown' }));
+    t.markRunning(rec.jobId);
+    t.markOutcomeUnknown(rec.jobId, 'transport lost');
+    expect(t.settleOutcomeUnknownRelease(rec.jobId)).toBe(true);
+    expect(t.settleOutcomeUnknownRelease(rec.jobId)).toBe(false);
+
+    for (let i = 0; i < JOB_FINISHED_CAP - 1; i++) {
+      const other = t.create(input({ requestId: `within-cap-${i}` }));
+      t.finish(other.jobId, true, ['{}']);
+    }
+    expect(t.byId(rec.jobId)).toBe(rec);
+    const overflow = t.create(input({ requestId: 'cap-overflow' }));
+    t.finish(overflow.jobId, true, ['{}']);
+    expect(t.byId(rec.jobId)).toBe('expired');
+  });
+
+  it('keeps held frames intact, then sheds them once release makes the unknown retention-eligible', () => {
+    const t = new JobTable();
+    const rec = t.create(input({ requestFrames: ['x'.repeat(JOB_FRAME_BYTES_CAP + 1)] }));
+    t.markRunning(rec.jobId);
+    t.markOutcomeUnknown(rec.jobId, 'transport lost');
+    t.sweep();
+    expect(rec.requestFrames).toHaveLength(1);
+    expect(rec.resultDropped).toBeUndefined();
+
+    expect(t.settleOutcomeUnknownRelease(rec.jobId)).toBe(true);
+    expect(rec.requestFrames).toEqual([]);
+    expect(rec.replyFrames).toEqual([]);
+    expect(rec.resultDropped).toBe(true);
+    expect(rec.state).toBe('outcome-unknown');
+    expect(rec.uncertaintyReason).toBe('transport lost');
   });
 });
 

--- a/tests/job-table.test.ts
+++ b/tests/job-table.test.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   JobTable, JOB_TTL_MS, JOB_FINISHED_CAP, JOB_FRAME_BYTES_CAP, isHealthyRunningJob,
+  toJobInfo,
   type CreateJobInput,
 } from '../cli/src/transport/job-table.ts';
 
@@ -273,6 +274,41 @@ describe('JobTable — markRunning / finish', () => {
       t.finish(other.jobId, true, ['{}']);
       expect(t.byId(other.jobId)).not.toBe('expired'); // not wrongly evicted by phantom cap pressure
     });
+  });
+});
+
+describe('JobTable — readiness dispatch reservation', () => {
+  it('guards queued reservation/running/terminal transitions and never resurrects a settled record', () => {
+    const c = clock();
+    const t = new JobTable(c.now, () => 'j_reserved');
+    const rec = t.create(input());
+
+    expect(t.markDispatchReserved(rec.jobId)).toBe(true);
+    expect(toJobInfo(rec)).toMatchObject({ state: 'queued', dispatchState: 'queued-not-dispatched-readiness-wait' });
+    expect(toJobInfo(rec)).not.toHaveProperty('queuePosition');
+    expect(t.transitionQueuedToRunning(rec.jobId)).toBe(true);
+    expect(toJobInfo(rec)).toMatchObject({ state: 'running' });
+    expect(toJobInfo(rec)).not.toHaveProperty('dispatchState');
+    expect(t.transitionQueuedToRunning(rec.jobId)).toBe(false);
+    expect(t.settleQueued(rec.jobId, 'failed', ['known-not-run'])).toBe(false);
+    expect(rec.state).toBe('running');
+  });
+
+  it('settles a reserved queued head once and status counts only the waiting list behind it', () => {
+    const t = new JobTable(() => 10, () => 'j_reserved');
+    const rec = t.create(input());
+    rec.queuePosition = 1;
+    expect(t.markDispatchReserved(rec.jobId)).toBe(true);
+    expect(t.summaryFor(rec.fileSlug, { slotOwnerId: rec.jobId, waitingDepth: 3 })).toEqual({
+      running: expect.objectContaining({
+        jobId: rec.jobId, state: 'queued', dispatchState: 'queued-not-dispatched-readiness-wait',
+      }),
+      queueDepth: 3,
+    });
+    expect(t.settleQueued(rec.jobId, 'cancelled', ['cancelled'])).toBe(true);
+    expect(t.settleQueued(rec.jobId, 'failed', ['late'])).toBe(false);
+    expect(toJobInfo(rec)).toMatchObject({ state: 'cancelled' });
+    expect(toJobInfo(rec)).not.toHaveProperty('dispatchState');
   });
 });
 

--- a/tests/json-out.test.ts
+++ b/tests/json-out.test.ts
@@ -56,4 +56,19 @@ describe('printErrorJson', () => {
       fileContext: { fileName: 'VSF - PCP' },
     });
   });
+
+  it('projects exact structured recovery while ordinary errors remain unchanged', () => {
+    const recovery = {
+      kind: 'inspect-and-force-release' as const,
+      command: 'figma-agent job j_3_3 --force-release',
+      requiresCanvasInspection: true as const,
+      retryAllowed: false as const,
+    };
+    const { out } = captureExit(() => printErrorJson(new CliError(
+      'E_OUTCOME_UNKNOWN', 'uncertain', { jobId: 'j_3_3', recovery },
+    )));
+    expect(JSON.parse(out)).toEqual({
+      error: { code: 'E_OUTCOME_UNKNOWN', message: 'uncertain', jobId: 'j_3_3', recovery },
+    });
+  });
 });

--- a/tests/plugin-registry.test.ts
+++ b/tests/plugin-registry.test.ts
@@ -4,8 +4,9 @@
 // list shape. Fake sockets are just `{ readyState }`; a mutable clock drives recency.
 import { describe, it, expect } from 'vitest';
 import {
-  FROZEN_AFTER_MS, PluginRegistry, WS_OPEN, extractScene, suspectedZombie, type RegistrySocket,
+  FROZEN_AFTER_MS, PluginRegistry, WS_OPEN, appReadiness, extractScene, suspectedZombie, type RegistrySocket,
 } from '../cli/src/transport/plugin-registry.ts';
+import { PLUGIN_PONG_TIMEOUT_MS } from '../shared/protocol.ts';
 
 const CLOSED = 3; // WebSocket.CLOSED
 const sock = (open = true): RegistrySocket => ({ readyState: open ? WS_OPEN : CLOSED });
@@ -343,6 +344,10 @@ describe('statusList — the per-file rows, most-recent first', () => {
       connectedAt: bConnectedAt,
       fileKey: null, // absent from the HELLO payload here — registry-integrity phase 01 §2
       appSilenceMs: 0, // b's HELLO IS an app frame — zombie-watchdog sensor, always present
+      appReady: true,
+      appState: 'ready',
+      appHeartbeatMode: 'legacy',
+      appReadinessAge: 0,
     });
     expect(list[1]).toMatchObject({ instanceId: 'a', fileName: 'A', page: 'P1', connectedAt: aConnectedAt });
     expect(list[1].lastHeartbeatAge).toBe(20); // a last seen 20ms ago
@@ -427,6 +432,57 @@ describe('zombie-watchdog — transport vs app liveness split', () => {
     expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(false); // == threshold, not over it
     tick(1);
     expect(suspectedZombie(reg.getByWs(ws)!, at())).toBe(true);
+  });
+});
+
+describe('application readiness lease', () => {
+  it('native pong never renews readiness; a JS frame does, including the exact deadline boundary', () => {
+    const { reg, tick, at } = makeReg();
+    const ws = sock();
+    reg.register(ws, {
+      instanceId: 'modern', fileName: 'Modern', caps: ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1'],
+    });
+
+    tick(PLUGIN_PONG_TIMEOUT_MS);
+    expect(appReadiness(reg.getByWs(ws)!, at())).toMatchObject({
+      appReady: true, appState: 'ready', appHeartbeatMode: 'correlated', appReadinessAge: PLUGIN_PONG_TIMEOUT_MS,
+    });
+    tick(1);
+    expect(appReadiness(reg.getByWs(ws)!, at()).appReady).toBe(false);
+    reg.touch(ws);
+    expect(appReadiness(reg.getByWs(ws)!, at()).appReady).toBe(false);
+    reg.touchApp(ws);
+    expect(appReadiness(reg.getByWs(ws)!, at())).toMatchObject({ appReady: true, appState: 'ready', appReadinessAge: 0 });
+  });
+
+  it('distinguishes absent legacy capability from an incomplete/unsupported readiness advertisement', () => {
+    const { reg, at } = makeReg();
+    const legacy = sock();
+    const unsupported = sock();
+    reg.register(legacy, { instanceId: 'legacy', fileName: 'Legacy', caps: ['fileGuard'] });
+    reg.register(unsupported, { instanceId: 'unsupported', fileName: 'Unsupported', caps: ['fileGuard', 'correlatedHeartbeatV1'] });
+
+    expect(appReadiness(reg.getByWs(legacy)!, at())).toMatchObject({ appReady: true, appHeartbeatMode: 'legacy' });
+    expect(appReadiness(reg.getByWs(unsupported)!, at())).toMatchObject({
+      appReady: null, appState: 'unknown', appHeartbeatMode: 'unknown', appReadinessAge: 0,
+    });
+  });
+
+  it('keeps explicit identity exact while unfiltered dispatch prefers ready and refuses an all-unready set', () => {
+    const { reg, tick } = makeReg();
+    const ready = sock();
+    const stale = sock();
+    reg.register(ready, { instanceId: 'ready', fileName: 'Ready', caps: ['fileGuard'] });
+    tick(PLUGIN_PONG_TIMEOUT_MS + 1);
+    reg.register(stale, { instanceId: 'stale', fileName: 'Stale', caps: ['fileGuard'] });
+    reg.touchApp(ready);
+    tick(PLUGIN_PONG_TIMEOUT_MS + 1);
+    reg.touchApp(ready);
+
+    expect(reg.selectTarget('Stale', { exact: true })?.instanceId).toBe('stale');
+    expect(reg.selectReadyTarget()?.instanceId).toBe('ready');
+    tick(PLUGIN_PONG_TIMEOUT_MS + 1);
+    expect(reg.selectReadyTarget()).toBeNull();
   });
 });
 

--- a/tests/status-peek.test.ts
+++ b/tests/status-peek.test.ts
@@ -13,7 +13,7 @@ import { tmpdir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
-import { peek } from '../cli/src/transport/broker-peek.ts';
+import { peek, projectReadiness } from '../cli/src/transport/broker-peek.ts';
 import { mutationGatePathFor } from '../cli/src/transport/mutation-admission-gate.ts';
 
 /** Accepts a TCP connection and then says nothing, forever — the ONLY way to
@@ -88,6 +88,11 @@ beforeEach(() => {
 });
 
 afterEach(async () => {
+  const shutdownSocket = sockets.find((ws) => ws.readyState === WebSocket.OPEN);
+  if (shutdownSocket) {
+    try { shutdownSocket.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' })); } catch { /* already closed */ }
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 20));
+  }
   for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
   rmSync(scratchDir, { recursive: true, force: true });
 });
@@ -140,6 +145,18 @@ describe('peek() — in-process, real broker + fake plugin', () => {
     expect(result.plugins?.[0]).toMatchObject({ fileName: 'Test File', pluginVersion: '0.1.0', protocolV: 1, versionMatch: true, protocolMatch: true });
     expect(result.versionMatch).toBe(true);
     expect(result.protocolMatch).toBe(true);
+    expect(result.broker).toMatchObject({ appReadinessVersion: 1, appReadinessVersionMatch: true });
+    expect(result.plugins?.[0]).toMatchObject({ appReady: true, appState: 'ready', appHeartbeatMode: 'legacy' });
+  });
+
+  it('old and unsupported broker payloads never fabricate readiness', () => {
+    const advertised = { appReady: true, appState: 'ready' as const, appHeartbeatMode: 'correlated' as const, appReadinessAge: 1 };
+    expect(projectReadiness(advertised, undefined)).toEqual({
+      appReady: null, appState: 'unknown', appHeartbeatMode: 'unknown', appReadinessAge: null,
+    });
+    expect(projectReadiness(advertised, 99)).toEqual({
+      appReady: null, appState: 'unknown', appHeartbeatMode: 'unknown', appReadinessAge: null,
+    });
   });
 
   it('a plugin build with no version at all reports versionMatch/protocolMatch null (unknown, not mismatched)', async () => {

--- a/tests/status-wait.test.ts
+++ b/tests/status-wait.test.ts
@@ -27,6 +27,8 @@ type BrokerDaemonModule = typeof import('../cli/src/transport/broker-daemon.ts')
 let scratchDir: string;
 let advertisePath: string;
 let sockets: WebSocket[];
+let priorAppReadinessMs: string | undefined;
+let priorPluginWaitMs: string | undefined;
 
 function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
   return {
@@ -42,10 +44,11 @@ function fakeArgs(flags: Record<string, string | boolean> = {}): CommandArgs {
   };
 }
 
-async function loadBrokerDaemon(): Promise<BrokerDaemonModule> {
+async function loadBrokerDaemon(env: Record<string, string> = {}): Promise<BrokerDaemonModule> {
   process.env.FIGMA_AGENT_CHANGES_DIR = scratchDir;
   process.env.FIGMA_AGENT_BINDS_FILE = join(scratchDir, 'binds.json');
   process.env.FIGMA_AGENT_UNBOUND_DIR = join(scratchDir, 'unbound-root');
+  for (const [key, value] of Object.entries(env)) process.env[key] = value;
   vi.resetModules();
   return import('../cli/src/transport/broker-daemon.ts');
 }
@@ -65,8 +68,11 @@ function connectSocket(port: number): Promise<WebSocket> {
   });
 }
 
-async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null): Promise<void> {
-  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey, caps: ['fileGuard'] } }));
+async function helloPlugin(
+  ws: WebSocket, instanceId: string, fileName: string, fileKey: string | null = null,
+  opts: { caps?: string[]; answerCommands?: boolean } = {},
+): Promise<void> {
+  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId, fileName, fileKey, caps: opts.caps ?? ['fileGuard'] } }));
   await new Promise<void>((resolvePromise) => {
     const handler = (raw: WebSocket.RawData): void => {
       const msg = JSON.parse(raw.toString()) as { type?: string };
@@ -77,6 +83,7 @@ async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, 
   // status.ts's non-peek path enriches the ACTIVE plugin with a live STATUS round-trip
   // (runCommand('STATUS', {})) — answer any wire request frame with a plain OK so that
   // round-trip doesn't hang waiting for a reply this fake plugin never planned to send.
+  if (opts.answerCommands === false) return;
   ws.on('message', (raw) => {
     const msg = JSON.parse(raw.toString()) as { id?: unknown; cmd?: unknown };
     if (typeof msg.id === 'string' && typeof msg.cmd === 'string') {
@@ -86,18 +93,47 @@ async function helloPlugin(ws: WebSocket, instanceId: string, fileName: string, 
 }
 
 beforeEach(() => {
+  priorAppReadinessMs = process.env.FIGMA_AGENT_APP_READINESS_MS;
+  priorPluginWaitMs = process.env.FIGMA_AGENT_PLUGIN_WAIT_MS;
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-status-wait-'));
   advertisePath = join(scratchDir, 'broker.json');
   sockets = [];
 });
 
 afterEach(async () => {
+  const shutdownSocket = sockets.find((ws) => ws.readyState === WebSocket.OPEN);
+  if (shutdownSocket) {
+    try { shutdownSocket.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' })); } catch { /* already closed */ }
+    await new Promise((resolve) => setTimeout(resolve, 20));
+  }
   for (const ws of sockets) { try { ws.terminate(); } catch { /* already closed */ } }
   rmSync(scratchDir, { recursive: true, force: true });
   vi.mocked(ensureBroker).mockReset();
+  if (priorAppReadinessMs === undefined) delete process.env.FIGMA_AGENT_APP_READINESS_MS;
+  else process.env.FIGMA_AGENT_APP_READINESS_MS = priorAppReadinessMs;
+  if (priorPluginWaitMs === undefined) delete process.env.FIGMA_AGENT_PLUGIN_WAIT_MS;
+  else process.env.FIGMA_AGENT_PLUGIN_WAIT_MS = priorPluginWaitMs;
 });
 
 describe('status --wait', () => {
+  it('keeps transport connected when live STATUS times out on application readiness', async () => {
+    const mod = await loadBrokerDaemon({
+      FIGMA_AGENT_APP_READINESS_MS: '30', FIGMA_AGENT_PLUGIN_WAIT_MS: '40',
+    });
+    await mod.runBrokerDaemon({ advertisePath, ports: [0], exit: testExit() });
+    const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+    vi.mocked(ensureBroker).mockResolvedValue({ port: ad.port, pid: ad.pid, protocolV: 1, buildMtime: 0, startedAt: Date.now(), lastSeen: Date.now() });
+    const ws = await connectSocket(ad.port);
+    await helloPlugin(ws, 'p_unready', 'Still Connected', 'raw-status', {
+      caps: ['fileGuard', 'correlatedHeartbeatV1', 'appProbeV1'], answerCommands: false,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    const result = await run(fakeArgs()) as { plugin: { connected: boolean; state: string }; plugins: unknown[] };
+    expect(result.plugin).toMatchObject({ connected: true, state: 'connected' });
+    expect(result.plugins).toHaveLength(1);
+  });
+
   it('keeps a persisted gate row and marks it connected only when the exact raw file key is live', async () => {
     writeFileSync(mutationGatePathFor(advertisePath), JSON.stringify({
       schemaVersion: 1,

--- a/tests/timeout-job-hint.test.ts
+++ b/tests/timeout-job-hint.test.ts
@@ -75,3 +75,38 @@ describe('exchange — JOB_STATE does not settle the promise on its own', () => 
     await expect(promise).resolves.toEqual({ ok: true });
   });
 });
+
+describe('exchange — structured unknown-outcome recovery', () => {
+  const recovery = {
+    kind: 'inspect-and-force-release' as const,
+    command: 'figma-agent job j_wire --force-release',
+    requiresCanvasInspection: true as const,
+    retryAllowed: false as const,
+  };
+
+  it('copies wire jobId and recovery without parsing message text; wire jobId wins', async () => {
+    const ws = fakeWs();
+    const promise = exchange(ws, 'EXEC_JS', {}, 5_000);
+    ws.emit('message', Buffer.from(jobStateEvent({ jobId: 'j_state', state: 'running', cmd: 'EXEC_JS', fileSlug: 'fileA' })));
+    const sentId = (JSON.parse(ws.sent[0]!) as { id: string }).id;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      id: sentId, ok: false,
+      error: { code: 'E_OUTCOME_UNKNOWN', message: 'opaque', jobId: 'j_wire', recovery },
+    })));
+    await expect(promise).rejects.toMatchObject({
+      code: 'E_OUTCOME_UNKNOWN', message: 'opaque', jobId: 'j_wire', recovery,
+    });
+  });
+
+  it('uses the matching JOB_STATE jobId only when an old peer omits wire jobId', async () => {
+    const ws = fakeWs();
+    const promise = exchange(ws, 'EXEC_JS', {}, 5_000);
+    ws.emit('message', Buffer.from(jobStateEvent({ jobId: 'j_fallback', state: 'running', cmd: 'EXEC_JS', fileSlug: 'fileA' })));
+    const sentId = (JSON.parse(ws.sent[0]!) as { id: string }).id;
+    ws.emit('message', Buffer.from(JSON.stringify({
+      id: sentId, ok: false,
+      error: { code: 'E_OUTCOME_UNKNOWN', message: 'contains no useful identifier', recovery: { ...recovery, command: 'figma-agent job j_fallback --force-release' } },
+    })));
+    await expect(promise).rejects.toMatchObject({ code: 'E_OUTCOME_UNKNOWN', jobId: 'j_fallback' });
+  });
+});


### PR DESCRIPTION
## Summary
- Keeps broker heartbeats and app-readiness probes suspension-aware while preserving exact file and node routing.
- Audits outcome-unknown releases, keeps COWORK dispatch exact-keyed, and retains watchdog-held slot ownership until safe release.

## Testing
- [x] Focused tests: 336 passed
- [x] Full suite: 1812 passed
- [x] Typecheck
- [x] Build
- [x] Skill emission
- [x] Comment lint
- [x] Diff check

## Live validation
- Three files reconnect with version match.
- An owner edit is preserved during a blocked iOS queue.
- Exact unique nodes are delivered once.
- True transport loss releases slots and cleans up.
- Shared broker interleaving preserves request attribution.

Closes #102