### PR TITLE
fix(plugin): validate payloads before import

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -93,6 +93,21 @@ the requested file and listing the ones actually connected. Mutating commands wa
 to skip) for a plugin whose name matches `--file` exactly before dispatching, so a command issued right
 after the broker went idle does not fail with `E_FILE_KEY_UNAVAILABLE`.
 
+## Payload import admission
+
+Direct `IMPORT_PAYLOAD` requests and HTML converter results are validated in the UI relay;
+the main importer validates again before creating styles, variables, or nodes. Invalid
+fields, active cycles, unrecognized properties, and inputs above the admission budgets
+return `E_INVALID_ARGS`. Direct and `{ payload, x, y, parentId, replaceId }` envelopes remain
+supported. Omitted or legacy `null` token groups become empty arrays before import consumers
+receive them; valid repeated object references are allowed.
+
+The current node, depth, string, image, token, and aggregate budgets are defined in
+[`IMPORT_PAYLOAD_LIMITS`](../shared/figma-payload-validation-context.ts). Image strings have
+separate headroom for the existing 8 MiB image producer's base64 output. These admission
+budgets bound validation and forwarding; they do not isolate arbitrary renderer JavaScript
+or establish a whole-process memory limit.
+
 ## Troubleshooting
 
 - **Panel says "No broker yet" and never connects** — that's the resting state; it only connects once a CLI

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -1,5 +1,9 @@
 "use strict";
 (() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
   // shared/protocol.ts
   var DEFAULT_IDLE_MS = 3e5;
   var MIN_IDLE_MS = 1e3;
@@ -2260,77 +2264,663 @@
     return { id: node.id, field, variable: variable.name };
   }
 
-  // plugin/src/main/executor-keyed-vars.ts
-  var resolvedByKey = /* @__PURE__ */ new Map();
-  var localByKey = null;
-  function resetKeyedVariableCache() {
-    resolvedByKey.clear();
-    localByKey = null;
-  }
-  async function readLocalVariablesByKey() {
-    if (localByKey) return localByKey;
-    const map = /* @__PURE__ */ new Map();
-    try {
-      for (const v of await figma.variables.getLocalVariablesAsync()) {
-        if (typeof v.key === "string" && v.key) map.set(v.key, v);
-      }
-    } catch {
+  // shared/figma-payload-validation-context.ts
+  var IMPORT_PAYLOAD_LIMITS = {
+    aggregateBytes: 64 * 1024 * 1024,
+    totalEntries: 5e6,
+    nodes: 1e5,
+    depth: 256,
+    textChars: 1024 * 1024,
+    imageChars: 16 * 1024 * 1024,
+    svgChars: 16 * 1024 * 1024,
+    arrayEntries: 1e5,
+    recordEntries: 1e4,
+    recordKeyChars: 16384,
+    tokenGroup: 1e4,
+    motionSteps: 1e4
+  };
+  var PayloadValidationError = class extends Error {
+    constructor(message) {
+      super(`IMPORT_PAYLOAD rejected: ${message}`);
+      __publicField(this, "code", "E_INVALID_ARGS");
+      this.name = "PayloadValidationError";
     }
-    localByKey = map;
-    return map;
+  };
+  function jsonStringBytes(value) {
+    let bytes = 2;
+    for (let i = 0; i < value.length; i++) {
+      const unit = value.charCodeAt(i);
+      if (unit === 34 || unit === 92) bytes += 2;
+      else if (unit === 8 || unit === 9 || unit === 10 || unit === 12 || unit === 13) bytes += 2;
+      else if (unit < 32) bytes += 6;
+      else if (unit < 128) bytes += 1;
+      else if (unit < 2048) bytes += 2;
+      else if (unit >= 55296 && unit <= 56319 && i + 1 < value.length && (value.charCodeAt(i + 1) & 64512) === 56320) {
+        bytes += 4;
+        i += 1;
+      } else if (unit >= 55296 && unit <= 57343) bytes += 6;
+      else bytes += 3;
+    }
+    return bytes;
   }
-  async function resolveKeyedVariable(key) {
-    const cached = resolvedByKey.get(key);
-    if (cached !== void 0) return cached;
-    let variable = (await readLocalVariablesByKey()).get(key) ?? null;
-    if (!variable) {
-      try {
-        variable = await figma.variables.importVariableByKeyAsync(key);
-      } catch (err) {
-        pushImportWarning(`variable resolve failed for key ${key}: not local, and import failed: ${String(err)}`);
+  var ValidationContext = class {
+    constructor(overrides = {}) {
+      __publicField(this, "limits");
+      __publicField(this, "aggregateBytes", 0);
+      __publicField(this, "totalEntries", 0);
+      __publicField(this, "nodeCount", 0);
+      __publicField(this, "active", /* @__PURE__ */ new WeakSet());
+      this.limits = { ...IMPORT_PAYLOAD_LIMITS, ...overrides };
+    }
+    fail(path, message) {
+      throw new PayloadValidationError(`${path} ${message}`);
+    }
+    addBytes(bytes, path) {
+      this.aggregateBytes += bytes;
+      if (this.aggregateBytes > this.limits.aggregateBytes) {
+        this.fail(path, `exceeds aggregate budget ${this.limits.aggregateBytes} bytes`);
       }
     }
-    resolvedByKey.set(key, variable);
-    return variable;
-  }
-  async function applyKeyedBindings(node, bindings) {
-    for (const [field, ref] of Object.entries(bindings)) {
-      if (!ref || typeof ref.key !== "string" || !ref.key) continue;
-      const variable = await resolveKeyedVariable(ref.key);
-      if (!variable) {
-        pushImportWarning(`keyed bind ${field}\u2192${ref.name ?? ref.key} skipped on "${node.name}": key not resolvable \u2014 literal value kept`);
-        continue;
+    addEntry(path) {
+      this.totalEntries += 1;
+      if (this.totalEntries > this.limits.totalEntries) {
+        this.fail(path, `exceeds aggregate entry budget ${this.limits.totalEntries}`);
       }
+    }
+    object(value, path, allowed, visit, maxKeys = allowed?.size ?? this.limits.recordEntries) {
+      if (!value || typeof value !== "object" || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+        this.fail(path, "must be a plain object");
+      }
+      if (this.active.has(value)) this.fail(path, "must not contain an active cycle");
+      this.active.add(value);
+      this.addBytes(2, path);
       try {
-        bindVariableToField(node, field, variable);
-      } catch (err) {
-        pushImportWarning(`keyed bind ${field}\u2192${ref.name ?? ref.key} failed on "${node.name}": ${String(err)}`);
+        let count = 0;
+        for (const key in value) {
+          if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+          count += 1;
+          if (count > maxKeys) this.fail(path, `must have at most ${maxKeys} fields`);
+          if (key.length > this.limits.recordKeyChars) {
+            this.fail(`${path} key`, `must be at most ${this.limits.recordKeyChars} characters`);
+          }
+          this.addEntry(`${path}.${key}`);
+          this.addBytes(jsonStringBytes(key) + 2, `${path}.${key}`);
+          if (allowed && !allowed.has(key)) this.fail(`${path}.${key}`, "is not a supported field");
+        }
+        return visit(value);
+      } finally {
+        this.active.delete(value);
       }
+    }
+    array(value, path, max, visit, min = 0) {
+      if (!Array.isArray(value) || value.length < min || value.length > max) {
+        this.fail(path, `must be an array with ${min}..${max} entries`);
+      }
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        const index = Number(key);
+        if (key.length > this.limits.recordKeyChars || !Number.isInteger(index) || index < 0 || index >= value.length || String(index) !== key) {
+          this.fail(path, "must not contain enumerable non-index fields");
+        }
+      }
+      if (this.active.has(value)) this.fail(path, "must not contain an active cycle");
+      this.active.add(value);
+      this.addBytes(2, path);
+      try {
+        for (let i = 0; i < value.length; i++) {
+          this.addEntry(`${path}[${i}]`);
+          this.addBytes(1, `${path}[${i}]`);
+          visit(value[i], i);
+        }
+      } finally {
+        this.active.delete(value);
+      }
+    }
+    string(value, path, max = this.limits.textChars) {
+      if (typeof value !== "string" || value.length > max) {
+        this.fail(path, `must be a string no longer than ${max} characters`);
+      }
+      this.addBytes(jsonStringBytes(value), path);
+      return value;
+    }
+    number(value, path, min = -Infinity, max = Infinity) {
+      if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+        this.fail(path, `must be a finite number between ${min} and ${max}`);
+      }
+      this.addBytes(24, path);
+      return value;
+    }
+    integer(value, path, min = 0) {
+      const parsed = this.number(value, path, min);
+      if (!Number.isInteger(parsed)) this.fail(path, "must be an integer");
+      return parsed;
+    }
+    boolean(value, path) {
+      if (typeof value !== "boolean") this.fail(path, "must be boolean");
+      this.addBytes(5, path);
+      return value;
+    }
+    enumValue(value, path, values) {
+      const parsed = this.string(value, path, 128);
+      if (!values.includes(parsed)) this.fail(path, `must be one of ${values.join(", ")}`);
+      return parsed;
+    }
+    node(path, depth) {
+      if (depth > this.limits.depth) this.fail(path, `exceeds maximum depth ${this.limits.depth}`);
+      this.nodeCount += 1;
+      if (this.nodeCount > this.limits.nodes) this.fail(path, `exceeds maximum node count ${this.limits.nodes}`);
+    }
+  };
+
+  // shared/figma-payload-validation-values.ts
+  var COLOR_FIELDS = /* @__PURE__ */ new Set(["r", "g", "b", "a"]);
+  var FILL_FIELDS = /* @__PURE__ */ new Set(["type", "color", "gradientStops", "gradientTransform"]);
+  var EFFECT_FIELDS = /* @__PURE__ */ new Set(["type", "offset", "radius", "spread", "color"]);
+  var OFFSET_FIELDS = /* @__PURE__ */ new Set(["x", "y"]);
+  var KEYED_BINDING_FIELDS = /* @__PURE__ */ new Set(["key", "name"]);
+  var TEXT_SEGMENT_FIELDS = /* @__PURE__ */ new Set([
+    "characters",
+    "fontFamily",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "lineHeight",
+    "letterSpacing",
+    "textColor",
+    "textDecoration",
+    "textCase"
+  ]);
+  var MOTION_FIELDS = /* @__PURE__ */ new Set(["steps", "durationSec", "easing"]);
+  var MOTION_STEP_FIELDS = /* @__PURE__ */ new Set(["offset", "style"]);
+  var MOTION_STYLE_FIELDS = /* @__PURE__ */ new Set(["opacity", "transform"]);
+  function required(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateColor(value, path, context) {
+    context.object(value, path, COLOR_FIELDS, (item) => {
+      for (const key of COLOR_FIELDS) context.number(required(item, key, path, context), `${path}.${key}`, 0, 1);
+    });
+  }
+  function validateFill(value, path, context) {
+    context.object(value, path, FILL_FIELDS, (item) => {
+      const type = context.enumValue(required(item, "type", path, context), `${path}.type`, [
+        "SOLID",
+        "GRADIENT_LINEAR",
+        "GRADIENT_RADIAL",
+        "GRADIENT_ANGULAR"
+      ]);
+      if (type === "SOLID") {
+        validateColor(required(item, "color", path, context), `${path}.color`, context);
+        if (item.gradientStops !== void 0 || item.gradientTransform !== void 0) {
+          context.fail(path, "SOLID fills must not contain gradient fields");
+        }
+        return;
+      }
+      if (item.color !== void 0) context.fail(`${path}.color`, "is only supported for SOLID fills");
+      context.array(required(item, "gradientStops", path, context), `${path}.gradientStops`, context.limits.arrayEntries, (stop, i) => {
+        const stopPath = `${path}.gradientStops[${i}]`;
+        context.object(stop, stopPath, /* @__PURE__ */ new Set(["color", "position"]), (entry) => {
+          validateColor(required(entry, "color", stopPath, context), `${stopPath}.color`, context);
+          context.number(required(entry, "position", stopPath, context), `${stopPath}.position`, 0, 1);
+        });
+      }, 2);
+      context.array(required(item, "gradientTransform", path, context), `${path}.gradientTransform`, 2, (row, i) => {
+        context.array(row, `${path}.gradientTransform[${i}]`, 3, (entry, j) => {
+          context.number(entry, `${path}.gradientTransform[${i}][${j}]`);
+        }, 3);
+      }, 2);
+    });
+  }
+  function validateEffect(value, path, context) {
+    context.object(value, path, EFFECT_FIELDS, (item) => {
+      context.enumValue(required(item, "type", path, context), `${path}.type`, [
+        "DROP_SHADOW",
+        "INNER_SHADOW",
+        "LAYER_BLUR",
+        "BACKGROUND_BLUR"
+      ]);
+      context.number(required(item, "radius", path, context), `${path}.radius`, 0);
+      if (item.spread !== void 0) context.number(item.spread, `${path}.spread`);
+      if (item.color !== void 0) validateColor(item.color, `${path}.color`, context);
+      if (item.offset !== void 0) context.object(item.offset, `${path}.offset`, OFFSET_FIELDS, (offset) => {
+        context.number(required(offset, "x", `${path}.offset`, context), `${path}.offset.x`);
+        context.number(required(offset, "y", `${path}.offset`, context), `${path}.offset.y`);
+      });
+    });
+  }
+  function validateRecord(value, path, context, visit) {
+    context.object(value, path, null, (item) => {
+      for (const key in item) {
+        if (Object.prototype.hasOwnProperty.call(item, key)) visit(item[key], `${path}.${key}`);
+      }
+    });
+  }
+  function validateKeyedBindings(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      context.object(entry, entryPath, KEYED_BINDING_FIELDS, (binding) => {
+        context.string(required(binding, "key", entryPath, context), `${entryPath}.key`);
+        if (binding.name !== void 0) context.string(binding.name, `${entryPath}.name`);
+      });
+    });
+  }
+  function validateStringRecord(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => context.string(entry, entryPath));
+  }
+  function validatePrimitiveRecord(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      if (typeof entry === "number") context.number(entry, entryPath);
+      else context.string(entry, entryPath);
+    });
+  }
+  function validateComponentProperties(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      if (typeof entry === "boolean") context.boolean(entry, entryPath);
+      else context.string(entry, entryPath);
+    });
+  }
+  function validateTextSegments(value, path, context) {
+    context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+      const entryPath = `${path}[${i}]`;
+      context.object(entry, entryPath, TEXT_SEGMENT_FIELDS, (segment) => {
+        context.string(required(segment, "characters", entryPath, context), `${entryPath}.characters`);
+        if (segment.fontFamily !== void 0) context.string(segment.fontFamily, `${entryPath}.fontFamily`);
+        for (const key of ["fontSize", "fontWeight", "lineHeight"]) if (segment[key] !== void 0) {
+          context.number(segment[key], `${entryPath}.${key}`, 0);
+        }
+        if (segment.letterSpacing !== void 0) context.number(segment.letterSpacing, `${entryPath}.letterSpacing`);
+        if (segment.fontStyle !== void 0) context.enumValue(segment.fontStyle, `${entryPath}.fontStyle`, ["normal", "italic"]);
+        if (segment.textDecoration !== void 0) context.enumValue(segment.textDecoration, `${entryPath}.textDecoration`, ["UNDERLINE", "STRIKETHROUGH"]);
+        if (segment.textCase !== void 0) context.enumValue(segment.textCase, `${entryPath}.textCase`, ["UPPER", "LOWER", "TITLE"]);
+        if (segment.textColor !== void 0) validateColor(segment.textColor, `${entryPath}.textColor`, context);
+      });
+    });
+  }
+  function validateMotion(value, path, context) {
+    context.object(value, path, MOTION_FIELDS, (motion) => {
+      context.number(required(motion, "durationSec", path, context), `${path}.durationSec`, 0);
+      if (motion.easing !== void 0) context.string(motion.easing, `${path}.easing`);
+      context.array(required(motion, "steps", path, context), `${path}.steps`, context.limits.motionSteps, (entry, i) => {
+        const entryPath = `${path}.steps[${i}]`;
+        context.object(entry, entryPath, MOTION_STEP_FIELDS, (step) => {
+          context.number(required(step, "offset", entryPath, context), `${entryPath}.offset`, 0, 1);
+          context.object(required(step, "style", entryPath, context), `${entryPath}.style`, MOTION_STYLE_FIELDS, (style) => {
+            for (const key of MOTION_STYLE_FIELDS) if (style[key] !== void 0) context.string(style[key], `${entryPath}.style.${key}`);
+          });
+        });
+      });
+    });
+  }
+
+  // shared/figma-payload-validation-node-details.ts
+  var TOKEN_REF_FIELDS = /* @__PURE__ */ new Set(["fill", "stroke", "textColor", "radius", "gap", "padding"]);
+  var INNER_OVERRIDE_FIELDS = /* @__PURE__ */ new Set([
+    "childKey",
+    "fields",
+    "componentKey",
+    "componentId",
+    "componentProperties",
+    "visual",
+    "figmaScanFillSize"
+  ]);
+  var INNER_VISUAL_FIELDS = /* @__PURE__ */ new Set([
+    "fills",
+    "strokes",
+    "effects",
+    "effectStyleId",
+    "visible",
+    "opacity",
+    "keyedBindings"
+  ]);
+  var FILL_SIZE_FIELDS = /* @__PURE__ */ new Set(["width", "height"]);
+  function required2(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateTokenRefs(value, path, context) {
+    context.object(value, path, TOKEN_REF_FIELDS, (refs) => {
+      for (const key of TOKEN_REF_FIELDS) if (refs[key] !== void 0) context.string(refs[key], `${path}.${key}`);
+    });
+  }
+  function validateInnerVisual(value, path, context) {
+    context.object(value, path, INNER_VISUAL_FIELDS, (visual) => {
+      for (const key of ["fills", "strokes"]) if (visual[key] !== void 0) {
+        context.array(visual[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+          validateFill(entry, `${path}.${key}[${i}]`, context);
+        });
+      }
+      if (visual.effects !== void 0) context.array(
+        visual.effects,
+        `${path}.effects`,
+        context.limits.arrayEntries,
+        (entry, i) => validateEffect(entry, `${path}.effects[${i}]`, context)
+      );
+      if (visual.effectStyleId !== void 0) context.string(visual.effectStyleId, `${path}.effectStyleId`);
+      if (visual.visible !== void 0) context.boolean(visual.visible, `${path}.visible`);
+      if (visual.opacity !== void 0) context.number(visual.opacity, `${path}.opacity`, 0, 1);
+      if (visual.keyedBindings !== void 0) validateKeyedBindings(visual.keyedBindings, `${path}.keyedBindings`, context);
+    });
+  }
+  function validateInnerOverrides(value, path, context) {
+    context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+      const entryPath = `${path}[${i}]`;
+      context.object(entry, entryPath, INNER_OVERRIDE_FIELDS, (override) => {
+        context.string(required2(override, "childKey", entryPath, context), `${entryPath}.childKey`);
+        validatePrimitiveRecord(required2(override, "fields", entryPath, context), `${entryPath}.fields`, context);
+        for (const key of ["componentKey", "componentId"]) if (override[key] !== void 0) {
+          context.string(override[key], `${entryPath}.${key}`);
+        }
+        if (override.componentProperties !== void 0) {
+          validateComponentProperties(override.componentProperties, `${entryPath}.componentProperties`, context);
+        }
+        if (override.visual !== void 0) validateInnerVisual(override.visual, `${entryPath}.visual`, context);
+        if (override.figmaScanFillSize !== void 0) {
+          context.object(override.figmaScanFillSize, `${entryPath}.figmaScanFillSize`, FILL_SIZE_FIELDS, (size) => {
+            for (const key of FILL_SIZE_FIELDS) if (size[key] !== void 0) {
+              context.number(size[key], `${entryPath}.figmaScanFillSize.${key}`, 0);
+            }
+          });
+        }
+      });
+    });
+  }
+  function validateScanMetadata(item, path, context) {
+    if (item.figmaScanBindings !== void 0) validateStringRecord(item.figmaScanBindings, `${path}.figmaScanBindings`, context);
+    if (item.figmaScanSourceType !== void 0) context.string(item.figmaScanSourceType, `${path}.figmaScanSourceType`);
+    for (const key of ["figmaScanUnreproducibleInner", "figmaScanInnerOverrides", "figmaScanUnbindable"]) {
+      if (item[key] !== void 0) context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+        context.string(entry, `${path}.${key}[${i}]`);
+      });
     }
   }
 
-  // plugin/src/main/executor-token-var-resolve.ts
-  function tokensAreEmpty(tokens) {
-    return !(tokens.colors?.length || tokens.spacing?.length || tokens.radii?.length);
+  // shared/figma-payload-validation-node.ts
+  var NODE_FIELDS = /* @__PURE__ */ new Set([
+    "type",
+    "name",
+    "width",
+    "height",
+    "layoutMode",
+    "itemSpacing",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "primaryAxisSizingMode",
+    "counterAxisSizingMode",
+    "primaryAxisAlignItems",
+    "counterAxisAlignItems",
+    "layoutWrap",
+    "counterAxisSpacing",
+    "layoutSizingHorizontal",
+    "layoutSizingVertical",
+    "layoutGrow",
+    "maxWidth",
+    "minWidth",
+    "maxHeight",
+    "minHeight",
+    "gridColumnCount",
+    "gridRowCount",
+    "gridRowGap",
+    "gridColumnGap",
+    "fills",
+    "cornerRadius",
+    "cornerRadii",
+    "effects",
+    "opacity",
+    "backgroundImageUrl",
+    "backgroundSize",
+    "backgroundPosition",
+    "strokes",
+    "strokeWeight",
+    "strokeWeights",
+    "strokeAlign",
+    "characters",
+    "fontFamily",
+    "fontStack",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "lineHeight",
+    "letterSpacing",
+    "wordSpacing",
+    "textAlignHorizontal",
+    "textAutoResize",
+    "textColor",
+    "textDecoration",
+    "textCase",
+    "textTruncation",
+    "blendMode",
+    "rotation",
+    "counterAxisAlignContent",
+    "imageUrl",
+    "svgContent",
+    "motion",
+    "clipsContent",
+    "absolutePosition",
+    "x",
+    "y",
+    "textSegments",
+    "keyedBindings",
+    "tokenRefs",
+    "componentKey",
+    "componentId",
+    "componentName",
+    "componentProperties",
+    "innerOverrides",
+    "figmaScanUnreproducibleInner",
+    "figmaScanBindings",
+    "figmaScanSourceType",
+    "figmaScanInnerOverrides",
+    "figmaScanUnbindable",
+    "children"
+  ]);
+  var ENUM_FIELDS = {
+    layoutMode: ["HORIZONTAL", "VERTICAL", "GRID", "NONE"],
+    primaryAxisSizingMode: ["AUTO", "FIXED"],
+    counterAxisSizingMode: ["AUTO", "FIXED"],
+    primaryAxisAlignItems: ["MIN", "CENTER", "MAX", "SPACE_BETWEEN"],
+    counterAxisAlignItems: ["MIN", "CENTER", "MAX", "BASELINE"],
+    layoutWrap: ["WRAP", "NO_WRAP"],
+    layoutSizingHorizontal: ["FILL", "FIXED", "HUG"],
+    layoutSizingVertical: ["FILL", "FIXED", "HUG"],
+    strokeAlign: ["INSIDE", "OUTSIDE", "CENTER"],
+    fontStyle: ["normal", "italic"],
+    textAlignHorizontal: ["LEFT", "CENTER", "RIGHT", "JUSTIFIED"],
+    textAutoResize: ["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"],
+    textDecoration: ["UNDERLINE", "STRIKETHROUGH"],
+    textCase: ["UPPER", "LOWER", "TITLE"],
+    textTruncation: ["ENDING"],
+    counterAxisAlignContent: ["AUTO", "SPACE_BETWEEN"]
+  };
+  var NONNEGATIVE_FIELDS = [
+    "width",
+    "height",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "counterAxisSpacing",
+    "layoutGrow",
+    "maxWidth",
+    "minWidth",
+    "maxHeight",
+    "minHeight",
+    "gridRowGap",
+    "gridColumnGap",
+    "cornerRadius",
+    "strokeWeight",
+    "fontSize",
+    "fontWeight",
+    "lineHeight"
+  ];
+  var FREE_NUMBER_FIELDS = ["itemSpacing", "letterSpacing", "wordSpacing", "rotation", "x", "y"];
+  var ORDINARY_STRING_FIELDS = [
+    "backgroundSize",
+    "backgroundPosition",
+    "characters",
+    "fontFamily",
+    "fontStack",
+    "blendMode",
+    "componentKey",
+    "componentId",
+    "componentName"
+  ];
+  var BOOLEAN_FIELDS = ["clipsContent", "absolutePosition"];
+  var FOUR_CORNER_FIELDS = /* @__PURE__ */ new Set(["tl", "tr", "br", "bl"]);
+  var FOUR_STROKE_FIELDS = /* @__PURE__ */ new Set(["top", "right", "bottom", "left"]);
+  function required3(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
   }
-  async function readLocalVariableMap() {
-    const byName = /* @__PURE__ */ new Map();
-    try {
-      for (const v of await figma.variables.getLocalVariablesAsync()) {
-        if (!byName.has(v.name)) byName.set(v.name, v);
+  function validateNumberRecord(value, path, fields, context) {
+    context.object(value, path, fields, (record) => {
+      for (const key of fields) context.number(required3(record, key, path, context), `${path}.${key}`, 0);
+    });
+  }
+  function validateNodeFields(item, path, context) {
+    context.enumValue(required3(item, "type", path, context), `${path}.type`, ["FRAME", "TEXT", "RECTANGLE", "IMAGE", "GROUP", "INSTANCE"]);
+    context.string(required3(item, "name", path, context), `${path}.name`);
+    for (const [field, values] of Object.entries(ENUM_FIELDS)) if (item[field] !== void 0) {
+      context.enumValue(item[field], `${path}.${field}`, values);
+    }
+    for (const field of NONNEGATIVE_FIELDS) if (item[field] !== void 0) context.number(item[field], `${path}.${field}`, 0);
+    for (const field of FREE_NUMBER_FIELDS) if (item[field] !== void 0) context.number(item[field], `${path}.${field}`);
+    for (const field of ["gridColumnCount", "gridRowCount"]) if (item[field] !== void 0) {
+      context.integer(item[field], `${path}.${field}`);
+    }
+    if (item.opacity !== void 0) context.number(item.opacity, `${path}.opacity`, 0, 1);
+    for (const field of ORDINARY_STRING_FIELDS) if (item[field] !== void 0) context.string(item[field], `${path}.${field}`);
+    for (const field of BOOLEAN_FIELDS) if (item[field] !== void 0) context.boolean(item[field], `${path}.${field}`);
+    if (item.imageUrl !== void 0) context.string(item.imageUrl, `${path}.imageUrl`, context.limits.imageChars);
+    if (item.backgroundImageUrl !== void 0) context.string(item.backgroundImageUrl, `${path}.backgroundImageUrl`, context.limits.imageChars);
+    if (item.svgContent !== void 0) context.string(item.svgContent, `${path}.svgContent`, context.limits.svgChars);
+  }
+  function validateNode(value, path, context, depth = 0) {
+    context.node(path, depth);
+    context.object(value, path, NODE_FIELDS, (item) => {
+      validateNodeFields(item, path, context);
+      for (const key of ["fills", "strokes"]) if (item[key] !== void 0) {
+        context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => validateFill(entry, `${path}.${key}[${i}]`, context));
       }
-    } catch (err) {
-      pushImportWarning(`local variable lookup failed \u2014 tokenRefs left unbound: ${String(err)}`);
-    }
-    return byName;
+      if (item.effects !== void 0) context.array(item.effects, `${path}.effects`, context.limits.arrayEntries, (entry, i) => {
+        validateEffect(entry, `${path}.effects[${i}]`, context);
+      });
+      if (item.cornerRadii !== void 0) validateNumberRecord(item.cornerRadii, `${path}.cornerRadii`, FOUR_CORNER_FIELDS, context);
+      if (item.strokeWeights !== void 0) validateNumberRecord(item.strokeWeights, `${path}.strokeWeights`, FOUR_STROKE_FIELDS, context);
+      if (item.textColor !== void 0) validateColor(item.textColor, `${path}.textColor`, context);
+      if (item.textSegments !== void 0) validateTextSegments(item.textSegments, `${path}.textSegments`, context);
+      if (item.motion !== void 0) validateMotion(item.motion, `${path}.motion`, context);
+      if (item.keyedBindings !== void 0) validateKeyedBindings(item.keyedBindings, `${path}.keyedBindings`, context);
+      if (item.tokenRefs !== void 0) validateTokenRefs(item.tokenRefs, `${path}.tokenRefs`, context);
+      if (item.componentProperties !== void 0) validateComponentProperties(item.componentProperties, `${path}.componentProperties`, context);
+      if (item.innerOverrides !== void 0) validateInnerOverrides(item.innerOverrides, `${path}.innerOverrides`, context);
+      validateScanMetadata(item, path, context);
+      if (item.children !== void 0) context.array(item.children, `${path}.children`, context.limits.arrayEntries, (child, i) => {
+        validateNode(child, `${path}.children[${i}]`, context, depth + 1);
+      });
+    });
   }
-  async function resolveTokenVars(tokens) {
-    const resolved = await readLocalVariableMap();
-    if (tokensAreEmpty(tokens)) return resolved;
-    for (const [name, variable] of await createVariablesFromTokens(tokens)) {
-      resolved.set(name, variable);
+
+  // shared/figma-payload-validation-tokens.ts
+  var TOKEN_FIELDS = /* @__PURE__ */ new Set(["colors", "typography", "spacing", "radii", "shadows"]);
+  var COLOR_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "hex", "color"]);
+  var TYPE_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "family", "size", "weight", "lineHeight", "letterSpacing"]);
+  var VALUE_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "value"]);
+  var SHADOW_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "css", "effect"]);
+  function required4(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateTokens(value, path, context) {
+    return context.object(value, path, TOKEN_FIELDS, (tokens) => {
+      const groups = {
+        colors: tokens.colors ?? [],
+        typography: tokens.typography ?? [],
+        spacing: tokens.spacing ?? [],
+        radii: tokens.radii ?? [],
+        shadows: tokens.shadows ?? []
+      };
+      context.array(groups.colors, `${path}.colors`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.colors[${i}]`;
+        context.object(entry, entryPath, COLOR_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "hex", entryPath, context), `${entryPath}.hex`);
+          validateColor(required4(token, "color", entryPath, context), `${entryPath}.color`, context);
+        });
+      });
+      context.array(groups.typography, `${path}.typography`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.typography[${i}]`;
+        context.object(entry, entryPath, TYPE_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "family", entryPath, context), `${entryPath}.family`);
+          context.number(required4(token, "size", entryPath, context), `${entryPath}.size`, 0);
+          context.number(required4(token, "weight", entryPath, context), `${entryPath}.weight`, 0);
+          if (token.lineHeight !== void 0) context.number(token.lineHeight, `${entryPath}.lineHeight`, 0);
+          if (token.letterSpacing !== void 0) context.number(token.letterSpacing, `${entryPath}.letterSpacing`);
+        });
+      });
+      for (const key of ["spacing", "radii"]) context.array(
+        groups[key],
+        `${path}.${key}`,
+        context.limits.tokenGroup,
+        (entry, i) => {
+          const entryPath = `${path}.${key}[${i}]`;
+          context.object(entry, entryPath, VALUE_TOKEN_FIELDS, (token) => {
+            context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+            context.number(required4(token, "value", entryPath, context), `${entryPath}.value`);
+          });
+        }
+      );
+      context.array(groups.shadows, `${path}.shadows`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.shadows[${i}]`;
+        context.object(entry, entryPath, SHADOW_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "css", entryPath, context), `${entryPath}.css`);
+          validateEffect(required4(token, "effect", entryPath, context), `${entryPath}.effect`, context);
+        });
+      });
+      return groups;
+    });
+  }
+
+  // shared/figma-payload-validation.ts
+  var PAYLOAD_FIELDS = /* @__PURE__ */ new Set(["version", "name", "width", "height", "tokens", "rootNode"]);
+  var PLACEMENT_FIELDS = /* @__PURE__ */ new Set(["x", "y", "parentId", "replaceId"]);
+  var WRAPPED_FIELDS = /* @__PURE__ */ new Set(["payload", ...PLACEMENT_FIELDS]);
+  var DIRECT_FIELDS = /* @__PURE__ */ new Set([...PAYLOAD_FIELDS, ...PLACEMENT_FIELDS]);
+  function required5(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validatePayloadFields(payload, path, context) {
+    const version = context.number(required5(payload, "version", path, context), `${path}.version`);
+    if (version !== 1) context.fail(`${path}.version`, "must be 1");
+    const name = context.string(required5(payload, "name", path, context), `${path}.name`);
+    const width = context.number(required5(payload, "width", path, context), `${path}.width`, 0);
+    const height = context.number(required5(payload, "height", path, context), `${path}.height`, 0);
+    const tokens = validateTokens(payload.tokens ?? {}, `${path}.tokens`, context);
+    const rootNode = required5(payload, "rootNode", path, context);
+    validateNode(rootNode, `${path}.rootNode`, context);
+    return { version: 1, name, width, height, tokens, rootNode };
+  }
+  function validatePlacement(source, context) {
+    const placement = {};
+    for (const key of ["x", "y"]) if (source[key] !== void 0) {
+      placement[key] = context.number(source[key], `params.${key}`);
     }
-    return resolved;
+    for (const key of ["parentId", "replaceId"]) if (source[key] !== void 0) {
+      placement[key] = context.string(source[key], `params.${key}`);
+    }
+    return placement;
+  }
+  function validateImportPayload(params, limitOverrides = {}) {
+    const context = new ValidationContext(limitOverrides);
+    const looksWrapped = !!params && typeof params === "object" && !Array.isArray(params) && Object.prototype.hasOwnProperty.call(params, "payload");
+    return context.object(params, "params", looksWrapped ? WRAPPED_FIELDS : DIRECT_FIELDS, (envelope) => {
+      const payload = looksWrapped ? context.object(required5(envelope, "payload", "params", context), "payload", PAYLOAD_FIELDS, (value) => validatePayloadFields(value, "payload", context)) : validatePayloadFields(envelope, "payload", context);
+      return { payload, placement: validatePlacement(envelope, context) };
+    });
   }
 
   // plugin/src/main/executor-text.ts
@@ -2599,7 +3189,7 @@
   }
 
   // plugin/src/main/instance-inner-override-keys.ts
-  var INNER_OVERRIDE_FIELDS = [
+  var INNER_OVERRIDE_FIELDS2 = [
     "name",
     "width",
     "height",
@@ -2608,7 +3198,7 @@
     "primaryAxisSizingMode",
     "counterAxisSizingMode"
   ];
-  var FIELD_SET = new Set(INNER_OVERRIDE_FIELDS);
+  var FIELD_SET = new Set(INNER_OVERRIDE_FIELDS2);
   function innerChildPrefix(instanceId) {
     return instanceId.startsWith("I") ? `${instanceId};` : `I${instanceId};`;
   }
@@ -2708,6 +3298,55 @@
       }
     }
     return any && changesVariant;
+  }
+
+  // plugin/src/main/executor-keyed-vars.ts
+  var resolvedByKey = /* @__PURE__ */ new Map();
+  var localByKey = null;
+  function resetKeyedVariableCache() {
+    resolvedByKey.clear();
+    localByKey = null;
+  }
+  async function readLocalVariablesByKey() {
+    if (localByKey) return localByKey;
+    const map = /* @__PURE__ */ new Map();
+    try {
+      for (const v of await figma.variables.getLocalVariablesAsync()) {
+        if (typeof v.key === "string" && v.key) map.set(v.key, v);
+      }
+    } catch {
+    }
+    localByKey = map;
+    return map;
+  }
+  async function resolveKeyedVariable(key) {
+    const cached = resolvedByKey.get(key);
+    if (cached !== void 0) return cached;
+    let variable = (await readLocalVariablesByKey()).get(key) ?? null;
+    if (!variable) {
+      try {
+        variable = await figma.variables.importVariableByKeyAsync(key);
+      } catch (err) {
+        pushImportWarning(`variable resolve failed for key ${key}: not local, and import failed: ${String(err)}`);
+      }
+    }
+    resolvedByKey.set(key, variable);
+    return variable;
+  }
+  async function applyKeyedBindings(node, bindings) {
+    for (const [field, ref] of Object.entries(bindings)) {
+      if (!ref || typeof ref.key !== "string" || !ref.key) continue;
+      const variable = await resolveKeyedVariable(ref.key);
+      if (!variable) {
+        pushImportWarning(`keyed bind ${field}\u2192${ref.name ?? ref.key} skipped on "${node.name}": key not resolvable \u2014 literal value kept`);
+        continue;
+      }
+      try {
+        bindVariableToField(node, field, variable);
+      } catch (err) {
+        pushImportWarning(`keyed bind ${field}\u2192${ref.name ?? ref.key} failed on "${node.name}": ${String(err)}`);
+      }
+    }
   }
 
   // plugin/src/main/scan-node-paint.ts
@@ -3365,6 +4004,73 @@
     }
     reassertAxisSizing(frame, exportNode);
     return frame;
+  }
+
+  // plugin/src/main/executor-token-var-resolve.ts
+  function tokensAreEmpty(tokens) {
+    return !(tokens.colors?.length || tokens.spacing?.length || tokens.radii?.length);
+  }
+  async function readLocalVariableMap() {
+    const byName = /* @__PURE__ */ new Map();
+    try {
+      for (const v of await figma.variables.getLocalVariablesAsync()) {
+        if (!byName.has(v.name)) byName.set(v.name, v);
+      }
+    } catch (err) {
+      pushImportWarning(`local variable lookup failed \u2014 tokenRefs left unbound: ${String(err)}`);
+    }
+    return byName;
+  }
+  async function resolveTokenVars(tokens) {
+    const resolved = await readLocalVariableMap();
+    if (tokensAreEmpty(tokens)) return resolved;
+    for (const [name, variable] of await createVariablesFromTokens(tokens)) {
+      resolved.set(name, variable);
+    }
+    return resolved;
+  }
+
+  // plugin/src/main/import-payload-admission.ts
+  async function importPayload(params) {
+    const { payload, placement } = validateImportPayload(params);
+    resetImportWarnings();
+    resetKeyedVariableCache();
+    const tokens = payload.tokens;
+    const colorStyles = await createColorStyles(tokens.colors);
+    await createTextStyles(tokens.typography);
+    await createEffectStyles(tokens.shadows);
+    const tokenVars = await resolveTokenVars(tokens);
+    const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);
+    if (!root) throw new Error("payload rootNode produced no Figma node");
+    let replaceTarget = null;
+    if (placement.replaceId) {
+      const target = await figma.getNodeByIdAsync(placement.replaceId);
+      if (target && target.type !== "DOCUMENT" && target.type !== "PAGE") replaceTarget = target;
+    }
+    let parent = figma.currentPage;
+    if (placement.parentId) {
+      const target = await figma.getNodeByIdAsync(placement.parentId);
+      if (target && "appendChild" in target) parent = target;
+    }
+    parent.appendChild(root);
+    if (replaceTarget) {
+      root.x = replaceTarget.x;
+      root.y = replaceTarget.y;
+      replaceTarget.remove();
+    } else if (placement.x !== void 0 && placement.y !== void 0) {
+      root.x = placement.x;
+      root.y = placement.y;
+    } else {
+      root.x = Math.round(figma.viewport.center.x - root.width / 2);
+      root.y = Math.round(figma.viewport.center.y - root.height / 2);
+    }
+    try {
+      figma.currentPage.selection = [root];
+      figma.viewport.scrollAndZoomIntoView([root]);
+    } catch {
+    }
+    figma.notify(`Imported "${payload.name}" (${tokens.colors.length} colors, ${tokens.typography.length} text styles)`);
+    return { id: root.id, name: root.name, warnings: getImportWarnings() };
   }
 
   // shared/audit-types.ts
@@ -4726,20 +5432,20 @@
     dev: "switch to Dev Mode and re-run"
   };
   function editorRefusal(opts) {
-    const { capability, required, found } = opts;
-    if (found !== null && required.includes(found)) return null;
+    const { capability, required: required6, found } = opts;
+    if (found !== null && required6.includes(found)) return null;
     const foundLabel = found === null ? "the host did not report an editor type" : EDITOR_LABEL[found];
-    const requiredLabels = required.filter((r) => r !== null).map((r) => EDITOR_LABEL[r]);
+    const requiredLabels = required6.filter((r) => r !== null).map((r) => EDITOR_LABEL[r]);
     const requiredList = requiredLabels.length === 1 ? requiredLabels[0] : `one of: ${requiredLabels.join(", ")}`;
-    const firstRequired = required.find((r) => r !== null);
+    const firstRequired = required6.find((r) => r !== null);
     const nextAction = firstRequired ? NEXT_ACTION[firstRequired] : "reopen the file the capability needs";
     return `${capability} needs ${requiredList}, but ${foundLabel} is open \u2014 ${nextAction}.`;
   }
 
   // plugin/src/main/exec-stdlib-editor.ts
-  function requireEditor(capability, required) {
+  function requireEditor(capability, required6) {
     const found = figma.editorType ?? null;
-    const message = editorRefusal({ capability, required, found });
+    const message = editorRefusal({ capability, required: required6, found });
     if (message !== null) throw withCode(new Error(message), "E_INVALID_ARGS");
   }
   function requireDesignFile(capability) {
@@ -7896,50 +8602,6 @@
       default:
         throw withCode(new Error(`unknown command: ${cmd}`), "E_INVALID_ARGS");
     }
-  }
-  async function importPayload(params) {
-    const payload = params.payload ?? params;
-    if (!payload || typeof payload !== "object" || !payload.rootNode) {
-      throw withCode(new Error("IMPORT_PAYLOAD requires params.payload (FigmaExportPayload with rootNode)"), "E_INVALID_ARGS");
-    }
-    resetImportWarnings();
-    resetKeyedVariableCache();
-    const tokens = payload.tokens ?? { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
-    const colorStyles = await createColorStyles(tokens.colors ?? []);
-    await createTextStyles(tokens.typography ?? []);
-    await createEffectStyles(tokens.shadows ?? []);
-    const tokenVars = await resolveTokenVars(tokens);
-    const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);
-    if (!root) throw new Error("payload rootNode produced no Figma node");
-    let replaceTarget = null;
-    if (typeof params.replaceId === "string" && params.replaceId) {
-      const t = await figma.getNodeByIdAsync(params.replaceId);
-      if (t && t.type !== "DOCUMENT" && t.type !== "PAGE") replaceTarget = t;
-    }
-    let parent = figma.currentPage;
-    if (typeof params.parentId === "string" && params.parentId) {
-      const p = await figma.getNodeByIdAsync(params.parentId);
-      if (p && "appendChild" in p) parent = p;
-    }
-    parent.appendChild(root);
-    if (replaceTarget) {
-      root.x = replaceTarget.x;
-      root.y = replaceTarget.y;
-      replaceTarget.remove();
-    } else if (typeof params.x === "number" && typeof params.y === "number") {
-      root.x = params.x;
-      root.y = params.y;
-    } else {
-      root.x = Math.round(figma.viewport.center.x - root.width / 2);
-      root.y = Math.round(figma.viewport.center.y - root.height / 2);
-    }
-    try {
-      figma.currentPage.selection = [root];
-      figma.viewport.scrollAndZoomIntoView([root]);
-    } catch {
-    }
-    figma.notify(`Imported "${payload.name}" (${(tokens.colors ?? []).length} colors, ${(tokens.typography ?? []).length} text styles)`);
-    return { id: root.id, name: root.name, warnings: getImportWarnings() };
   }
   async function runBatch(params) {
     const ops = Array.isArray(params) ? params : params.ops;

--- a/plugin/src/main/import-payload-admission.ts
+++ b/plugin/src/main/import-payload-admission.ts
@@ -1,0 +1,59 @@
+import { validateImportPayload } from '../../../shared/figma-payload-validation';
+import {
+  createColorStyles, createEffectStyles, createTextStyles, getImportWarnings, resetImportWarnings,
+} from './executor-styles';
+import { createFigmaNode } from './executor-frame';
+import { resetKeyedVariableCache } from './executor-keyed-vars';
+import { resolveTokenVars } from './executor-token-var-resolve';
+
+type Params = Record<string, unknown>;
+
+/** Validate one import completely before the first Figma style, variable, or node write. */
+export async function importPayload(
+  params: Params,
+): Promise<{ id: string; name: string; warnings: string[] }> {
+  const { payload, placement } = validateImportPayload(params);
+  resetImportWarnings();
+  resetKeyedVariableCache();
+
+  const tokens = payload.tokens;
+  const colorStyles = await createColorStyles(tokens.colors);
+  await createTextStyles(tokens.typography);
+  await createEffectStyles(tokens.shadows);
+  const tokenVars = await resolveTokenVars(tokens);
+
+  const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);
+  if (!root) throw new Error('payload rootNode produced no Figma node');
+
+  let replaceTarget: SceneNode | null = null;
+  if (placement.replaceId) {
+    const target = await figma.getNodeByIdAsync(placement.replaceId);
+    if (target && target.type !== 'DOCUMENT' && target.type !== 'PAGE') replaceTarget = target as SceneNode;
+  }
+  let parent: BaseNode & ChildrenMixin = figma.currentPage;
+  if (placement.parentId) {
+    const target = await figma.getNodeByIdAsync(placement.parentId);
+    if (target && 'appendChild' in target) parent = target as BaseNode & ChildrenMixin;
+  }
+  parent.appendChild(root);
+
+  if (replaceTarget) {
+    root.x = replaceTarget.x;
+    root.y = replaceTarget.y;
+    replaceTarget.remove();
+  } else if (placement.x !== undefined && placement.y !== undefined) {
+    root.x = placement.x;
+    root.y = placement.y;
+  } else {
+    root.x = Math.round(figma.viewport.center.x - root.width / 2);
+    root.y = Math.round(figma.viewport.center.y - root.height / 2);
+  }
+
+  try {
+    figma.currentPage.selection = [root];
+    figma.viewport.scrollAndZoomIntoView([root]);
+  } catch { /* root not on current page */ }
+
+  figma.notify(`Imported "${payload.name}" (${tokens.colors.length} colors, ${tokens.typography.length} text styles)`);
+  return { id: root.id, name: root.name, warnings: getImportWarnings() };
+}

--- a/plugin/src/main/main.ts
+++ b/plugin/src/main/main.ts
@@ -8,7 +8,6 @@
 import type { CommandName, ErrorCode, FileContext, WireError } from '../../../shared/protocol';
 import { DEFAULT_IDLE_MS, MIN_IDLE_MS } from '../../../shared/protocol';
 import { fileMatches } from '../../../shared/file-match';
-import type { FigmaExportPayload } from '../../../shared/figma-payload-types';
 import {
   clearLegacyGapfillDocumentData, runGapfillDiff, snapshotPageBounded, writeBaseline,
 } from './edit-gapfill';
@@ -24,14 +23,9 @@ import {
 } from './edit-actor';
 import { createEditIdentityCache } from './change-node-identity';
 import { createDocumentChangeCapture } from './document-change-capture';
-import {
-  createColorStyles, createTextStyles, createEffectStyles,
-  resetImportWarnings, getImportWarnings, withCode,
-} from './executor-styles';
+import { withCode } from './executor-styles';
 import { opCreateVariable, opBindVariable } from './executor-variables';
-import { resetKeyedVariableCache } from './executor-keyed-vars';
-import { resolveTokenVars } from './executor-token-var-resolve';
-import { createFigmaNode } from './executor-frame';
+import { importPayload } from './import-payload-admission';
 import { serializeDesignSystem } from './serialize-node';
 import { auditDs } from './executor-audit';
 import { figmaContextEnv, opGetContext } from './executor-context';
@@ -590,68 +584,6 @@ async function dispatch(cmd: CommandName, params: Params): Promise<unknown> {
       // HTML_TO_FIGMA is handled entirely in the UI relay and arrives here as IMPORT_PAYLOAD
       throw withCode(new Error(`unknown command: ${cmd}`), 'E_INVALID_ARGS');
   }
-}
-
-/**
- * IMPORT_PAYLOAD: consume a FigmaExportPayload (ported EaseUI code.ts import
- * path): styles + variables from tokens → node tree → position → select.
- */
-async function importPayload(params: Params): Promise<{ id: string; name: string; warnings: string[] }> {
-  const payload = (params.payload ?? params) as FigmaExportPayload;
-  if (!payload || typeof payload !== 'object' || !payload.rootNode) {
-    throw withCode(new Error('IMPORT_PAYLOAD requires params.payload (FigmaExportPayload with rootNode)'), 'E_INVALID_ARGS');
-  }
-  resetImportWarnings();
-  resetKeyedVariableCache(); // spec-005 P7/P8: one resolve per variable key, per import run
-
-  // 1. Local styles + variables from tokens (variables are de-duped on re-import);
-  //    tokenVars (name → Variable) feeds tokenRefs binding during node build (P3 leg B).
-  //    spec-005 P6: the map now also carries the file's EXISTING local variables, so a
-  //    rebuild from a spec alone (no payload.tokens) reattaches its bindings by name.
-  const tokens = payload.tokens ?? { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
-  const colorStyles = await createColorStyles(tokens.colors ?? []);
-  await createTextStyles(tokens.typography ?? []);
-  await createEffectStyles(tokens.shadows ?? []);
-  const tokenVars = await resolveTokenVars(tokens);
-
-  // 2. Build the node tree (tokenRefs bound inline via tokenVars)
-  const root = await createFigmaNode(payload.rootNode, colorStyles, tokenVars);
-  if (!root) throw new Error('payload rootNode produced no Figma node');
-
-  // 3. Resolve replace target + parent BEFORE positioning
-  let replaceTarget: SceneNode | null = null;
-  if (typeof params.replaceId === 'string' && params.replaceId) {
-    const t = await figma.getNodeByIdAsync(params.replaceId);
-    if (t && t.type !== 'DOCUMENT' && t.type !== 'PAGE') replaceTarget = t as SceneNode;
-  }
-  let parent: BaseNode & ChildrenMixin = figma.currentPage;
-  if (typeof params.parentId === 'string' && params.parentId) {
-    const p = await figma.getNodeByIdAsync(params.parentId);
-    if (p && 'appendChild' in p) parent = p as BaseNode & ChildrenMixin;
-  }
-  parent.appendChild(root);
-
-  // 4. Position: replace target's coords > explicit x/y > viewport center
-  if (replaceTarget) {
-    root.x = replaceTarget.x;
-    root.y = replaceTarget.y;
-    replaceTarget.remove(); // only after the new node is placed successfully
-  } else if (typeof params.x === 'number' && typeof params.y === 'number') {
-    root.x = params.x;
-    root.y = params.y;
-  } else {
-    root.x = Math.round(figma.viewport.center.x - root.width / 2);
-    root.y = Math.round(figma.viewport.center.y - root.height / 2);
-  }
-
-  // 5. Select + bring into view (skip silently if parented to another page)
-  try {
-    figma.currentPage.selection = [root];
-    figma.viewport.scrollAndZoomIntoView([root]);
-  } catch { /* root not on current page */ }
-
-  figma.notify(`Imported "${payload.name}" (${(tokens.colors ?? []).length} colors, ${(tokens.typography ?? []).length} text styles)`);
-  return { id: root.id, name: root.name, warnings: getImportWarnings() };
 }
 
 /** BATCH: sequential {cmd, params}[] through the same dispatch; stopOnError optional. */

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -26,6 +26,8 @@ import {
 import { createPreOpenBuffer, handshakeBatch, isBufferableFrame, stampCapturedFrame } from './outbound-buffer';
 import { flushHandshake, refuseAdoption } from './socket-adoption';
 import { renderHtmlToPayload } from './render-host';
+import { forwardValidatedDirectImport, forwardValidatedHtmlImport } from '../../../shared/figma-payload-validation-relay';
+import { PayloadValidationError } from '../../../shared/figma-payload-validation';
 import { renderGradientToPng, GradientRenderError } from './gradient-host';
 import { summarizeError, summarizeResult } from './activity-summary';
 import { createHeartbeatDriver } from './heartbeat-driver';
@@ -276,7 +278,7 @@ function handleChunk(c: ChunkMsg): void {
   handleWireData(buf.join(''));
 }
 
-// ─── Request routing: HTML_TO_FIGMA converts here, rest passes to main ──
+// ─── Request routing: HTML converts, direct payload imports admit, rest passes ──
 interface HtmlToFigmaParams {
   html?: string; width?: number; name?: string;
   x?: number; y?: number; parentId?: string; replaceId?: string;
@@ -305,14 +307,12 @@ async function handleRequest(req: RequestMsg): Promise<void> {
       setStatusText('connected', 'ok');
       // The HTML render above still runs before main can refuse a wrong-file HTML_TO_FIGMA —
       // wasted work only; the iframe cannot touch the scene, and main's guard still fires here.
-      parent.postMessage({
-        pluginMessage: {
-          requestId: req.id,
-          cmd: 'IMPORT_PAYLOAD',
-          expectedFile: req.expectedFile,
-          params: { payload, x: p.x, y: p.y, parentId: p.parentId, replaceId: p.replaceId },
-        },
-      }, '*');
+      forwardValidatedHtmlImport({
+        requestId: req.id,
+        expectedFile: req.expectedFile,
+        payload,
+        placement: { x: p.x, y: p.y, parentId: p.parentId, replaceId: p.replaceId },
+      }, (message) => parent.postMessage(message, '*'));
     } else if (req.cmd === 'SHADER_GRADIENT_PROBE') {
       // Read-only capability probe. Renders a deliberately tiny field and reports the
       // outcome; it never posts IMPORT_GRADIENT, so no node and no fill is ever touched.
@@ -384,6 +384,13 @@ async function handleRequest(req: RequestMsg): Promise<void> {
           },
         },
       }, '*');
+    } else if (req.cmd === 'IMPORT_PAYLOAD') {
+      forwardValidatedDirectImport({
+        requestId: req.id,
+        expectedFile: req.expectedFile,
+        params: req.params,
+        readOnly: req.readOnly,
+      }, (message) => parent.postMessage(message, '*'));
     } else {
       // Everything else is a main-thread op — forward unchanged. `readOnly` is carried
       // through here (never forwarded before this — main.ts never saw it regardless of
@@ -400,6 +407,11 @@ async function handleRequest(req: RequestMsg): Promise<void> {
   } catch (err) {
     setStatusText('connected', 'ok');
     const message = err instanceof Error ? err.message : String(err);
+    if (err instanceof PayloadValidationError) {
+      sendErr(req.id, err.code, message);
+      emitActivity(req.id, false, { code: err.code, message });
+      return;
+    }
     // A gradient render failure carries its OWN reason (no WebGL, CDN unreachable,
     // empty capture). Collapsing it into a bare E_PLUGIN_ERROR would leave the user
     // with a command that "just failed" and no way to tell which of those it was.

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -520,6 +520,10 @@ body {
 <script>
 "use strict";
 (() => {
+  var __defProp = Object.defineProperty;
+  var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
+  var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
+
   // shared/protocol.ts
   var PROTOCOL_VERSION = 1;
   var PLUGIN_CAPABILITIES = [
@@ -1859,7 +1863,7 @@ body {
   var syncBadge = el("fga-sync-badge");
   var activityView = new ActivityView(el("fga-failure-count"));
   var thinkingOrb = mountThinkingOrb(orbHost);
-  var BUILD_LINE = `v0.1.0 \xB7 ${true ? "a60308f" : "dev"}`;
+  var BUILD_LINE = `v0.1.0 \xB7 ${true ? "8029b07" : "dev"}`;
   var SYNC_RESULT_HOLD_MS = 4e3;
   var payload = null;
   var hadConnection = false;
@@ -3668,6 +3672,690 @@ body {
     }
   }
 
+  // shared/figma-payload-validation-context.ts
+  var IMPORT_PAYLOAD_LIMITS = {
+    aggregateBytes: 64 * 1024 * 1024,
+    totalEntries: 5e6,
+    nodes: 1e5,
+    depth: 256,
+    textChars: 1024 * 1024,
+    imageChars: 16 * 1024 * 1024,
+    svgChars: 16 * 1024 * 1024,
+    arrayEntries: 1e5,
+    recordEntries: 1e4,
+    recordKeyChars: 16384,
+    tokenGroup: 1e4,
+    motionSteps: 1e4
+  };
+  var PayloadValidationError = class extends Error {
+    constructor(message) {
+      super(`IMPORT_PAYLOAD rejected: ${message}`);
+      __publicField(this, "code", "E_INVALID_ARGS");
+      this.name = "PayloadValidationError";
+    }
+  };
+  function jsonStringBytes(value) {
+    let bytes = 2;
+    for (let i = 0; i < value.length; i++) {
+      const unit = value.charCodeAt(i);
+      if (unit === 34 || unit === 92) bytes += 2;
+      else if (unit === 8 || unit === 9 || unit === 10 || unit === 12 || unit === 13) bytes += 2;
+      else if (unit < 32) bytes += 6;
+      else if (unit < 128) bytes += 1;
+      else if (unit < 2048) bytes += 2;
+      else if (unit >= 55296 && unit <= 56319 && i + 1 < value.length && (value.charCodeAt(i + 1) & 64512) === 56320) {
+        bytes += 4;
+        i += 1;
+      } else if (unit >= 55296 && unit <= 57343) bytes += 6;
+      else bytes += 3;
+    }
+    return bytes;
+  }
+  var ValidationContext = class {
+    constructor(overrides = {}) {
+      __publicField(this, "limits");
+      __publicField(this, "aggregateBytes", 0);
+      __publicField(this, "totalEntries", 0);
+      __publicField(this, "nodeCount", 0);
+      __publicField(this, "active", /* @__PURE__ */ new WeakSet());
+      this.limits = { ...IMPORT_PAYLOAD_LIMITS, ...overrides };
+    }
+    fail(path, message) {
+      throw new PayloadValidationError(`${path} ${message}`);
+    }
+    addBytes(bytes, path) {
+      this.aggregateBytes += bytes;
+      if (this.aggregateBytes > this.limits.aggregateBytes) {
+        this.fail(path, `exceeds aggregate budget ${this.limits.aggregateBytes} bytes`);
+      }
+    }
+    addEntry(path) {
+      this.totalEntries += 1;
+      if (this.totalEntries > this.limits.totalEntries) {
+        this.fail(path, `exceeds aggregate entry budget ${this.limits.totalEntries}`);
+      }
+    }
+    object(value, path, allowed, visit, maxKeys = allowed?.size ?? this.limits.recordEntries) {
+      if (!value || typeof value !== "object" || Array.isArray(value) || Object.getPrototypeOf(value) !== Object.prototype) {
+        this.fail(path, "must be a plain object");
+      }
+      if (this.active.has(value)) this.fail(path, "must not contain an active cycle");
+      this.active.add(value);
+      this.addBytes(2, path);
+      try {
+        let count = 0;
+        for (const key in value) {
+          if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+          count += 1;
+          if (count > maxKeys) this.fail(path, `must have at most ${maxKeys} fields`);
+          if (key.length > this.limits.recordKeyChars) {
+            this.fail(`${path} key`, `must be at most ${this.limits.recordKeyChars} characters`);
+          }
+          this.addEntry(`${path}.${key}`);
+          this.addBytes(jsonStringBytes(key) + 2, `${path}.${key}`);
+          if (allowed && !allowed.has(key)) this.fail(`${path}.${key}`, "is not a supported field");
+        }
+        return visit(value);
+      } finally {
+        this.active.delete(value);
+      }
+    }
+    array(value, path, max, visit, min = 0) {
+      if (!Array.isArray(value) || value.length < min || value.length > max) {
+        this.fail(path, `must be an array with ${min}..${max} entries`);
+      }
+      for (const key in value) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        const index = Number(key);
+        if (key.length > this.limits.recordKeyChars || !Number.isInteger(index) || index < 0 || index >= value.length || String(index) !== key) {
+          this.fail(path, "must not contain enumerable non-index fields");
+        }
+      }
+      if (this.active.has(value)) this.fail(path, "must not contain an active cycle");
+      this.active.add(value);
+      this.addBytes(2, path);
+      try {
+        for (let i = 0; i < value.length; i++) {
+          this.addEntry(`${path}[${i}]`);
+          this.addBytes(1, `${path}[${i}]`);
+          visit(value[i], i);
+        }
+      } finally {
+        this.active.delete(value);
+      }
+    }
+    string(value, path, max = this.limits.textChars) {
+      if (typeof value !== "string" || value.length > max) {
+        this.fail(path, `must be a string no longer than ${max} characters`);
+      }
+      this.addBytes(jsonStringBytes(value), path);
+      return value;
+    }
+    number(value, path, min = -Infinity, max = Infinity) {
+      if (typeof value !== "number" || !Number.isFinite(value) || value < min || value > max) {
+        this.fail(path, `must be a finite number between ${min} and ${max}`);
+      }
+      this.addBytes(24, path);
+      return value;
+    }
+    integer(value, path, min = 0) {
+      const parsed = this.number(value, path, min);
+      if (!Number.isInteger(parsed)) this.fail(path, "must be an integer");
+      return parsed;
+    }
+    boolean(value, path) {
+      if (typeof value !== "boolean") this.fail(path, "must be boolean");
+      this.addBytes(5, path);
+      return value;
+    }
+    enumValue(value, path, values) {
+      const parsed = this.string(value, path, 128);
+      if (!values.includes(parsed)) this.fail(path, `must be one of ${values.join(", ")}`);
+      return parsed;
+    }
+    node(path, depth) {
+      if (depth > this.limits.depth) this.fail(path, `exceeds maximum depth ${this.limits.depth}`);
+      this.nodeCount += 1;
+      if (this.nodeCount > this.limits.nodes) this.fail(path, `exceeds maximum node count ${this.limits.nodes}`);
+    }
+  };
+
+  // shared/figma-payload-validation-values.ts
+  var COLOR_FIELDS = /* @__PURE__ */ new Set(["r", "g", "b", "a"]);
+  var FILL_FIELDS = /* @__PURE__ */ new Set(["type", "color", "gradientStops", "gradientTransform"]);
+  var EFFECT_FIELDS = /* @__PURE__ */ new Set(["type", "offset", "radius", "spread", "color"]);
+  var OFFSET_FIELDS = /* @__PURE__ */ new Set(["x", "y"]);
+  var KEYED_BINDING_FIELDS = /* @__PURE__ */ new Set(["key", "name"]);
+  var TEXT_SEGMENT_FIELDS = /* @__PURE__ */ new Set([
+    "characters",
+    "fontFamily",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "lineHeight",
+    "letterSpacing",
+    "textColor",
+    "textDecoration",
+    "textCase"
+  ]);
+  var MOTION_FIELDS = /* @__PURE__ */ new Set(["steps", "durationSec", "easing"]);
+  var MOTION_STEP_FIELDS = /* @__PURE__ */ new Set(["offset", "style"]);
+  var MOTION_STYLE_FIELDS = /* @__PURE__ */ new Set(["opacity", "transform"]);
+  function required(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateColor(value, path, context) {
+    context.object(value, path, COLOR_FIELDS, (item) => {
+      for (const key of COLOR_FIELDS) context.number(required(item, key, path, context), `${path}.${key}`, 0, 1);
+    });
+  }
+  function validateFill(value, path, context) {
+    context.object(value, path, FILL_FIELDS, (item) => {
+      const type = context.enumValue(required(item, "type", path, context), `${path}.type`, [
+        "SOLID",
+        "GRADIENT_LINEAR",
+        "GRADIENT_RADIAL",
+        "GRADIENT_ANGULAR"
+      ]);
+      if (type === "SOLID") {
+        validateColor(required(item, "color", path, context), `${path}.color`, context);
+        if (item.gradientStops !== void 0 || item.gradientTransform !== void 0) {
+          context.fail(path, "SOLID fills must not contain gradient fields");
+        }
+        return;
+      }
+      if (item.color !== void 0) context.fail(`${path}.color`, "is only supported for SOLID fills");
+      context.array(required(item, "gradientStops", path, context), `${path}.gradientStops`, context.limits.arrayEntries, (stop, i) => {
+        const stopPath = `${path}.gradientStops[${i}]`;
+        context.object(stop, stopPath, /* @__PURE__ */ new Set(["color", "position"]), (entry) => {
+          validateColor(required(entry, "color", stopPath, context), `${stopPath}.color`, context);
+          context.number(required(entry, "position", stopPath, context), `${stopPath}.position`, 0, 1);
+        });
+      }, 2);
+      context.array(required(item, "gradientTransform", path, context), `${path}.gradientTransform`, 2, (row, i) => {
+        context.array(row, `${path}.gradientTransform[${i}]`, 3, (entry, j) => {
+          context.number(entry, `${path}.gradientTransform[${i}][${j}]`);
+        }, 3);
+      }, 2);
+    });
+  }
+  function validateEffect(value, path, context) {
+    context.object(value, path, EFFECT_FIELDS, (item) => {
+      context.enumValue(required(item, "type", path, context), `${path}.type`, [
+        "DROP_SHADOW",
+        "INNER_SHADOW",
+        "LAYER_BLUR",
+        "BACKGROUND_BLUR"
+      ]);
+      context.number(required(item, "radius", path, context), `${path}.radius`, 0);
+      if (item.spread !== void 0) context.number(item.spread, `${path}.spread`);
+      if (item.color !== void 0) validateColor(item.color, `${path}.color`, context);
+      if (item.offset !== void 0) context.object(item.offset, `${path}.offset`, OFFSET_FIELDS, (offset) => {
+        context.number(required(offset, "x", `${path}.offset`, context), `${path}.offset.x`);
+        context.number(required(offset, "y", `${path}.offset`, context), `${path}.offset.y`);
+      });
+    });
+  }
+  function validateRecord(value, path, context, visit) {
+    context.object(value, path, null, (item) => {
+      for (const key in item) {
+        if (Object.prototype.hasOwnProperty.call(item, key)) visit(item[key], `${path}.${key}`);
+      }
+    });
+  }
+  function validateKeyedBindings(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      context.object(entry, entryPath, KEYED_BINDING_FIELDS, (binding) => {
+        context.string(required(binding, "key", entryPath, context), `${entryPath}.key`);
+        if (binding.name !== void 0) context.string(binding.name, `${entryPath}.name`);
+      });
+    });
+  }
+  function validateStringRecord(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => context.string(entry, entryPath));
+  }
+  function validatePrimitiveRecord(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      if (typeof entry === "number") context.number(entry, entryPath);
+      else context.string(entry, entryPath);
+    });
+  }
+  function validateComponentProperties(value, path, context) {
+    validateRecord(value, path, context, (entry, entryPath) => {
+      if (typeof entry === "boolean") context.boolean(entry, entryPath);
+      else context.string(entry, entryPath);
+    });
+  }
+  function validateTextSegments(value, path, context) {
+    context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+      const entryPath = `${path}[${i}]`;
+      context.object(entry, entryPath, TEXT_SEGMENT_FIELDS, (segment) => {
+        context.string(required(segment, "characters", entryPath, context), `${entryPath}.characters`);
+        if (segment.fontFamily !== void 0) context.string(segment.fontFamily, `${entryPath}.fontFamily`);
+        for (const key of ["fontSize", "fontWeight", "lineHeight"]) if (segment[key] !== void 0) {
+          context.number(segment[key], `${entryPath}.${key}`, 0);
+        }
+        if (segment.letterSpacing !== void 0) context.number(segment.letterSpacing, `${entryPath}.letterSpacing`);
+        if (segment.fontStyle !== void 0) context.enumValue(segment.fontStyle, `${entryPath}.fontStyle`, ["normal", "italic"]);
+        if (segment.textDecoration !== void 0) context.enumValue(segment.textDecoration, `${entryPath}.textDecoration`, ["UNDERLINE", "STRIKETHROUGH"]);
+        if (segment.textCase !== void 0) context.enumValue(segment.textCase, `${entryPath}.textCase`, ["UPPER", "LOWER", "TITLE"]);
+        if (segment.textColor !== void 0) validateColor(segment.textColor, `${entryPath}.textColor`, context);
+      });
+    });
+  }
+  function validateMotion(value, path, context) {
+    context.object(value, path, MOTION_FIELDS, (motion) => {
+      context.number(required(motion, "durationSec", path, context), `${path}.durationSec`, 0);
+      if (motion.easing !== void 0) context.string(motion.easing, `${path}.easing`);
+      context.array(required(motion, "steps", path, context), `${path}.steps`, context.limits.motionSteps, (entry, i) => {
+        const entryPath = `${path}.steps[${i}]`;
+        context.object(entry, entryPath, MOTION_STEP_FIELDS, (step) => {
+          context.number(required(step, "offset", entryPath, context), `${entryPath}.offset`, 0, 1);
+          context.object(required(step, "style", entryPath, context), `${entryPath}.style`, MOTION_STYLE_FIELDS, (style) => {
+            for (const key of MOTION_STYLE_FIELDS) if (style[key] !== void 0) context.string(style[key], `${entryPath}.style.${key}`);
+          });
+        });
+      });
+    });
+  }
+
+  // shared/figma-payload-validation-node-details.ts
+  var TOKEN_REF_FIELDS = /* @__PURE__ */ new Set(["fill", "stroke", "textColor", "radius", "gap", "padding"]);
+  var INNER_OVERRIDE_FIELDS = /* @__PURE__ */ new Set([
+    "childKey",
+    "fields",
+    "componentKey",
+    "componentId",
+    "componentProperties",
+    "visual",
+    "figmaScanFillSize"
+  ]);
+  var INNER_VISUAL_FIELDS = /* @__PURE__ */ new Set([
+    "fills",
+    "strokes",
+    "effects",
+    "effectStyleId",
+    "visible",
+    "opacity",
+    "keyedBindings"
+  ]);
+  var FILL_SIZE_FIELDS = /* @__PURE__ */ new Set(["width", "height"]);
+  function required2(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateTokenRefs(value, path, context) {
+    context.object(value, path, TOKEN_REF_FIELDS, (refs) => {
+      for (const key of TOKEN_REF_FIELDS) if (refs[key] !== void 0) context.string(refs[key], `${path}.${key}`);
+    });
+  }
+  function validateInnerVisual(value, path, context) {
+    context.object(value, path, INNER_VISUAL_FIELDS, (visual) => {
+      for (const key of ["fills", "strokes"]) if (visual[key] !== void 0) {
+        context.array(visual[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+          validateFill(entry, `${path}.${key}[${i}]`, context);
+        });
+      }
+      if (visual.effects !== void 0) context.array(
+        visual.effects,
+        `${path}.effects`,
+        context.limits.arrayEntries,
+        (entry, i) => validateEffect(entry, `${path}.effects[${i}]`, context)
+      );
+      if (visual.effectStyleId !== void 0) context.string(visual.effectStyleId, `${path}.effectStyleId`);
+      if (visual.visible !== void 0) context.boolean(visual.visible, `${path}.visible`);
+      if (visual.opacity !== void 0) context.number(visual.opacity, `${path}.opacity`, 0, 1);
+      if (visual.keyedBindings !== void 0) validateKeyedBindings(visual.keyedBindings, `${path}.keyedBindings`, context);
+    });
+  }
+  function validateInnerOverrides(value, path, context) {
+    context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+      const entryPath = `${path}[${i}]`;
+      context.object(entry, entryPath, INNER_OVERRIDE_FIELDS, (override) => {
+        context.string(required2(override, "childKey", entryPath, context), `${entryPath}.childKey`);
+        validatePrimitiveRecord(required2(override, "fields", entryPath, context), `${entryPath}.fields`, context);
+        for (const key of ["componentKey", "componentId"]) if (override[key] !== void 0) {
+          context.string(override[key], `${entryPath}.${key}`);
+        }
+        if (override.componentProperties !== void 0) {
+          validateComponentProperties(override.componentProperties, `${entryPath}.componentProperties`, context);
+        }
+        if (override.visual !== void 0) validateInnerVisual(override.visual, `${entryPath}.visual`, context);
+        if (override.figmaScanFillSize !== void 0) {
+          context.object(override.figmaScanFillSize, `${entryPath}.figmaScanFillSize`, FILL_SIZE_FIELDS, (size) => {
+            for (const key of FILL_SIZE_FIELDS) if (size[key] !== void 0) {
+              context.number(size[key], `${entryPath}.figmaScanFillSize.${key}`, 0);
+            }
+          });
+        }
+      });
+    });
+  }
+  function validateScanMetadata(item, path, context) {
+    if (item.figmaScanBindings !== void 0) validateStringRecord(item.figmaScanBindings, `${path}.figmaScanBindings`, context);
+    if (item.figmaScanSourceType !== void 0) context.string(item.figmaScanSourceType, `${path}.figmaScanSourceType`);
+    for (const key of ["figmaScanUnreproducibleInner", "figmaScanInnerOverrides", "figmaScanUnbindable"]) {
+      if (item[key] !== void 0) context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+        context.string(entry, `${path}.${key}[${i}]`);
+      });
+    }
+  }
+
+  // shared/figma-payload-validation-node.ts
+  var NODE_FIELDS = /* @__PURE__ */ new Set([
+    "type",
+    "name",
+    "width",
+    "height",
+    "layoutMode",
+    "itemSpacing",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "primaryAxisSizingMode",
+    "counterAxisSizingMode",
+    "primaryAxisAlignItems",
+    "counterAxisAlignItems",
+    "layoutWrap",
+    "counterAxisSpacing",
+    "layoutSizingHorizontal",
+    "layoutSizingVertical",
+    "layoutGrow",
+    "maxWidth",
+    "minWidth",
+    "maxHeight",
+    "minHeight",
+    "gridColumnCount",
+    "gridRowCount",
+    "gridRowGap",
+    "gridColumnGap",
+    "fills",
+    "cornerRadius",
+    "cornerRadii",
+    "effects",
+    "opacity",
+    "backgroundImageUrl",
+    "backgroundSize",
+    "backgroundPosition",
+    "strokes",
+    "strokeWeight",
+    "strokeWeights",
+    "strokeAlign",
+    "characters",
+    "fontFamily",
+    "fontStack",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "lineHeight",
+    "letterSpacing",
+    "wordSpacing",
+    "textAlignHorizontal",
+    "textAutoResize",
+    "textColor",
+    "textDecoration",
+    "textCase",
+    "textTruncation",
+    "blendMode",
+    "rotation",
+    "counterAxisAlignContent",
+    "imageUrl",
+    "svgContent",
+    "motion",
+    "clipsContent",
+    "absolutePosition",
+    "x",
+    "y",
+    "textSegments",
+    "keyedBindings",
+    "tokenRefs",
+    "componentKey",
+    "componentId",
+    "componentName",
+    "componentProperties",
+    "innerOverrides",
+    "figmaScanUnreproducibleInner",
+    "figmaScanBindings",
+    "figmaScanSourceType",
+    "figmaScanInnerOverrides",
+    "figmaScanUnbindable",
+    "children"
+  ]);
+  var ENUM_FIELDS = {
+    layoutMode: ["HORIZONTAL", "VERTICAL", "GRID", "NONE"],
+    primaryAxisSizingMode: ["AUTO", "FIXED"],
+    counterAxisSizingMode: ["AUTO", "FIXED"],
+    primaryAxisAlignItems: ["MIN", "CENTER", "MAX", "SPACE_BETWEEN"],
+    counterAxisAlignItems: ["MIN", "CENTER", "MAX", "BASELINE"],
+    layoutWrap: ["WRAP", "NO_WRAP"],
+    layoutSizingHorizontal: ["FILL", "FIXED", "HUG"],
+    layoutSizingVertical: ["FILL", "FIXED", "HUG"],
+    strokeAlign: ["INSIDE", "OUTSIDE", "CENTER"],
+    fontStyle: ["normal", "italic"],
+    textAlignHorizontal: ["LEFT", "CENTER", "RIGHT", "JUSTIFIED"],
+    textAutoResize: ["NONE", "WIDTH_AND_HEIGHT", "HEIGHT", "TRUNCATE"],
+    textDecoration: ["UNDERLINE", "STRIKETHROUGH"],
+    textCase: ["UPPER", "LOWER", "TITLE"],
+    textTruncation: ["ENDING"],
+    counterAxisAlignContent: ["AUTO", "SPACE_BETWEEN"]
+  };
+  var NONNEGATIVE_FIELDS = [
+    "width",
+    "height",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "counterAxisSpacing",
+    "layoutGrow",
+    "maxWidth",
+    "minWidth",
+    "maxHeight",
+    "minHeight",
+    "gridRowGap",
+    "gridColumnGap",
+    "cornerRadius",
+    "strokeWeight",
+    "fontSize",
+    "fontWeight",
+    "lineHeight"
+  ];
+  var FREE_NUMBER_FIELDS = ["itemSpacing", "letterSpacing", "wordSpacing", "rotation", "x", "y"];
+  var ORDINARY_STRING_FIELDS = [
+    "backgroundSize",
+    "backgroundPosition",
+    "characters",
+    "fontFamily",
+    "fontStack",
+    "blendMode",
+    "componentKey",
+    "componentId",
+    "componentName"
+  ];
+  var BOOLEAN_FIELDS = ["clipsContent", "absolutePosition"];
+  var FOUR_CORNER_FIELDS = /* @__PURE__ */ new Set(["tl", "tr", "br", "bl"]);
+  var FOUR_STROKE_FIELDS = /* @__PURE__ */ new Set(["top", "right", "bottom", "left"]);
+  function required3(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateNumberRecord(value, path, fields, context) {
+    context.object(value, path, fields, (record) => {
+      for (const key of fields) context.number(required3(record, key, path, context), `${path}.${key}`, 0);
+    });
+  }
+  function validateNodeFields(item, path, context) {
+    context.enumValue(required3(item, "type", path, context), `${path}.type`, ["FRAME", "TEXT", "RECTANGLE", "IMAGE", "GROUP", "INSTANCE"]);
+    context.string(required3(item, "name", path, context), `${path}.name`);
+    for (const [field, values] of Object.entries(ENUM_FIELDS)) if (item[field] !== void 0) {
+      context.enumValue(item[field], `${path}.${field}`, values);
+    }
+    for (const field of NONNEGATIVE_FIELDS) if (item[field] !== void 0) context.number(item[field], `${path}.${field}`, 0);
+    for (const field of FREE_NUMBER_FIELDS) if (item[field] !== void 0) context.number(item[field], `${path}.${field}`);
+    for (const field of ["gridColumnCount", "gridRowCount"]) if (item[field] !== void 0) {
+      context.integer(item[field], `${path}.${field}`);
+    }
+    if (item.opacity !== void 0) context.number(item.opacity, `${path}.opacity`, 0, 1);
+    for (const field of ORDINARY_STRING_FIELDS) if (item[field] !== void 0) context.string(item[field], `${path}.${field}`);
+    for (const field of BOOLEAN_FIELDS) if (item[field] !== void 0) context.boolean(item[field], `${path}.${field}`);
+    if (item.imageUrl !== void 0) context.string(item.imageUrl, `${path}.imageUrl`, context.limits.imageChars);
+    if (item.backgroundImageUrl !== void 0) context.string(item.backgroundImageUrl, `${path}.backgroundImageUrl`, context.limits.imageChars);
+    if (item.svgContent !== void 0) context.string(item.svgContent, `${path}.svgContent`, context.limits.svgChars);
+  }
+  function validateNode(value, path, context, depth = 0) {
+    context.node(path, depth);
+    context.object(value, path, NODE_FIELDS, (item) => {
+      validateNodeFields(item, path, context);
+      for (const key of ["fills", "strokes"]) if (item[key] !== void 0) {
+        context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => validateFill(entry, `${path}.${key}[${i}]`, context));
+      }
+      if (item.effects !== void 0) context.array(item.effects, `${path}.effects`, context.limits.arrayEntries, (entry, i) => {
+        validateEffect(entry, `${path}.effects[${i}]`, context);
+      });
+      if (item.cornerRadii !== void 0) validateNumberRecord(item.cornerRadii, `${path}.cornerRadii`, FOUR_CORNER_FIELDS, context);
+      if (item.strokeWeights !== void 0) validateNumberRecord(item.strokeWeights, `${path}.strokeWeights`, FOUR_STROKE_FIELDS, context);
+      if (item.textColor !== void 0) validateColor(item.textColor, `${path}.textColor`, context);
+      if (item.textSegments !== void 0) validateTextSegments(item.textSegments, `${path}.textSegments`, context);
+      if (item.motion !== void 0) validateMotion(item.motion, `${path}.motion`, context);
+      if (item.keyedBindings !== void 0) validateKeyedBindings(item.keyedBindings, `${path}.keyedBindings`, context);
+      if (item.tokenRefs !== void 0) validateTokenRefs(item.tokenRefs, `${path}.tokenRefs`, context);
+      if (item.componentProperties !== void 0) validateComponentProperties(item.componentProperties, `${path}.componentProperties`, context);
+      if (item.innerOverrides !== void 0) validateInnerOverrides(item.innerOverrides, `${path}.innerOverrides`, context);
+      validateScanMetadata(item, path, context);
+      if (item.children !== void 0) context.array(item.children, `${path}.children`, context.limits.arrayEntries, (child, i) => {
+        validateNode(child, `${path}.children[${i}]`, context, depth + 1);
+      });
+    });
+  }
+
+  // shared/figma-payload-validation-tokens.ts
+  var TOKEN_FIELDS = /* @__PURE__ */ new Set(["colors", "typography", "spacing", "radii", "shadows"]);
+  var COLOR_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "hex", "color"]);
+  var TYPE_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "family", "size", "weight", "lineHeight", "letterSpacing"]);
+  var VALUE_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "value"]);
+  var SHADOW_TOKEN_FIELDS = /* @__PURE__ */ new Set(["name", "css", "effect"]);
+  function required4(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validateTokens(value, path, context) {
+    return context.object(value, path, TOKEN_FIELDS, (tokens) => {
+      const groups = {
+        colors: tokens.colors ?? [],
+        typography: tokens.typography ?? [],
+        spacing: tokens.spacing ?? [],
+        radii: tokens.radii ?? [],
+        shadows: tokens.shadows ?? []
+      };
+      context.array(groups.colors, `${path}.colors`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.colors[${i}]`;
+        context.object(entry, entryPath, COLOR_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "hex", entryPath, context), `${entryPath}.hex`);
+          validateColor(required4(token, "color", entryPath, context), `${entryPath}.color`, context);
+        });
+      });
+      context.array(groups.typography, `${path}.typography`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.typography[${i}]`;
+        context.object(entry, entryPath, TYPE_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "family", entryPath, context), `${entryPath}.family`);
+          context.number(required4(token, "size", entryPath, context), `${entryPath}.size`, 0);
+          context.number(required4(token, "weight", entryPath, context), `${entryPath}.weight`, 0);
+          if (token.lineHeight !== void 0) context.number(token.lineHeight, `${entryPath}.lineHeight`, 0);
+          if (token.letterSpacing !== void 0) context.number(token.letterSpacing, `${entryPath}.letterSpacing`);
+        });
+      });
+      for (const key of ["spacing", "radii"]) context.array(
+        groups[key],
+        `${path}.${key}`,
+        context.limits.tokenGroup,
+        (entry, i) => {
+          const entryPath = `${path}.${key}[${i}]`;
+          context.object(entry, entryPath, VALUE_TOKEN_FIELDS, (token) => {
+            context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+            context.number(required4(token, "value", entryPath, context), `${entryPath}.value`);
+          });
+        }
+      );
+      context.array(groups.shadows, `${path}.shadows`, context.limits.tokenGroup, (entry, i) => {
+        const entryPath = `${path}.shadows[${i}]`;
+        context.object(entry, entryPath, SHADOW_TOKEN_FIELDS, (token) => {
+          context.string(required4(token, "name", entryPath, context), `${entryPath}.name`);
+          context.string(required4(token, "css", entryPath, context), `${entryPath}.css`);
+          validateEffect(required4(token, "effect", entryPath, context), `${entryPath}.effect`, context);
+        });
+      });
+      return groups;
+    });
+  }
+
+  // shared/figma-payload-validation.ts
+  var PAYLOAD_FIELDS = /* @__PURE__ */ new Set(["version", "name", "width", "height", "tokens", "rootNode"]);
+  var PLACEMENT_FIELDS = /* @__PURE__ */ new Set(["x", "y", "parentId", "replaceId"]);
+  var WRAPPED_FIELDS = /* @__PURE__ */ new Set(["payload", ...PLACEMENT_FIELDS]);
+  var DIRECT_FIELDS = /* @__PURE__ */ new Set([...PAYLOAD_FIELDS, ...PLACEMENT_FIELDS]);
+  function required5(item, key, path, context) {
+    if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, "is required");
+    return item[key];
+  }
+  function validatePayloadFields(payload2, path, context) {
+    const version = context.number(required5(payload2, "version", path, context), `${path}.version`);
+    if (version !== 1) context.fail(`${path}.version`, "must be 1");
+    const name = context.string(required5(payload2, "name", path, context), `${path}.name`);
+    const width = context.number(required5(payload2, "width", path, context), `${path}.width`, 0);
+    const height = context.number(required5(payload2, "height", path, context), `${path}.height`, 0);
+    const tokens = validateTokens(payload2.tokens ?? {}, `${path}.tokens`, context);
+    const rootNode = required5(payload2, "rootNode", path, context);
+    validateNode(rootNode, `${path}.rootNode`, context);
+    return { version: 1, name, width, height, tokens, rootNode };
+  }
+  function validatePlacement(source, context) {
+    const placement = {};
+    for (const key of ["x", "y"]) if (source[key] !== void 0) {
+      placement[key] = context.number(source[key], `params.${key}`);
+    }
+    for (const key of ["parentId", "replaceId"]) if (source[key] !== void 0) {
+      placement[key] = context.string(source[key], `params.${key}`);
+    }
+    return placement;
+  }
+  function validateImportPayload(params, limitOverrides = {}) {
+    const context = new ValidationContext(limitOverrides);
+    const looksWrapped = !!params && typeof params === "object" && !Array.isArray(params) && Object.prototype.hasOwnProperty.call(params, "payload");
+    return context.object(params, "params", looksWrapped ? WRAPPED_FIELDS : DIRECT_FIELDS, (envelope) => {
+      const payload2 = looksWrapped ? context.object(required5(envelope, "payload", "params", context), "payload", PAYLOAD_FIELDS, (value) => validatePayloadFields(value, "payload", context)) : validatePayloadFields(envelope, "payload", context);
+      return { payload: payload2, placement: validatePlacement(envelope, context) };
+    });
+  }
+
+  // shared/figma-payload-validation-relay.ts
+  function forwardValidatedDirectImport(request, forward) {
+    const admission = validateImportPayload(request.params);
+    forward({
+      pluginMessage: {
+        requestId: request.requestId,
+        cmd: "IMPORT_PAYLOAD",
+        params: { payload: admission.payload, ...admission.placement },
+        expectedFile: request.expectedFile,
+        ...request.readOnly === true && { readOnly: true }
+      }
+    });
+  }
+  function forwardValidatedHtmlImport(result, forward) {
+    const admission = validateImportPayload({ payload: result.payload, ...result.placement });
+    forward({
+      pluginMessage: {
+        requestId: result.requestId,
+        cmd: "IMPORT_PAYLOAD",
+        expectedFile: result.expectedFile,
+        params: { payload: admission.payload, ...admission.placement }
+      }
+    });
+  }
+
   // plugin/src/ui/gradient-host.ts
   var RENDERER_VERSION = "2.4.20";
   var CDN_BASE = "https://esm.sh";
@@ -4184,14 +4872,12 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
         setStatusText("rendering html\u2026", "ok");
         const payload2 = await renderHtmlToPayload(p.html, p.width ?? 1280, p.name ?? "HTML Import");
         setStatusText("connected", "ok");
-        parent.postMessage({
-          pluginMessage: {
-            requestId: req.id,
-            cmd: "IMPORT_PAYLOAD",
-            expectedFile: req.expectedFile,
-            params: { payload: payload2, x: p.x, y: p.y, parentId: p.parentId, replaceId: p.replaceId }
-          }
-        }, "*");
+        forwardValidatedHtmlImport({
+          requestId: req.id,
+          expectedFile: req.expectedFile,
+          payload: payload2,
+          placement: { x: p.x, y: p.y, parentId: p.parentId, replaceId: p.replaceId }
+        }, (message) => parent.postMessage(message, "*"));
       } else if (req.cmd === "SHADER_GRADIENT_PROBE") {
         const p = req.params ?? {};
         if (!p.props || typeof p.props !== "object") {
@@ -4260,6 +4946,13 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
             }
           }
         }, "*");
+      } else if (req.cmd === "IMPORT_PAYLOAD") {
+        forwardValidatedDirectImport({
+          requestId: req.id,
+          expectedFile: req.expectedFile,
+          params: req.params,
+          readOnly: req.readOnly
+        }, (message) => parent.postMessage(message, "*"));
       } else {
         parent.postMessage({
           pluginMessage: {
@@ -4274,6 +4967,11 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     } catch (err) {
       setStatusText("connected", "ok");
       const message = err instanceof Error ? err.message : String(err);
+      if (err instanceof PayloadValidationError) {
+        sendErr(req.id, err.code, message);
+        emitActivity(req.id, false, { code: err.code, message });
+        return;
+      }
       const code = err instanceof GradientRenderError ? `E_PLUGIN_ERROR (${err.code})` : "E_PLUGIN_ERROR";
       sendErr(req.id, "E_PLUGIN_ERROR", code === "E_PLUGIN_ERROR" ? message : `${err instanceof GradientRenderError ? err.code : ""}: ${message}`);
       emitActivity(req.id, false, { message });

--- a/shared/figma-payload-validation-context.ts
+++ b/shared/figma-payload-validation-context.ts
@@ -1,0 +1,194 @@
+export interface ImportPayloadLimits {
+  aggregateBytes: number;
+  totalEntries: number;
+  nodes: number;
+  depth: number;
+  textChars: number;
+  imageChars: number;
+  svgChars: number;
+  arrayEntries: number;
+  recordEntries: number;
+  recordKeyChars: number;
+  tokenGroup: number;
+  motionSteps: number;
+}
+
+export const IMPORT_PAYLOAD_LIMITS: ImportPayloadLimits = {
+  aggregateBytes: 64 * 1024 * 1024,
+  totalEntries: 5_000_000,
+  nodes: 100_000,
+  depth: 256,
+  textChars: 1024 * 1024,
+  imageChars: 16 * 1024 * 1024,
+  svgChars: 16 * 1024 * 1024,
+  arrayEntries: 100_000,
+  recordEntries: 10_000,
+  recordKeyChars: 16_384,
+  tokenGroup: 10_000,
+  motionSteps: 10_000,
+};
+
+export class PayloadValidationError extends Error {
+  readonly code = 'E_INVALID_ARGS';
+
+  constructor(message: string) {
+    super(`IMPORT_PAYLOAD rejected: ${message}`);
+    this.name = 'PayloadValidationError';
+  }
+}
+
+export type ObjectValue = Record<string, unknown>;
+
+function jsonStringBytes(value: string): number {
+  let bytes = 2;
+  for (let i = 0; i < value.length; i++) {
+    const unit = value.charCodeAt(i);
+    if (unit === 0x22 || unit === 0x5c) bytes += 2;
+    else if (unit === 0x08 || unit === 0x09 || unit === 0x0a || unit === 0x0c || unit === 0x0d) bytes += 2;
+    else if (unit < 0x20) bytes += 6;
+    else if (unit < 0x80) bytes += 1;
+    else if (unit < 0x800) bytes += 2;
+    else if (unit >= 0xd800 && unit <= 0xdbff
+      && i + 1 < value.length && (value.charCodeAt(i + 1) & 0xfc00) === 0xdc00) {
+      bytes += 4;
+      i += 1;
+    } else if (unit >= 0xd800 && unit <= 0xdfff) bytes += 6;
+    else bytes += 3;
+  }
+  return bytes;
+}
+
+export class ValidationContext {
+  readonly limits: ImportPayloadLimits;
+  private aggregateBytes = 0;
+  private totalEntries = 0;
+  private nodeCount = 0;
+  private readonly active = new WeakSet<object>();
+
+  constructor(overrides: Partial<ImportPayloadLimits> = {}) {
+    this.limits = { ...IMPORT_PAYLOAD_LIMITS, ...overrides };
+  }
+
+  fail(path: string, message: string): never {
+    throw new PayloadValidationError(`${path} ${message}`);
+  }
+
+  private addBytes(bytes: number, path: string): void {
+    this.aggregateBytes += bytes;
+    if (this.aggregateBytes > this.limits.aggregateBytes) {
+      this.fail(path, `exceeds aggregate budget ${this.limits.aggregateBytes} bytes`);
+    }
+  }
+
+  private addEntry(path: string): void {
+    this.totalEntries += 1;
+    if (this.totalEntries > this.limits.totalEntries) {
+      this.fail(path, `exceeds aggregate entry budget ${this.limits.totalEntries}`);
+    }
+  }
+
+  object<T>(
+    value: unknown,
+    path: string,
+    allowed: ReadonlySet<string> | null,
+    visit: (item: ObjectValue) => T,
+    maxKeys = allowed?.size ?? this.limits.recordEntries,
+  ): T {
+    if (!value || typeof value !== 'object' || Array.isArray(value)
+      || Object.getPrototypeOf(value) !== Object.prototype) {
+      this.fail(path, 'must be a plain object');
+    }
+    if (this.active.has(value)) this.fail(path, 'must not contain an active cycle');
+    this.active.add(value);
+    this.addBytes(2, path);
+    try {
+      let count = 0;
+      for (const key in value as ObjectValue) {
+        if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+        count += 1;
+        if (count > maxKeys) this.fail(path, `must have at most ${maxKeys} fields`);
+        if (key.length > this.limits.recordKeyChars) {
+          this.fail(`${path} key`, `must be at most ${this.limits.recordKeyChars} characters`);
+        }
+        this.addEntry(`${path}.${key}`);
+        this.addBytes(jsonStringBytes(key) + 2, `${path}.${key}`);
+        if (allowed && !allowed.has(key)) this.fail(`${path}.${key}`, 'is not a supported field');
+      }
+      return visit(value as ObjectValue);
+    } finally {
+      this.active.delete(value);
+    }
+  }
+
+  array(
+    value: unknown,
+    path: string,
+    max: number,
+    visit: (entry: unknown, index: number) => void,
+    min = 0,
+  ): void {
+    if (!Array.isArray(value) || value.length < min || value.length > max) {
+      this.fail(path, `must be an array with ${min}..${max} entries`);
+    }
+    for (const key in value) {
+      if (!Object.prototype.hasOwnProperty.call(value, key)) continue;
+      const index = Number(key);
+      if (key.length > this.limits.recordKeyChars || !Number.isInteger(index)
+        || index < 0 || index >= value.length || String(index) !== key) {
+        this.fail(path, 'must not contain enumerable non-index fields');
+      }
+    }
+    if (this.active.has(value)) this.fail(path, 'must not contain an active cycle');
+    this.active.add(value);
+    this.addBytes(2, path);
+    try {
+      for (let i = 0; i < value.length; i++) {
+        this.addEntry(`${path}[${i}]`);
+        this.addBytes(1, `${path}[${i}]`);
+        visit(value[i], i);
+      }
+    } finally {
+      this.active.delete(value);
+    }
+  }
+
+  string(value: unknown, path: string, max = this.limits.textChars): string {
+    if (typeof value !== 'string' || value.length > max) {
+      this.fail(path, `must be a string no longer than ${max} characters`);
+    }
+    this.addBytes(jsonStringBytes(value), path);
+    return value;
+  }
+
+  number(value: unknown, path: string, min = -Infinity, max = Infinity): number {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value < min || value > max) {
+      this.fail(path, `must be a finite number between ${min} and ${max}`);
+    }
+    this.addBytes(24, path);
+    return value;
+  }
+
+  integer(value: unknown, path: string, min = 0): number {
+    const parsed = this.number(value, path, min);
+    if (!Number.isInteger(parsed)) this.fail(path, 'must be an integer');
+    return parsed;
+  }
+
+  boolean(value: unknown, path: string): boolean {
+    if (typeof value !== 'boolean') this.fail(path, 'must be boolean');
+    this.addBytes(5, path);
+    return value;
+  }
+
+  enumValue<T extends string>(value: unknown, path: string, values: readonly T[]): T {
+    const parsed = this.string(value, path, 128) as T;
+    if (!values.includes(parsed)) this.fail(path, `must be one of ${values.join(', ')}`);
+    return parsed;
+  }
+
+  node(path: string, depth: number): void {
+    if (depth > this.limits.depth) this.fail(path, `exceeds maximum depth ${this.limits.depth}`);
+    this.nodeCount += 1;
+    if (this.nodeCount > this.limits.nodes) this.fail(path, `exceeds maximum node count ${this.limits.nodes}`);
+  }
+}

--- a/shared/figma-payload-validation-node-details.ts
+++ b/shared/figma-payload-validation-node-details.ts
@@ -1,0 +1,79 @@
+import { type ObjectValue, ValidationContext } from './figma-payload-validation-context';
+import {
+  validateComponentProperties, validateEffect, validateFill, validateKeyedBindings,
+  validatePrimitiveRecord, validateStringRecord,
+} from './figma-payload-validation-values';
+
+const TOKEN_REF_FIELDS = new Set(['fill', 'stroke', 'textColor', 'radius', 'gap', 'padding']);
+const INNER_OVERRIDE_FIELDS = new Set([
+  'childKey', 'fields', 'componentKey', 'componentId', 'componentProperties', 'visual', 'figmaScanFillSize',
+]);
+const INNER_VISUAL_FIELDS = new Set([
+  'fills', 'strokes', 'effects', 'effectStyleId', 'visible', 'opacity', 'keyedBindings',
+]);
+const FILL_SIZE_FIELDS = new Set(['width', 'height']);
+
+function required(item: ObjectValue, key: string, path: string, context: ValidationContext): unknown {
+  if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, 'is required');
+  return item[key];
+}
+
+export function validateTokenRefs(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, TOKEN_REF_FIELDS, (refs) => {
+    for (const key of TOKEN_REF_FIELDS) if (refs[key] !== undefined) context.string(refs[key], `${path}.${key}`);
+  });
+}
+
+function validateInnerVisual(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, INNER_VISUAL_FIELDS, (visual) => {
+    for (const key of ['fills', 'strokes'] as const) if (visual[key] !== undefined) {
+      context.array(visual[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+        validateFill(entry, `${path}.${key}[${i}]`, context);
+      });
+    }
+    if (visual.effects !== undefined) context.array(
+      visual.effects,
+      `${path}.effects`,
+      context.limits.arrayEntries,
+      (entry, i) => validateEffect(entry, `${path}.effects[${i}]`, context),
+    );
+    if (visual.effectStyleId !== undefined) context.string(visual.effectStyleId, `${path}.effectStyleId`);
+    if (visual.visible !== undefined) context.boolean(visual.visible, `${path}.visible`);
+    if (visual.opacity !== undefined) context.number(visual.opacity, `${path}.opacity`, 0, 1);
+    if (visual.keyedBindings !== undefined) validateKeyedBindings(visual.keyedBindings, `${path}.keyedBindings`, context);
+  });
+}
+
+export function validateInnerOverrides(value: unknown, path: string, context: ValidationContext): void {
+  context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+    const entryPath = `${path}[${i}]`;
+    context.object(entry, entryPath, INNER_OVERRIDE_FIELDS, (override) => {
+      context.string(required(override, 'childKey', entryPath, context), `${entryPath}.childKey`);
+      validatePrimitiveRecord(required(override, 'fields', entryPath, context), `${entryPath}.fields`, context);
+      for (const key of ['componentKey', 'componentId'] as const) if (override[key] !== undefined) {
+        context.string(override[key], `${entryPath}.${key}`);
+      }
+      if (override.componentProperties !== undefined) {
+        validateComponentProperties(override.componentProperties, `${entryPath}.componentProperties`, context);
+      }
+      if (override.visual !== undefined) validateInnerVisual(override.visual, `${entryPath}.visual`, context);
+      if (override.figmaScanFillSize !== undefined) {
+        context.object(override.figmaScanFillSize, `${entryPath}.figmaScanFillSize`, FILL_SIZE_FIELDS, (size) => {
+          for (const key of FILL_SIZE_FIELDS) if (size[key] !== undefined) {
+            context.number(size[key], `${entryPath}.figmaScanFillSize.${key}`, 0);
+          }
+        });
+      }
+    });
+  });
+}
+
+export function validateScanMetadata(item: ObjectValue, path: string, context: ValidationContext): void {
+  if (item.figmaScanBindings !== undefined) validateStringRecord(item.figmaScanBindings, `${path}.figmaScanBindings`, context);
+  if (item.figmaScanSourceType !== undefined) context.string(item.figmaScanSourceType, `${path}.figmaScanSourceType`);
+  for (const key of ['figmaScanUnreproducibleInner', 'figmaScanInnerOverrides', 'figmaScanUnbindable'] as const) {
+    if (item[key] !== undefined) context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => {
+      context.string(entry, `${path}.${key}[${i}]`);
+    });
+  }
+}

--- a/shared/figma-payload-validation-node.ts
+++ b/shared/figma-payload-validation-node.ts
@@ -1,0 +1,106 @@
+import { type ObjectValue, ValidationContext } from './figma-payload-validation-context';
+import {
+  validateComponentProperties, validateColor, validateEffect, validateFill, validateKeyedBindings,
+  validateMotion, validateTextSegments,
+} from './figma-payload-validation-values';
+import { validateInnerOverrides, validateScanMetadata, validateTokenRefs } from './figma-payload-validation-node-details';
+
+const NODE_FIELDS = new Set([
+  'type', 'name', 'width', 'height', 'layoutMode', 'itemSpacing', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft',
+  'primaryAxisSizingMode', 'counterAxisSizingMode', 'primaryAxisAlignItems', 'counterAxisAlignItems', 'layoutWrap', 'counterAxisSpacing',
+  'layoutSizingHorizontal', 'layoutSizingVertical', 'layoutGrow', 'maxWidth', 'minWidth', 'maxHeight', 'minHeight', 'gridColumnCount',
+  'gridRowCount', 'gridRowGap', 'gridColumnGap', 'fills', 'cornerRadius', 'cornerRadii', 'effects', 'opacity', 'backgroundImageUrl',
+  'backgroundSize', 'backgroundPosition', 'strokes', 'strokeWeight', 'strokeWeights', 'strokeAlign', 'characters', 'fontFamily',
+  'fontStack', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight', 'letterSpacing', 'wordSpacing', 'textAlignHorizontal',
+  'textAutoResize', 'textColor', 'textDecoration', 'textCase', 'textTruncation', 'blendMode', 'rotation', 'counterAxisAlignContent',
+  'imageUrl', 'svgContent', 'motion', 'clipsContent', 'absolutePosition', 'x', 'y', 'textSegments', 'keyedBindings', 'tokenRefs',
+  'componentKey', 'componentId', 'componentName', 'componentProperties', 'innerOverrides', 'figmaScanUnreproducibleInner',
+  'figmaScanBindings', 'figmaScanSourceType', 'figmaScanInnerOverrides', 'figmaScanUnbindable', 'children',
+]);
+
+const ENUM_FIELDS: Record<string, readonly string[]> = {
+  layoutMode: ['HORIZONTAL', 'VERTICAL', 'GRID', 'NONE'],
+  primaryAxisSizingMode: ['AUTO', 'FIXED'], counterAxisSizingMode: ['AUTO', 'FIXED'],
+  primaryAxisAlignItems: ['MIN', 'CENTER', 'MAX', 'SPACE_BETWEEN'],
+  counterAxisAlignItems: ['MIN', 'CENTER', 'MAX', 'BASELINE'], layoutWrap: ['WRAP', 'NO_WRAP'],
+  layoutSizingHorizontal: ['FILL', 'FIXED', 'HUG'], layoutSizingVertical: ['FILL', 'FIXED', 'HUG'],
+  strokeAlign: ['INSIDE', 'OUTSIDE', 'CENTER'], fontStyle: ['normal', 'italic'],
+  textAlignHorizontal: ['LEFT', 'CENTER', 'RIGHT', 'JUSTIFIED'],
+  textAutoResize: ['NONE', 'WIDTH_AND_HEIGHT', 'HEIGHT', 'TRUNCATE'],
+  textDecoration: ['UNDERLINE', 'STRIKETHROUGH'], textCase: ['UPPER', 'LOWER', 'TITLE'],
+  textTruncation: ['ENDING'], counterAxisAlignContent: ['AUTO', 'SPACE_BETWEEN'],
+};
+const NONNEGATIVE_FIELDS = [
+  'width', 'height', 'paddingTop', 'paddingRight', 'paddingBottom', 'paddingLeft', 'counterAxisSpacing', 'layoutGrow',
+  'maxWidth', 'minWidth', 'maxHeight', 'minHeight', 'gridRowGap', 'gridColumnGap', 'cornerRadius', 'strokeWeight',
+  'fontSize', 'fontWeight', 'lineHeight',
+] as const;
+const FREE_NUMBER_FIELDS = ['itemSpacing', 'letterSpacing', 'wordSpacing', 'rotation', 'x', 'y'] as const;
+const ORDINARY_STRING_FIELDS = [
+  'backgroundSize', 'backgroundPosition', 'characters', 'fontFamily', 'fontStack', 'blendMode',
+  'componentKey', 'componentId', 'componentName',
+] as const;
+const BOOLEAN_FIELDS = ['clipsContent', 'absolutePosition'] as const;
+const FOUR_CORNER_FIELDS = new Set(['tl', 'tr', 'br', 'bl']);
+const FOUR_STROKE_FIELDS = new Set(['top', 'right', 'bottom', 'left']);
+
+function required(item: ObjectValue, key: string, path: string, context: ValidationContext): unknown {
+  if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, 'is required');
+  return item[key];
+}
+
+function validateNumberRecord(
+  value: unknown,
+  path: string,
+  fields: ReadonlySet<string>,
+  context: ValidationContext,
+): void {
+  context.object(value, path, fields, (record) => {
+    for (const key of fields) context.number(required(record, key, path, context), `${path}.${key}`, 0);
+  });
+}
+
+function validateNodeFields(item: ObjectValue, path: string, context: ValidationContext): void {
+  context.enumValue(required(item, 'type', path, context), `${path}.type`, ['FRAME', 'TEXT', 'RECTANGLE', 'IMAGE', 'GROUP', 'INSTANCE'] as const);
+  context.string(required(item, 'name', path, context), `${path}.name`);
+  for (const [field, values] of Object.entries(ENUM_FIELDS)) if (item[field] !== undefined) {
+    context.enumValue(item[field], `${path}.${field}`, values);
+  }
+  for (const field of NONNEGATIVE_FIELDS) if (item[field] !== undefined) context.number(item[field], `${path}.${field}`, 0);
+  for (const field of FREE_NUMBER_FIELDS) if (item[field] !== undefined) context.number(item[field], `${path}.${field}`);
+  for (const field of ['gridColumnCount', 'gridRowCount'] as const) if (item[field] !== undefined) {
+    context.integer(item[field], `${path}.${field}`);
+  }
+  if (item.opacity !== undefined) context.number(item.opacity, `${path}.opacity`, 0, 1);
+  for (const field of ORDINARY_STRING_FIELDS) if (item[field] !== undefined) context.string(item[field], `${path}.${field}`);
+  for (const field of BOOLEAN_FIELDS) if (item[field] !== undefined) context.boolean(item[field], `${path}.${field}`);
+  if (item.imageUrl !== undefined) context.string(item.imageUrl, `${path}.imageUrl`, context.limits.imageChars);
+  if (item.backgroundImageUrl !== undefined) context.string(item.backgroundImageUrl, `${path}.backgroundImageUrl`, context.limits.imageChars);
+  if (item.svgContent !== undefined) context.string(item.svgContent, `${path}.svgContent`, context.limits.svgChars);
+}
+
+export function validateNode(value: unknown, path: string, context: ValidationContext, depth = 0): void {
+  context.node(path, depth);
+  context.object(value, path, NODE_FIELDS, (item) => {
+    validateNodeFields(item, path, context);
+    for (const key of ['fills', 'strokes'] as const) if (item[key] !== undefined) {
+      context.array(item[key], `${path}.${key}`, context.limits.arrayEntries, (entry, i) => validateFill(entry, `${path}.${key}[${i}]`, context));
+    }
+    if (item.effects !== undefined) context.array(item.effects, `${path}.effects`, context.limits.arrayEntries, (entry, i) => {
+      validateEffect(entry, `${path}.effects[${i}]`, context);
+    });
+    if (item.cornerRadii !== undefined) validateNumberRecord(item.cornerRadii, `${path}.cornerRadii`, FOUR_CORNER_FIELDS, context);
+    if (item.strokeWeights !== undefined) validateNumberRecord(item.strokeWeights, `${path}.strokeWeights`, FOUR_STROKE_FIELDS, context);
+    if (item.textColor !== undefined) validateColor(item.textColor, `${path}.textColor`, context);
+    if (item.textSegments !== undefined) validateTextSegments(item.textSegments, `${path}.textSegments`, context);
+    if (item.motion !== undefined) validateMotion(item.motion, `${path}.motion`, context);
+    if (item.keyedBindings !== undefined) validateKeyedBindings(item.keyedBindings, `${path}.keyedBindings`, context);
+    if (item.tokenRefs !== undefined) validateTokenRefs(item.tokenRefs, `${path}.tokenRefs`, context);
+    if (item.componentProperties !== undefined) validateComponentProperties(item.componentProperties, `${path}.componentProperties`, context);
+    if (item.innerOverrides !== undefined) validateInnerOverrides(item.innerOverrides, `${path}.innerOverrides`, context);
+    validateScanMetadata(item, path, context);
+    if (item.children !== undefined) context.array(item.children, `${path}.children`, context.limits.arrayEntries, (child, i) => {
+      validateNode(child, `${path}.children[${i}]`, context, depth + 1);
+    });
+  });
+}

--- a/shared/figma-payload-validation-relay.ts
+++ b/shared/figma-payload-validation-relay.ts
@@ -1,0 +1,65 @@
+import type { FigmaExportPayload } from './figma-payload-types';
+import { validateImportPayload } from './figma-payload-validation';
+
+export interface HtmlImportRelayResult {
+  requestId: string;
+  expectedFile?: string;
+  payload: unknown;
+  placement: { x?: unknown; y?: unknown; parentId?: unknown; replaceId?: unknown };
+}
+
+export interface DirectImportRelayRequest {
+  requestId: string;
+  expectedFile?: string;
+  params: unknown;
+  readOnly?: boolean;
+}
+
+export interface MainImportMessage {
+  pluginMessage: {
+    requestId: string;
+    cmd: 'IMPORT_PAYLOAD';
+    expectedFile?: string;
+    params: {
+      payload: FigmaExportPayload;
+      x?: number;
+      y?: number;
+      parentId?: string;
+      replaceId?: string;
+    };
+    readOnly?: true;
+  };
+}
+
+/** Admit a direct wire import before the relay gives it any main-thread authority. */
+export function forwardValidatedDirectImport(
+  request: DirectImportRelayRequest,
+  forward: (message: MainImportMessage) => void,
+): void {
+  const admission = validateImportPayload(request.params);
+  forward({
+    pluginMessage: {
+      requestId: request.requestId,
+      cmd: 'IMPORT_PAYLOAD',
+      params: { payload: admission.payload, ...admission.placement },
+      expectedFile: request.expectedFile,
+      ...(request.readOnly === true && { readOnly: true as const }),
+    },
+  });
+}
+
+/** Admit a renderer result before the relay gives it any main-thread authority. */
+export function forwardValidatedHtmlImport(
+  result: HtmlImportRelayResult,
+  forward: (message: MainImportMessage) => void,
+): void {
+  const admission = validateImportPayload({ payload: result.payload, ...result.placement });
+  forward({
+    pluginMessage: {
+      requestId: result.requestId,
+      cmd: 'IMPORT_PAYLOAD',
+      expectedFile: result.expectedFile,
+      params: { payload: admission.payload, ...admission.placement },
+    },
+  });
+}

--- a/shared/figma-payload-validation-tokens.ts
+++ b/shared/figma-payload-validation-tokens.ts
@@ -1,0 +1,67 @@
+import type { FigmaExportTokens } from './figma-payload-types';
+import { type ObjectValue, ValidationContext } from './figma-payload-validation-context';
+import { validateColor, validateEffect } from './figma-payload-validation-values';
+
+const TOKEN_FIELDS = new Set(['colors', 'typography', 'spacing', 'radii', 'shadows']);
+const COLOR_TOKEN_FIELDS = new Set(['name', 'hex', 'color']);
+const TYPE_TOKEN_FIELDS = new Set(['name', 'family', 'size', 'weight', 'lineHeight', 'letterSpacing']);
+const VALUE_TOKEN_FIELDS = new Set(['name', 'value']);
+const SHADOW_TOKEN_FIELDS = new Set(['name', 'css', 'effect']);
+
+function required(item: ObjectValue, key: string, path: string, context: ValidationContext): unknown {
+  if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, 'is required');
+  return item[key];
+}
+
+/** Legacy absent/null token groups normalize to arrays; the admitted output has the exact token shape. */
+export function validateTokens(value: unknown, path: string, context: ValidationContext): FigmaExportTokens {
+  return context.object(value, path, TOKEN_FIELDS, (tokens) => {
+    const groups = {
+      colors: tokens.colors ?? [],
+      typography: tokens.typography ?? [],
+      spacing: tokens.spacing ?? [],
+      radii: tokens.radii ?? [],
+      shadows: tokens.shadows ?? [],
+    };
+    context.array(groups.colors, `${path}.colors`, context.limits.tokenGroup, (entry, i) => {
+      const entryPath = `${path}.colors[${i}]`;
+      context.object(entry, entryPath, COLOR_TOKEN_FIELDS, (token) => {
+        context.string(required(token, 'name', entryPath, context), `${entryPath}.name`);
+        context.string(required(token, 'hex', entryPath, context), `${entryPath}.hex`);
+        validateColor(required(token, 'color', entryPath, context), `${entryPath}.color`, context);
+      });
+    });
+    context.array(groups.typography, `${path}.typography`, context.limits.tokenGroup, (entry, i) => {
+      const entryPath = `${path}.typography[${i}]`;
+      context.object(entry, entryPath, TYPE_TOKEN_FIELDS, (token) => {
+        context.string(required(token, 'name', entryPath, context), `${entryPath}.name`);
+        context.string(required(token, 'family', entryPath, context), `${entryPath}.family`);
+        context.number(required(token, 'size', entryPath, context), `${entryPath}.size`, 0);
+        context.number(required(token, 'weight', entryPath, context), `${entryPath}.weight`, 0);
+        if (token.lineHeight !== undefined) context.number(token.lineHeight, `${entryPath}.lineHeight`, 0);
+        if (token.letterSpacing !== undefined) context.number(token.letterSpacing, `${entryPath}.letterSpacing`);
+      });
+    });
+    for (const key of ['spacing', 'radii'] as const) context.array(
+      groups[key],
+      `${path}.${key}`,
+      context.limits.tokenGroup,
+      (entry, i) => {
+        const entryPath = `${path}.${key}[${i}]`;
+        context.object(entry, entryPath, VALUE_TOKEN_FIELDS, (token) => {
+          context.string(required(token, 'name', entryPath, context), `${entryPath}.name`);
+          context.number(required(token, 'value', entryPath, context), `${entryPath}.value`);
+        });
+      },
+    );
+    context.array(groups.shadows, `${path}.shadows`, context.limits.tokenGroup, (entry, i) => {
+      const entryPath = `${path}.shadows[${i}]`;
+      context.object(entry, entryPath, SHADOW_TOKEN_FIELDS, (token) => {
+        context.string(required(token, 'name', entryPath, context), `${entryPath}.name`);
+        context.string(required(token, 'css', entryPath, context), `${entryPath}.css`);
+        validateEffect(required(token, 'effect', entryPath, context), `${entryPath}.effect`, context);
+      });
+    });
+    return groups as FigmaExportTokens;
+  });
+}

--- a/shared/figma-payload-validation-values.ts
+++ b/shared/figma-payload-validation-values.ts
@@ -1,0 +1,142 @@
+import { type ObjectValue, ValidationContext } from './figma-payload-validation-context';
+
+const COLOR_FIELDS = new Set(['r', 'g', 'b', 'a']);
+const FILL_FIELDS = new Set(['type', 'color', 'gradientStops', 'gradientTransform']);
+const EFFECT_FIELDS = new Set(['type', 'offset', 'radius', 'spread', 'color']);
+const OFFSET_FIELDS = new Set(['x', 'y']);
+const KEYED_BINDING_FIELDS = new Set(['key', 'name']);
+const TEXT_SEGMENT_FIELDS = new Set([
+  'characters', 'fontFamily', 'fontSize', 'fontWeight', 'fontStyle', 'lineHeight',
+  'letterSpacing', 'textColor', 'textDecoration', 'textCase',
+]);
+const MOTION_FIELDS = new Set(['steps', 'durationSec', 'easing']);
+const MOTION_STEP_FIELDS = new Set(['offset', 'style']);
+const MOTION_STYLE_FIELDS = new Set(['opacity', 'transform']);
+
+function required(item: ObjectValue, key: string, path: string, context: ValidationContext): unknown {
+  if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, 'is required');
+  return item[key];
+}
+
+export function validateColor(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, COLOR_FIELDS, (item) => {
+    for (const key of COLOR_FIELDS) context.number(required(item, key, path, context), `${path}.${key}`, 0, 1);
+  });
+}
+
+export function validateFill(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, FILL_FIELDS, (item) => {
+    const type = context.enumValue(required(item, 'type', path, context), `${path}.type`, [
+      'SOLID', 'GRADIENT_LINEAR', 'GRADIENT_RADIAL', 'GRADIENT_ANGULAR',
+    ] as const);
+    if (type === 'SOLID') {
+      validateColor(required(item, 'color', path, context), `${path}.color`, context);
+      if (item.gradientStops !== undefined || item.gradientTransform !== undefined) {
+        context.fail(path, 'SOLID fills must not contain gradient fields');
+      }
+      return;
+    }
+    if (item.color !== undefined) context.fail(`${path}.color`, 'is only supported for SOLID fills');
+    context.array(required(item, 'gradientStops', path, context), `${path}.gradientStops`, context.limits.arrayEntries, (stop, i) => {
+      const stopPath = `${path}.gradientStops[${i}]`;
+      context.object(stop, stopPath, new Set(['color', 'position']), (entry) => {
+        validateColor(required(entry, 'color', stopPath, context), `${stopPath}.color`, context);
+        context.number(required(entry, 'position', stopPath, context), `${stopPath}.position`, 0, 1);
+      });
+    }, 2);
+    context.array(required(item, 'gradientTransform', path, context), `${path}.gradientTransform`, 2, (row, i) => {
+      context.array(row, `${path}.gradientTransform[${i}]`, 3, (entry, j) => {
+        context.number(entry, `${path}.gradientTransform[${i}][${j}]`);
+      }, 3);
+    }, 2);
+  });
+}
+
+export function validateEffect(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, EFFECT_FIELDS, (item) => {
+    context.enumValue(required(item, 'type', path, context), `${path}.type`, [
+      'DROP_SHADOW', 'INNER_SHADOW', 'LAYER_BLUR', 'BACKGROUND_BLUR',
+    ] as const);
+    context.number(required(item, 'radius', path, context), `${path}.radius`, 0);
+    if (item.spread !== undefined) context.number(item.spread, `${path}.spread`);
+    if (item.color !== undefined) validateColor(item.color, `${path}.color`, context);
+    if (item.offset !== undefined) context.object(item.offset, `${path}.offset`, OFFSET_FIELDS, (offset) => {
+      context.number(required(offset, 'x', `${path}.offset`, context), `${path}.offset.x`);
+      context.number(required(offset, 'y', `${path}.offset`, context), `${path}.offset.y`);
+    });
+  });
+}
+
+function validateRecord(
+  value: unknown,
+  path: string,
+  context: ValidationContext,
+  visit: (entry: unknown, entryPath: string) => void,
+): void {
+  context.object(value, path, null, (item) => {
+    for (const key in item) {
+      if (Object.prototype.hasOwnProperty.call(item, key)) visit(item[key], `${path}.${key}`);
+    }
+  });
+}
+
+export function validateKeyedBindings(value: unknown, path: string, context: ValidationContext): void {
+  validateRecord(value, path, context, (entry, entryPath) => {
+    context.object(entry, entryPath, KEYED_BINDING_FIELDS, (binding) => {
+      context.string(required(binding, 'key', entryPath, context), `${entryPath}.key`);
+      if (binding.name !== undefined) context.string(binding.name, `${entryPath}.name`);
+    });
+  });
+}
+
+export function validateStringRecord(value: unknown, path: string, context: ValidationContext): void {
+  validateRecord(value, path, context, (entry, entryPath) => context.string(entry, entryPath));
+}
+
+export function validatePrimitiveRecord(value: unknown, path: string, context: ValidationContext): void {
+  validateRecord(value, path, context, (entry, entryPath) => {
+    if (typeof entry === 'number') context.number(entry, entryPath);
+    else context.string(entry, entryPath);
+  });
+}
+
+export function validateComponentProperties(value: unknown, path: string, context: ValidationContext): void {
+  validateRecord(value, path, context, (entry, entryPath) => {
+    if (typeof entry === 'boolean') context.boolean(entry, entryPath);
+    else context.string(entry, entryPath);
+  });
+}
+
+export function validateTextSegments(value: unknown, path: string, context: ValidationContext): void {
+  context.array(value, path, context.limits.arrayEntries, (entry, i) => {
+    const entryPath = `${path}[${i}]`;
+    context.object(entry, entryPath, TEXT_SEGMENT_FIELDS, (segment) => {
+      context.string(required(segment, 'characters', entryPath, context), `${entryPath}.characters`);
+      if (segment.fontFamily !== undefined) context.string(segment.fontFamily, `${entryPath}.fontFamily`);
+      for (const key of ['fontSize', 'fontWeight', 'lineHeight'] as const) if (segment[key] !== undefined) {
+        context.number(segment[key], `${entryPath}.${key}`, 0);
+      }
+      if (segment.letterSpacing !== undefined) context.number(segment.letterSpacing, `${entryPath}.letterSpacing`);
+      if (segment.fontStyle !== undefined) context.enumValue(segment.fontStyle, `${entryPath}.fontStyle`, ['normal', 'italic'] as const);
+      if (segment.textDecoration !== undefined) context.enumValue(segment.textDecoration, `${entryPath}.textDecoration`, ['UNDERLINE', 'STRIKETHROUGH'] as const);
+      if (segment.textCase !== undefined) context.enumValue(segment.textCase, `${entryPath}.textCase`, ['UPPER', 'LOWER', 'TITLE'] as const);
+      if (segment.textColor !== undefined) validateColor(segment.textColor, `${entryPath}.textColor`, context);
+    });
+  });
+}
+
+export function validateMotion(value: unknown, path: string, context: ValidationContext): void {
+  context.object(value, path, MOTION_FIELDS, (motion) => {
+    context.number(required(motion, 'durationSec', path, context), `${path}.durationSec`, 0);
+    if (motion.easing !== undefined) context.string(motion.easing, `${path}.easing`);
+    context.array(required(motion, 'steps', path, context), `${path}.steps`, context.limits.motionSteps, (entry, i) => {
+      const entryPath = `${path}.steps[${i}]`;
+      context.object(entry, entryPath, MOTION_STEP_FIELDS, (step) => {
+        context.number(required(step, 'offset', entryPath, context), `${entryPath}.offset`, 0, 1);
+        context.object(required(step, 'style', entryPath, context), `${entryPath}.style`, MOTION_STYLE_FIELDS, (style) => {
+          for (const key of MOTION_STYLE_FIELDS) if (style[key] !== undefined) context.string(style[key], `${entryPath}.style.${key}`);
+        });
+      });
+    });
+  });
+}

--- a/shared/figma-payload-validation.ts
+++ b/shared/figma-payload-validation.ts
@@ -1,0 +1,69 @@
+import type { FigmaExportPayload } from './figma-payload-types';
+import {
+  type ImportPayloadLimits, type ObjectValue, ValidationContext,
+} from './figma-payload-validation-context';
+import { validateNode } from './figma-payload-validation-node';
+import { validateTokens } from './figma-payload-validation-tokens';
+
+export { IMPORT_PAYLOAD_LIMITS, PayloadValidationError } from './figma-payload-validation-context';
+export type { ImportPayloadLimits } from './figma-payload-validation-context';
+
+export interface ImportPayloadAdmission {
+  payload: FigmaExportPayload;
+  placement: { x?: number; y?: number; parentId?: string; replaceId?: string };
+}
+
+const PAYLOAD_FIELDS = new Set(['version', 'name', 'width', 'height', 'tokens', 'rootNode']);
+const PLACEMENT_FIELDS = new Set(['x', 'y', 'parentId', 'replaceId']);
+const WRAPPED_FIELDS = new Set(['payload', ...PLACEMENT_FIELDS]);
+const DIRECT_FIELDS = new Set([...PAYLOAD_FIELDS, ...PLACEMENT_FIELDS]);
+
+function required(item: ObjectValue, key: string, path: string, context: ValidationContext): unknown {
+  if (!Object.prototype.hasOwnProperty.call(item, key)) context.fail(`${path}.${key}`, 'is required');
+  return item[key];
+}
+
+function validatePayloadFields(
+  payload: ObjectValue,
+  path: string,
+  context: ValidationContext,
+): FigmaExportPayload {
+  const version = context.number(required(payload, 'version', path, context), `${path}.version`);
+  if (version !== 1) context.fail(`${path}.version`, 'must be 1');
+  const name = context.string(required(payload, 'name', path, context), `${path}.name`);
+  const width = context.number(required(payload, 'width', path, context), `${path}.width`, 0);
+  const height = context.number(required(payload, 'height', path, context), `${path}.height`, 0);
+  const tokens = validateTokens(payload.tokens ?? {}, `${path}.tokens`, context);
+  const rootNode = required(payload, 'rootNode', path, context);
+  validateNode(rootNode, `${path}.rootNode`, context);
+  return { version: 1, name, width, height, tokens, rootNode: rootNode as FigmaExportPayload['rootNode'] };
+}
+
+function validatePlacement(source: ObjectValue, context: ValidationContext): ImportPayloadAdmission['placement'] {
+  const placement: ImportPayloadAdmission['placement'] = {};
+  for (const key of ['x', 'y'] as const) if (source[key] !== undefined) {
+    placement[key] = context.number(source[key], `params.${key}`);
+  }
+  for (const key of ['parentId', 'replaceId'] as const) if (source[key] !== undefined) {
+    placement[key] = context.string(source[key], `params.${key}`);
+  }
+  return placement;
+}
+
+/** Closed, bounded admission for wrapped and legacy unwrapped IMPORT_PAYLOAD input. */
+export function validateImportPayload(
+  params: unknown,
+  limitOverrides: Partial<ImportPayloadLimits> = {},
+): ImportPayloadAdmission {
+  const context = new ValidationContext(limitOverrides);
+  const looksWrapped = !!params && typeof params === 'object' && !Array.isArray(params)
+    && Object.prototype.hasOwnProperty.call(params, 'payload');
+  return context.object(params, 'params', looksWrapped ? WRAPPED_FIELDS : DIRECT_FIELDS, (envelope) => {
+    const payload = looksWrapped
+      ? context.object(required(envelope, 'payload', 'params', context), 'payload', PAYLOAD_FIELDS, (value) => (
+        validatePayloadFields(value, 'payload', context)
+      ))
+      : validatePayloadFields(envelope, 'payload', context);
+    return { payload, placement: validatePlacement(envelope, context) };
+  });
+}

--- a/tests/figma-payload-validation-budgets.test.ts
+++ b/tests/figma-payload-validation-budgets.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest';
+import { PayloadValidationError, validateImportPayload } from '../shared/figma-payload-validation.ts';
+
+const valid = () => ({
+  version: 1 as const,
+  name: 'Card',
+  width: 100,
+  height: 50,
+  tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] },
+  rootNode: {
+    type: 'FRAME', name: 'Card',
+    children: [{ type: 'TEXT', name: 'Title', characters: 'Hello' }],
+  },
+});
+
+function rejected(input: unknown, limits: Parameters<typeof validateImportPayload>[1]): void {
+  expect(() => validateImportPayload(input, limits)).toThrow(PayloadValidationError);
+}
+
+describe('IMPORT_PAYLOAD bounded work', () => {
+  it('refuses depth and node-count excess with small injected limits', () => {
+    rejected(valid(), { depth: 0 });
+    rejected(valid(), { nodes: 1 });
+  });
+
+  it('refuses ordinary strings, arrays, dynamic records, record keys, and aggregate entries', () => {
+    rejected(valid(), { textChars: 4 });
+    rejected(valid(), { arrayEntries: 0 });
+    rejected({
+      ...valid(), rootNode: { type: 'FRAME', name: 'Card', keyedBindings: { fills: { key: 'k' } } },
+    }, { recordEntries: 0 });
+    rejected({
+      ...valid(), rootNode: { type: 'FRAME', name: 'Card', keyedBindings: { 'long-key-123': { key: 'k' } } },
+    }, { recordKeyChars: 10 });
+    rejected(valid(), { totalEntries: 1 });
+  });
+
+  it('refuses token and motion excess through their independent ceilings', () => {
+    rejected({
+      ...valid(), tokens: {
+        colors: [{ name: 'c', hex: '#000', color: { r: 0, g: 0, b: 0, a: 1 } }],
+      },
+    }, { tokenGroup: 0 });
+    rejected({
+      ...valid(), rootNode: {
+        type: 'FRAME', name: 'Card',
+        motion: {
+          durationSec: 1,
+          steps: [{ offset: 0, style: {} }, { offset: 1, style: {} }],
+        },
+      },
+    }, { motionSteps: 1 });
+  });
+
+  it('budgets imageUrl and backgroundImageUrl as images and SVG separately', () => {
+    for (const field of ['imageUrl', 'backgroundImageUrl']) rejected({
+      ...valid(), rootNode: { type: 'IMAGE', name: 'asset', [field]: '12345' },
+    }, { imageChars: 4 });
+    rejected({
+      ...valid(), rootNode: { type: 'IMAGE', name: 'asset', svgContent: '<svg/>' },
+    }, { svgChars: 4 });
+  });
+
+  it('refuses aggregate bytes incrementally without calling JSON.stringify', () => {
+    rejected(valid(), { aggregateBytes: 64 });
+    const original = JSON.stringify;
+    let calls = 0;
+    JSON.stringify = ((...args: Parameters<typeof JSON.stringify>) => {
+      calls += 1;
+      return original(...args);
+    }) as typeof JSON.stringify;
+    try {
+      validateImportPayload(valid());
+      expect(calls).toBe(0);
+    } finally {
+      JSON.stringify = original;
+    }
+  });
+
+  it('counts JSON escape expansion in the incremental aggregate budget', () => {
+    const plain = { ...valid(), rootNode: { type: 'TEXT', name: 'text', characters: 'a'.repeat(50) } };
+    const escaped = { ...valid(), rootNode: { type: 'TEXT', name: 'text', characters: '\0'.repeat(50) } };
+    expect(() => validateImportPayload(plain, { aggregateBytes: 500 })).not.toThrow();
+    rejected(escaped, { aggregateBytes: 500 });
+  });
+
+  it('refuses enumerable non-index array sidecars before structured-clone forwarding', () => {
+    const children: unknown[] & { unvalidatedSidecar?: string } = [];
+    children.unvalidatedSidecar = 'x'.repeat(1_000_000);
+    const input = structuredClone({
+      ...valid(), rootNode: { type: 'FRAME', name: 'root', children },
+    });
+    expect((input.rootNode.children as typeof children).unvalidatedSidecar).toHaveLength(1_000_000);
+    rejected(input, { aggregateBytes: 1024 });
+  });
+
+  it('allows repeated aliases, rejects active cycles, and bounds repeated work', () => {
+    const color = { r: 0, g: 0, b: 0, a: 1 };
+    expect(() => validateImportPayload({
+      ...valid(), rootNode: {
+        type: 'FRAME', name: 'Card', textColor: color,
+        fills: [{ type: 'SOLID', color }],
+      },
+    })).not.toThrow();
+
+    const cyclic = { type: 'FRAME', name: 'cycle', children: [] as unknown[] };
+    cyclic.children.push(cyclic);
+    expect(() => validateImportPayload({ ...valid(), rootNode: cyclic })).toThrow(PayloadValidationError);
+
+    const shared = { type: 'FRAME', name: 'shared' };
+    rejected({ ...valid(), rootNode: { type: 'FRAME', name: 'root', children: [shared, shared] } }, { nodes: 2 });
+  });
+});

--- a/tests/figma-payload-validation-schema.test.ts
+++ b/tests/figma-payload-validation-schema.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { PayloadValidationError, validateImportPayload } from '../shared/figma-payload-validation.ts';
+
+const sharedColor = { r: 0.1, g: 0.2, b: 0.3, a: 1 };
+const emptyTokens = () => ({ colors: [], typography: [], spacing: [], radii: [], shadows: [] });
+
+function completeNode(): Record<string, unknown> {
+  return {
+    type: 'INSTANCE', name: '', width: 0, height: 0,
+    layoutMode: 'GRID', itemSpacing: 0, paddingTop: 0, paddingRight: 0, paddingBottom: 0, paddingLeft: 0,
+    primaryAxisSizingMode: 'AUTO', counterAxisSizingMode: 'FIXED', primaryAxisAlignItems: 'SPACE_BETWEEN',
+    counterAxisAlignItems: 'BASELINE', layoutWrap: 'WRAP', counterAxisSpacing: 0,
+    layoutSizingHorizontal: 'FILL', layoutSizingVertical: 'HUG', layoutGrow: 0,
+    maxWidth: 0, minWidth: 0, maxHeight: 0, minHeight: 0,
+    gridColumnCount: 1, gridRowCount: 1, gridRowGap: 0, gridColumnGap: 0,
+    fills: [
+      { type: 'SOLID', color: sharedColor },
+      {
+        type: 'GRADIENT_LINEAR',
+        gradientStops: [{ color: sharedColor, position: 0 }, { color: sharedColor, position: 1 }],
+        gradientTransform: [[1, 0, 0], [0, 1, 0]],
+      },
+    ],
+    cornerRadius: 0, cornerRadii: { tl: 0, tr: 0, br: 0, bl: 0 },
+    effects: [
+      { type: 'DROP_SHADOW', offset: { x: -1, y: 2 }, radius: 0, spread: -1, color: sharedColor },
+      { type: 'LAYER_BLUR', radius: 0 },
+    ],
+    opacity: 0, backgroundImageUrl: 'data:image/png;base64,AA==', backgroundSize: 'future-value',
+    backgroundPosition: 'future-value', strokes: [{ type: 'SOLID', color: sharedColor }],
+    strokeWeight: 0, strokeWeights: { top: 0, right: 0, bottom: 0, left: 0 }, strokeAlign: 'CENTER',
+    characters: '', fontFamily: '', fontStack: 'Inter, future-font', fontSize: 0, fontWeight: 0,
+    fontStyle: 'italic', lineHeight: 0, letterSpacing: -1, wordSpacing: -1,
+    textAlignHorizontal: 'JUSTIFIED', textAutoResize: 'TRUNCATE', textColor: sharedColor,
+    textDecoration: 'STRIKETHROUGH', textCase: 'TITLE', textTruncation: 'ENDING',
+    blendMode: 'FUTURE_BLEND_MODE', rotation: -45, counterAxisAlignContent: 'SPACE_BETWEEN',
+    imageUrl: 'https://example.test/image.png', svgContent: '<svg/>',
+    motion: {
+      steps: [{ offset: 0, style: {} }, { offset: 1, style: { opacity: '1', transform: 'none' } }],
+      durationSec: 0, easing: 'future-easing',
+    },
+    clipsContent: false, absolutePosition: true, x: -1, y: -2,
+    textSegments: [{
+      characters: '', fontFamily: '', fontSize: 0, fontWeight: 0, fontStyle: 'normal',
+      lineHeight: 0, letterSpacing: -1, textColor: sharedColor, textDecoration: 'UNDERLINE', textCase: 'UPPER',
+    }],
+    keyedBindings: { fills: { key: 'published-key', name: '' } },
+    tokenRefs: { fill: 'c', stroke: 'c', textColor: 'c', radius: 'r', gap: 's', padding: 's' },
+    componentKey: '', componentId: '', componentName: '', componentProperties: { State: 'On', Enabled: false },
+    innerOverrides: [{
+      childKey: '0/1', fields: { name: '', width: 0 }, componentKey: '', componentId: '',
+      componentProperties: { State: 'Off', Enabled: true }, figmaScanFillSize: { width: 0, height: 0 },
+      visual: {
+        fills: [], strokes: [], effects: [], effectStyleId: '', visible: false, opacity: 0,
+        keyedBindings: { fills: { key: 'inner-key', name: '' } },
+      },
+    }],
+    figmaScanUnreproducibleInner: ['width'], figmaScanBindings: { fontSize: 'VariableID:1' },
+    figmaScanSourceType: 'FUTURE_SOURCE', figmaScanInnerOverrides: ['effects'],
+    figmaScanUnbindable: ['maxWidth'], children: [],
+  };
+}
+
+function completePayload(rootNode = completeNode()) {
+  return {
+    version: 1, name: '', width: 0, height: 0,
+    tokens: {
+      colors: [{ name: 'c', hex: '#19334d', color: sharedColor }],
+      typography: [{ name: 't', family: '', size: 0, weight: 0, lineHeight: 0, letterSpacing: -1 }],
+      spacing: [{ name: 's', value: -1 }], radii: [{ name: 'r', value: 0 }],
+      shadows: [{ name: 'shadow', css: '', effect: { type: 'BACKGROUND_BLUR', radius: 0 } }],
+    },
+    rootNode,
+  };
+}
+
+describe('IMPORT_PAYLOAD complete schema', () => {
+  it('accepts every current optional field, scanner extension, empty visual, alias, and token shape', () => {
+    expect(validateImportPayload(completePayload()).payload).toEqual(completePayload());
+  });
+
+  it('validates every declared node field by its runtime type', () => {
+    const node = completeNode();
+    for (const [field, value] of Object.entries(node)) {
+      const wrong = typeof value === 'number' ? 'wrong'
+        : typeof value === 'string' ? 5
+          : typeof value === 'boolean' ? 'wrong'
+            : Array.isArray(value) ? {} : 'wrong';
+      expect(
+        () => validateImportPayload(completePayload({ ...node, [field]: wrong })),
+        `field ${field}`,
+      ).toThrow(PayloadValidationError);
+    }
+  });
+
+  it('rejects every node and text-segment enum outside its declared union', () => {
+    const nodeEnums = [
+      'type', 'layoutMode', 'primaryAxisSizingMode', 'counterAxisSizingMode', 'primaryAxisAlignItems',
+      'counterAxisAlignItems', 'layoutWrap', 'layoutSizingHorizontal', 'layoutSizingVertical', 'strokeAlign',
+      'fontStyle', 'textAlignHorizontal', 'textAutoResize', 'textDecoration', 'textCase', 'textTruncation',
+      'counterAxisAlignContent',
+    ];
+    for (const field of nodeEnums) expect(
+      () => validateImportPayload(completePayload({ ...completeNode(), [field]: 'NOT_IN_UNION' })),
+      `enum ${field}`,
+    ).toThrow(PayloadValidationError);
+    for (const field of ['fontStyle', 'textDecoration', 'textCase']) expect(() => validateImportPayload(completePayload({
+      type: 'TEXT', name: 'bad', textSegments: [{ characters: 'x', [field]: 'NOT_IN_UNION' }],
+    }))).toThrow(PayloadValidationError);
+  });
+
+  it('rejects malformed nested unions, records, ranges, and unknown fields', () => {
+    const rejects = [
+      { fills: [{ type: 'SOLID' }] },
+      { fills: [{ type: 'GRADIENT_LINEAR', gradientStops: [], gradientTransform: [[1, 0, 0], [0, 1, 0]] }] },
+      { fills: [{ type: 'GRADIENT_LINEAR', gradientStops: [{ color: sharedColor, position: 0 }, { color: sharedColor, position: 2 }], gradientTransform: [[1, 0, 0], [0, 1, 0]] }] },
+      { fills: [{ type: 'GRADIENT_LINEAR', gradientStops: [{ color: sharedColor, position: 0 }, { color: sharedColor, position: 1 }], gradientTransform: [[1, 0, 0]] }] },
+      { opacity: 2 }, { tokenRefs: { unknown: 'x' } }, { keyedBindings: { fills: { key: 5 } } },
+      { innerOverrides: [{ childKey: '0', fields: {}, visual: { unknown: true } }] },
+      { figmaScanBindings: { fills: 5 } }, { children: [{ type: 'FRAME', name: 'bad', unknown: true }] },
+    ];
+    for (const fields of rejects) expect(
+      () => validateImportPayload(completePayload({ type: 'FRAME', name: 'bad', ...fields })),
+    ).toThrow(PayloadValidationError);
+  });
+
+  it('normalizes each partial token group but rejects malformed present token fields', () => {
+    expect(validateImportPayload({ ...completePayload(), tokens: { colors: [] } }).payload.tokens).toEqual(emptyTokens());
+    expect(() => validateImportPayload({
+      ...completePayload(), tokens: { colors: [{ name: 'c', hex: '#fff', color: { ...sharedColor, a: 2 } }] },
+    })).toThrow(PayloadValidationError);
+  });
+});

--- a/tests/figma-payload-validation.test.ts
+++ b/tests/figma-payload-validation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { PayloadValidationError, validateImportPayload } from '../shared/figma-payload-validation.ts';
+
+const valid = () => ({
+  version: 1 as const,
+  name: 'Card',
+  width: 320,
+  height: 200,
+  tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] },
+  rootNode: { type: 'FRAME', name: 'Card', children: [{ type: 'TEXT', name: 'Title', characters: 'Hello' }] },
+});
+
+describe('IMPORT_PAYLOAD admission', () => {
+  it('accepts both wire envelopes and keeps placement separate', () => {
+    expect(validateImportPayload({ ...valid(), x: 11 })).toMatchObject({ payload: valid(), placement: { x: 11 } });
+    expect(validateImportPayload({ payload: valid(), x: 12, y: 13, parentId: '1:2' })).toMatchObject({
+      payload: valid(), placement: { x: 12, y: 13, parentId: '1:2' },
+    });
+  });
+
+  it('normalizes omitted token groups', () => {
+    const input = valid();
+    delete (input as Partial<typeof input>).tokens;
+    expect(validateImportPayload(input).payload.tokens).toEqual({ colors: [], typography: [], spacing: [], radii: [], shadows: [] });
+  });
+
+  it('normalizes every omitted token group independently', () => {
+    const input = valid();
+    input.tokens = { colors: [] } as typeof input.tokens;
+    expect(validateImportPayload(input).payload.tokens).toEqual({
+      colors: [], typography: [], spacing: [], radii: [], shadows: [],
+    });
+  });
+
+  it('canonicalizes legacy null token values without forwarding null groups', () => {
+    const empty = { colors: [], typography: [], spacing: [], radii: [], shadows: [] };
+    const legacyValues = [null, ...Object.keys(empty).map((key) => ({ [key]: null }))];
+    for (const tokens of legacyValues) {
+      const payload = { ...valid(), tokens };
+      for (const params of [payload, { payload }]) {
+        expect(validateImportPayload(params).payload.tokens).toEqual(empty);
+      }
+    }
+  });
+
+  it('rejects non-null malformed token objects and groups in either envelope', () => {
+    const groups = ['colors', 'typography', 'spacing', 'radii', 'shadows'];
+    const malformed = [0, false, 'x', [], ...groups.flatMap((key) => (
+      [0, false, 'x', {}].map((value) => ({ [key]: value }))
+    ))];
+    for (const tokens of malformed) {
+      const payload = { ...valid(), tokens };
+      for (const params of [payload, { payload }]) {
+        expect(() => validateImportPayload(params)).toThrow(PayloadValidationError);
+      }
+    }
+  });
+
+  it('rejects malformed typed node fields instead of only checking their broad primitive kind', () => {
+    expect(() => validateImportPayload({
+      ...valid(), rootNode: { type: 'FRAME', name: 'bad', counterAxisSpacing: {} },
+    })).toThrow(PayloadValidationError);
+    expect(() => validateImportPayload({
+      ...valid(), rootNode: { type: 'FRAME', name: 'bad', layoutMode: 'NOT_A_LAYOUT' },
+    })).toThrow(PayloadValidationError);
+    expect(() => validateImportPayload({
+      ...valid(),
+      rootNode: {
+        type: 'TEXT', name: 'bad',
+        textSegments: [{ characters: 'x', fontSize: 'bad', fontFamily: 5 }],
+      },
+    })).toThrow(PayloadValidationError);
+  });
+
+  it('permits a valid repeated-reference alias while still rejecting active cycles', () => {
+    const sharedColor = { r: 0.1, g: 0.2, b: 0.3, a: 1 };
+    const input = valid();
+    input.rootNode = {
+      type: 'FRAME', name: 'alias', textColor: sharedColor,
+      fills: [{ type: 'SOLID', color: sharedColor }],
+    } as typeof input.rootNode;
+    expect(() => validateImportPayload(input)).not.toThrow();
+  });
+
+  it('accepts the existing 8 MiB image producer boundary after base64 expansion', () => {
+    const encodedLength = 4 * Math.ceil((8 * 1024 * 1024) / 3);
+    const input = valid();
+    input.rootNode = {
+      type: 'FRAME', name: 'image',
+      backgroundImageUrl: `data:image/png;base64,${'A'.repeat(encodedLength)}`,
+    } as typeof input.rootNode;
+    expect(() => validateImportPayload(input)).not.toThrow();
+  });
+
+  it('returns the established E_INVALID_ARGS wire code and never serializes the whole payload', () => {
+    try {
+      validateImportPayload({ ...valid(), rootNode: { type: 'FRAME', name: 'bad', layoutMode: 'NOPE' } });
+      throw new Error('expected validation to fail');
+    } catch (error) {
+      expect(error).toMatchObject({ code: 'E_INVALID_ARGS' });
+    }
+
+    const stringify = JSON.stringify;
+    let calls = 0;
+    JSON.stringify = ((...args: Parameters<typeof JSON.stringify>) => {
+      calls += 1;
+      return stringify(...args);
+    }) as typeof JSON.stringify;
+    try {
+      validateImportPayload(valid());
+      expect(calls).toBe(0);
+    } finally {
+      JSON.stringify = stringify;
+    }
+  });
+
+  it('rejects unknown fields, invalid tags, non-finite numbers, cycles, and excess depth', () => {
+    expect(() => validateImportPayload({ ...valid(), unexpected: true })).toThrow(PayloadValidationError);
+    expect(() => validateImportPayload({ ...valid(), rootNode: { type: 'ALIEN', name: 'bad' } })).toThrow(PayloadValidationError);
+    expect(() => validateImportPayload({ ...valid(), width: Number.NaN })).toThrow(PayloadValidationError);
+    const cyclic = valid(); cyclic.rootNode.children = [cyclic.rootNode];
+    expect(() => validateImportPayload(cyclic)).toThrow(PayloadValidationError);
+    let child: Record<string, unknown> = { type: 'FRAME', name: 'end' };
+    for (let i = 0; i < 65; i++) child = { type: 'FRAME', name: 'deep', children: [child] };
+    expect(() => validateImportPayload({ ...valid(), rootNode: child }, { depth: 64 })).toThrow(PayloadValidationError);
+  });
+});

--- a/tests/import-payload-admission.test.ts
+++ b/tests/import-payload-admission.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const effects = vi.hoisted(() => ({
+  resetWarnings: vi.fn(),
+  resetKeyedVariables: vi.fn(),
+  createColorStyles: vi.fn(async () => new Map()),
+  createTextStyles: vi.fn(async () => undefined),
+  createEffectStyles: vi.fn(async () => undefined),
+  resolveTokenVars: vi.fn(async () => new Map()),
+  createFigmaNode: vi.fn(async () => ({ id: '2:1', name: 'Card', width: 100, height: 50, x: 0, y: 0 })),
+}));
+
+vi.mock('../plugin/src/main/executor-styles.ts', () => ({
+  resetImportWarnings: effects.resetWarnings,
+  getImportWarnings: () => [],
+  createColorStyles: effects.createColorStyles,
+  createTextStyles: effects.createTextStyles,
+  createEffectStyles: effects.createEffectStyles,
+}));
+vi.mock('../plugin/src/main/executor-keyed-vars.ts', () => ({
+  resetKeyedVariableCache: effects.resetKeyedVariables,
+}));
+vi.mock('../plugin/src/main/executor-token-var-resolve.ts', () => ({
+  resolveTokenVars: effects.resolveTokenVars,
+}));
+vi.mock('../plugin/src/main/executor-frame.ts', () => ({ createFigmaNode: effects.createFigmaNode }));
+
+import { importPayload } from '../plugin/src/main/import-payload-admission.ts';
+
+const valid = () => ({
+  version: 1 as const,
+  name: 'Card',
+  width: 100,
+  height: 50,
+  tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] },
+  rootNode: { type: 'FRAME', name: 'Card' },
+});
+
+function mutationSpies() {
+  return [
+    effects.resetWarnings,
+    effects.resetKeyedVariables,
+    effects.createColorStyles,
+    effects.createTextStyles,
+    effects.createEffectStyles,
+    effects.resolveTokenVars,
+    effects.createFigmaNode,
+  ];
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const currentPage = { appendChild: vi.fn(), selection: [] };
+  vi.stubGlobal('figma', {
+    currentPage,
+    viewport: { center: { x: 200, y: 100 }, scrollAndZoomIntoView: vi.fn() },
+    getNodeByIdAsync: vi.fn(async () => null),
+    notify: vi.fn(),
+  });
+});
+
+describe('main IMPORT_PAYLOAD owning boundary', () => {
+  it.each([
+    ['direct', () => ({ ...valid(), rootNode: { type: 'FRAME', name: 'bad', layoutMode: 'NOT_A_LAYOUT' } })],
+    ['wrapped', () => ({ payload: { ...valid(), rootNode: { type: 'FRAME', name: 'bad', counterAxisSpacing: {} } } })],
+  ])('refuses malformed %s input before every import side effect', async (_label, makeParams) => {
+    await expect(importPayload(makeParams())).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    for (const spy of mutationSpies()) expect(spy).not.toHaveBeenCalled();
+    expect(figma.currentPage.appendChild).not.toHaveBeenCalled();
+    expect(figma.getNodeByIdAsync).not.toHaveBeenCalled();
+    expect(figma.notify).not.toHaveBeenCalled();
+  });
+
+  it('normalizes partial tokens and preserves placement through the production importer', async () => {
+    const input = valid();
+    input.tokens = { colors: [] } as typeof input.tokens;
+    await expect(importPayload({ payload: input, x: 17, y: 23 })).resolves.toMatchObject({ id: '2:1', name: 'Card' });
+    expect(effects.createTextStyles).toHaveBeenCalledWith([]);
+    expect(effects.createEffectStyles).toHaveBeenCalledWith([]);
+    expect(effects.createFigmaNode).toHaveBeenCalledOnce();
+    expect(figma.currentPage.appendChild).toHaveBeenCalledOnce();
+    expect(effects.createFigmaNode.mock.results[0].value).resolves.toMatchObject({ x: 17, y: 23 });
+  });
+
+  it('keeps legacy null token input canonical before invoking import consumers', async () => {
+    for (const tokens of [null, { colors: null, typography: null, shadows: null }]) {
+      await expect(importPayload({ payload: { ...valid(), tokens } })).resolves.toMatchObject({ id: '2:1' });
+      expect(effects.createColorStyles).toHaveBeenLastCalledWith([]);
+      expect(effects.createTextStyles).toHaveBeenLastCalledWith([]);
+      expect(effects.createEffectStyles).toHaveBeenLastCalledWith([]);
+      expect(effects.resolveTokenVars).toHaveBeenLastCalledWith({ colors: [], typography: [], spacing: [], radii: [], shadows: [] });
+    }
+  });
+});

--- a/tests/import-payload-relay-errors.test.ts
+++ b/tests/import-payload-relay-errors.test.ts
@@ -1,0 +1,91 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+import { chromium, type Browser } from 'playwright';
+
+let browser: Browser;
+let panel: string;
+let relay: string;
+
+beforeAll(async () => {
+  const root = fileURLToPath(new URL('..', import.meta.url));
+  panel = await readFile(`${root}/plugin/src/ui/panel.html`, 'utf8');
+  const result = await build({
+    entryPoints: [`${root}/plugin/src/ui/ui-relay.ts`],
+    bundle: true, platform: 'browser', format: 'iife', target: 'es2020',
+    write: false, logLevel: 'silent',
+  });
+  relay = result.outputFiles[0].text;
+  try { browser = await chromium.launch({ headless: true }); }
+  catch { browser = await chromium.launch({ headless: true, channel: 'chrome' }); }
+}, 30_000);
+
+afterAll(async () => { await browser?.close(); });
+
+describe('actual UI relay admission errors', () => {
+  it.each(['IMPORT_PAYLOAD', 'HTML_TO_FIGMA'])('preserves typed refusal and correlation for %s', async (cmd) => {
+    const page = await browser.newPage();
+    try {
+      await page.addInitScript(() => {
+        const probe = window as any;
+        probe.sockets = [];
+        probe.forwarded = [];
+        probe.activities = [];
+        class BrokerSocket {
+          static OPEN = 1;
+          readyState = 1;
+          sent: any[] = [];
+          onmessage: ((event: { data: string }) => void) | null = null;
+          constructor(public url: string) {
+            probe.sockets.push(this);
+            setTimeout(() => this.onmessage?.({
+              data: JSON.stringify({ type: 'BROKER_HELLO', data: {} }),
+            }), 0);
+          }
+          send(frame: string) { this.sent.push(JSON.parse(frame)); }
+          close() { this.readyState = 3; }
+        }
+        probe.WebSocket = BrokerSocket;
+        probe.postMessage = (message: unknown) => probe.forwarded.push(message);
+        window.addEventListener('figma-agent:activity', (event) => {
+          probe.activities.push((event as CustomEvent).detail);
+        });
+      });
+      await page.goto(`data:text/html,${encodeURIComponent(panel)}`);
+      await page.addScriptTag({ content: relay });
+      await page.waitForFunction(() => (window as any).sockets.some(
+        (socket: any) => socket.sent.some((frame: any) => frame.type === 'PLUGIN_HELLO'),
+      ));
+      await page.evaluate((command) => {
+        const socket = (window as any).sockets.find(
+          (candidate: any) => candidate.sent.some((frame: any) => frame.type === 'PLUGIN_HELLO'),
+        );
+        const params = command === 'HTML_TO_FIGMA'
+          ? { html: '<body style="background:#111"><div>Hi</div></body>', width: 100, name: 'x'.repeat(1024 * 1024 + 1) }
+          : { version: 1, name: 'invalid', width: 100, height: 100, rootNode: { type: 'NOT_A_NODE', name: 'invalid' } };
+        socket.onmessage({ data: JSON.stringify({ id: 'invalid-import', cmd: command, params, v: 1 }) });
+      }, cmd);
+      await page.waitForFunction(() => (window as any).sockets.some(
+        (socket: any) => socket.sent.some((frame: any) => frame.id === 'invalid-import'),
+      ));
+      const result = await page.evaluate(() => {
+        const probe = window as any;
+        return {
+          replies: probe.sockets.flatMap((socket: any) => socket.sent).filter((frame: any) => frame.id === 'invalid-import'),
+          imports: probe.forwarded.filter((message: any) => message?.pluginMessage?.cmd === 'IMPORT_PAYLOAD'),
+          completed: probe.activities.filter((activity: any) => activity.id === 'invalid-import' && activity.phase === 'done'),
+          iframes: document.querySelectorAll('iframe').length,
+        };
+      });
+      expect(result.replies).toHaveLength(1);
+      expect(result.replies[0]).toMatchObject({ id: 'invalid-import', ok: false, error: { code: 'E_INVALID_ARGS' } });
+      expect(result.imports).toEqual([]);
+      expect(result.completed).toHaveLength(1);
+      expect(result.completed[0]).toMatchObject({ ok: false, code: 'E_INVALID_ARGS' });
+      expect(result.iframes).toBe(0);
+    } finally {
+      await page.close();
+    }
+  }, 20_000);
+});

--- a/tests/import-payload-relay.test.ts
+++ b/tests/import-payload-relay.test.ts
@@ -1,0 +1,144 @@
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import * as esbuild from 'esbuild';
+import type { Browser } from 'playwright';
+import { chromium } from 'playwright';
+import { forwardValidatedDirectImport, forwardValidatedHtmlImport } from '../shared/figma-payload-validation-relay.ts';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+let browser: Browser;
+let authoredHtmlBundle: string;
+let repositoryPanelHtml: string;
+
+beforeAll(async () => {
+  repositoryPanelHtml = await readFile(new URL('../plugin/src/ui/panel.html', import.meta.url), 'utf8');
+  const built = await esbuild.build({
+    stdin: {
+      contents: `
+        import { renderHtmlToPayload } from './plugin/src/ui/render-host.ts';
+        import { forwardValidatedHtmlImport } from './shared/figma-payload-validation-relay.ts';
+        window.__relayRepositoryHtml = async (html) => {
+          const payload = await renderHtmlToPayload(html, 640, 'Repository panel');
+          let forwarded;
+          forwardValidatedHtmlImport({
+            requestId: 'repository-html', expectedFile: 'Plugin panel', payload,
+            placement: { x: 12, y: 24 },
+          }, (message) => { forwarded = message; });
+          return { forwarded, bytes: JSON.stringify(payload).length };
+        };
+      `,
+      resolveDir: ROOT,
+      loader: 'ts',
+    },
+    bundle: true,
+    platform: 'browser',
+    format: 'iife',
+    target: 'es2020',
+    write: false,
+    logLevel: 'silent',
+  });
+  authoredHtmlBundle = built.outputFiles[0].text;
+  try {
+    browser = await chromium.launch({ headless: true });
+  } catch {
+    browser = await chromium.launch({ headless: true, channel: 'chrome' });
+  }
+}, 30_000);
+
+afterAll(async () => { await browser?.close(); });
+
+const valid = () => ({
+  version: 1 as const,
+  name: 'Authored HTML',
+  width: 320,
+  height: 200,
+  tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] },
+  rootNode: { type: 'FRAME', name: 'Page' },
+});
+
+describe('direct IMPORT_PAYLOAD relay admission', () => {
+  it.each([
+    ['direct', { ...valid(), rootNode: { type: 'FRAME', name: 'bad', layoutMode: 'NOT_A_LAYOUT' } }],
+    ['wrapped', { payload: { ...valid(), rootNode: { type: 'FRAME', name: 'bad', counterAxisSpacing: {} } } }],
+  ])('refuses malformed %s input before forwarding to parent', (_label, params) => {
+    const forward = vi.fn();
+    expect(() => forwardValidatedDirectImport({
+      requestId: 'direct-bad', expectedFile: 'Landing', params,
+    }, forward)).toThrowError(expect.objectContaining({ code: 'E_INVALID_ARGS' }));
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['direct', { ...valid(), tokens: { colors: [] }, x: 10, y: 20 }],
+    ['wrapped', {
+      payload: { ...valid(), tokens: { colors: [] } },
+      x: 10, y: 20, parentId: '1:2', replaceId: '1:3',
+    }],
+  ])('normalizes valid %s input and preserves correlation plus placement', (_label, params) => {
+    const forward = vi.fn();
+    forwardValidatedDirectImport({ requestId: 'direct-ok', expectedFile: 'Landing', params }, forward);
+    expect(forward).toHaveBeenCalledWith({
+      pluginMessage: {
+        requestId: 'direct-ok', cmd: 'IMPORT_PAYLOAD', expectedFile: 'Landing',
+        params: {
+          payload: { ...valid(), tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] } },
+          x: 10, y: 20, ...(_label === 'wrapped' ? { parentId: '1:2', replaceId: '1:3' } : {}),
+        },
+      },
+    });
+  });
+});
+
+describe('HTML render-result relay admission', () => {
+  it('does not forward malformed renderer output', () => {
+    const forward = vi.fn();
+    expect(() => forwardValidatedHtmlImport({
+      requestId: 'req-bad',
+      expectedFile: 'Landing',
+      payload: { ...valid(), rootNode: { type: 'FRAME', name: 'bad', layoutMode: 'NOT_A_LAYOUT' } },
+      placement: { x: 10, y: 20 },
+    }, forward)).toThrowError(expect.objectContaining({ code: 'E_INVALID_ARGS' }));
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it('preserves correlation and placement when forwarding admitted output', () => {
+    const forward = vi.fn();
+    forwardValidatedHtmlImport({
+      requestId: 'req-ok', expectedFile: 'Landing', payload: valid(),
+      placement: { x: 10, y: 20, parentId: '1:2', replaceId: '1:3' },
+    }, forward);
+    expect(forward).toHaveBeenCalledWith({
+      pluginMessage: {
+        requestId: 'req-ok', cmd: 'IMPORT_PAYLOAD', expectedFile: 'Landing',
+        params: { payload: valid(), x: 10, y: 20, parentId: '1:2', replaceId: '1:3' },
+      },
+    });
+  });
+
+  it('accepts actual converter output from repository-authored panel HTML before relaying it', async () => {
+    const page = await browser.newPage();
+    await page.setContent('<body style="background:#111"></body>');
+    await page.addScriptTag({ content: authoredHtmlBundle });
+    const result = await page.evaluate(async (html) => (
+      (window as typeof window & { __relayRepositoryHtml: (source: string) => Promise<Record<string, unknown>> })
+        .__relayRepositoryHtml(html)
+    ), repositoryPanelHtml);
+    const forwarded = result.forwarded as {
+      pluginMessage: { requestId: string; expectedFile: string; params: Record<string, unknown> };
+    };
+    console.info('repository-html converter measurement', {
+      serializedBytes: result.bytes,
+      corpus: 'repository-authored plugin/src/ui/panel.html',
+      figmaCorpus: 'absent',
+      stress: 'separate synthetic unit fixtures',
+    });
+    expect(forwarded.pluginMessage).toMatchObject({
+      requestId: 'repository-html', expectedFile: 'Plugin panel',
+      params: { x: 12, y: 24, payload: { version: 1, name: 'Repository panel' } },
+    });
+    expect(((forwarded.pluginMessage.params.payload as { rootNode: { children: unknown[] } }).rootNode.children).length).toBeGreaterThan(0);
+    expect(await page.locator('iframe').count()).toBe(0);
+    await page.close();
+  }, 30_000);
+});

--- a/tests/mirror-verify.test.ts
+++ b/tests/mirror-verify.test.ts
@@ -10,6 +10,7 @@ import { describe, it, expect } from 'vitest';
 import { parseArgs } from '../cli/src/arg-parse.ts';
 import { COMMAND_TIMEOUTS } from '../shared/protocol.ts';
 import { execute, normalizeForDiff } from '../cli/src/commands/mirror-verify.ts';
+import { validateImportPayload } from '../shared/figma-payload-validation.ts';
 
 interface Call { cmd: string; params: unknown; opts?: { timeoutMs?: number } }
 
@@ -39,7 +40,10 @@ function fakePlugin(specs: unknown[], calls: Call[], warnings: string[] = []) {
   const queue = [...specs];
   return async (cmd: string, params: unknown, opts?: { timeoutMs?: number }) => {
     calls.push({ cmd, params, opts });
-    if (cmd === 'IMPORT_PAYLOAD') return { id: '99:1', name: 'Card', warnings };
+    if (cmd === 'IMPORT_PAYLOAD') {
+      validateImportPayload(params);
+      return { id: '99:1', name: 'Card', warnings };
+    }
     const code = String((params as { code: string }).code);
     if (code.includes('.remove()')) return execJsReply({ removed: true });
     return execJsReply(queue.shift());

--- a/tests/scan-node-fixed-point.test.ts
+++ b/tests/scan-node-fixed-point.test.ts
@@ -39,6 +39,7 @@ import {
 import { structuralDiff } from '../cli/src/util/structural-diff.ts';
 import { getImportWarnings, resetImportWarnings } from '../plugin/src/main/executor-styles.ts';
 import type { FigmaExportNode } from '../shared/figma-payload-types.ts';
+import { validateImportPayload } from '../shared/figma-payload-validation.ts';
 import type { ScannedNode } from '../plugin/src/main/scan-node.ts';
 
 // Install the mock BEFORE any builder call (executors read `figma` at call time).
@@ -81,6 +82,16 @@ async function build(spec: FigmaExportNode, vars?: Vars, tokenNames = namesOf(va
  */
 async function roundTrips(spec0: FigmaExportNode, vars?: Vars): Promise<[ScannedNode, ScannedNode]> {
   const spec1 = await build(spec0, vars);
+  validateImportPayload({
+    payload: {
+      version: 1,
+      name: spec1.name,
+      width: spec1.width ?? 0,
+      height: spec1.height ?? 0,
+      tokens: { colors: [], typography: [], spacing: [], radii: [], shadows: [] },
+      rootNode: spec1,
+    },
+  });
   const spec2 = await build(spec1, vars);
   return [spec1, spec2];
 }
@@ -119,6 +130,12 @@ describe('fixed point — auto-layout FRAME with text children', () => {
 
   it('reaches a fixed point (spec1 === spec2)', async () => {
     const [spec1, spec2] = await roundTrips(card);
+    expectFixedPoint(spec1, spec2);
+  });
+
+  it('preserves source-supported negative overlap spacing through scan and admission', async () => {
+    const [spec1, spec2] = await roundTrips({ ...card, itemSpacing: -8 });
+    expect(spec1.itemSpacing).toBe(-8);
     expectFixedPoint(spec1, spec2);
   });
 


### PR DESCRIPTION
Validate direct imports and HTML converter results before forwarding to main, and validate again before creating Figma styles, variables or nodes. The parser bounds traversal and payload fields, rejects malformed data and enumerable array sidecars, and preserves current scanner metadata, overlapping layouts, image producer sizes and legacy token normalization.

Admission failures retain `E_INVALID_ARGS` and request correlation through the actual UI relay. Both committed plugin artifacts are regenerated, and the operations reference documents the input contract and limits.

Validation: 2,589 tests passed, including real browser relay regressions and scanner/mirror compatibility; typecheck, build, comment lint, artifact freshness and independent review passed. Renderer origin isolation is tracked separately in #133; this change does not claim live Figma or large-user-corpus qualification.

Closes #128.
