### PR TITLE
fix(transport): acquire private runtime snapshots exclusively

### DIFF
--- a/cli/src/transport/broker-discovery.ts
+++ b/cli/src/transport/broker-discovery.ts
@@ -4,7 +4,7 @@
 // polling until advertised.
 import { spawn } from 'node:child_process';
 import { dirname, basename, join } from 'node:path';
-import { readdirSync, readFileSync, renameSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, renameSync, statSync, unlinkSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import WebSocket from 'ws';
 import {
@@ -17,6 +17,7 @@ import {
 } from '../../../shared/protocol.ts';
 import { CliError, envMs } from './protocol-helpers.ts';
 import { safeCleanup } from '../../../shared/safe-cleanup.ts';
+import { writePrivateFileExclusive } from './private-file-write.ts';
 
 // Mirrors broker-daemon.ts's own `HEARTBEAT_MS` override (same env var, same
 // fallback) — see envMs's doc for why this must be the ONE shared reader, not a
@@ -102,8 +103,8 @@ export function isAdvertisementLive(ad: BrokerAdvertisement): boolean {
  */
 function writeFileAtomic(path: string, contents: string): void {
   const tmpPath = `${path}.${process.pid}.tmp`;
+  writePrivateFileExclusive(tmpPath, contents);
   try {
-    writeFileSync(tmpPath, contents);
     renameSync(tmpPath, path);
   } catch (err) {
     // Best-effort temp-file removal on failure (issue #24: routed through the

--- a/cli/src/transport/last-plugins-log.ts
+++ b/cli/src/transport/last-plugins-log.ts
@@ -11,8 +11,9 @@
 // `toAwaitingReconnectStatus`'s own doc). A JSON snapshot, not an append-only log (unlike
 // contention-log.ts/error-log.ts): only the LATEST live set matters here, never history —
 // same "near-copy, deliberately separate" contract as those two, not a shared util.
-import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, renameSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { writePrivateFileExclusive } from './private-file-write.ts';
 
 export const LAST_PLUGINS_FILENAME = 'last-plugins.json';
 
@@ -85,7 +86,7 @@ export function readLastPlugins(path: string): LastPluginRecord[] {
 export function writeLastPluginsAtomic(path: string, records: readonly LastPluginRecord[]): void {
   mkdirSync(dirname(path), { recursive: true });
   const tmpPath = `${path}.${process.pid}.tmp`;
-  writeFileSync(tmpPath, JSON.stringify(records));
+  writePrivateFileExclusive(tmpPath, JSON.stringify(records));
   try {
     renameSync(tmpPath, path);
   } catch (err) {

--- a/cli/src/transport/mutation-admission-gate.ts
+++ b/cli/src/transport/mutation-admission-gate.ts
@@ -1,7 +1,8 @@
-import { mkdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, renameSync, unlinkSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import type { ErrorCode, MutationGateRow, MutationGateState, MutationGateStoreHealth } from '../../../shared/protocol.ts';
 import { durableFileKey } from './file-identity.ts';
+import { writePrivateFileExclusive } from './private-file-write.ts';
 
 export const MUTATION_GATE_FILENAME = 'mutation-gates.json';
 const SCHEMA_VERSION = 1;
@@ -70,7 +71,7 @@ export class MutationAdmissionGate {
 
   constructor(readonly path: string, options: MutationAdmissionGateOptions = {}) {
     this.now = options.now ?? Date.now;
-    this.writeFile = options.writeFile ?? ((path, data) => writeFileSync(path, data, 'utf8'));
+    this.writeFile = options.writeFile ?? writePrivateFileExclusive;
     this.rename = options.rename ?? renameSync;
   }
 
@@ -129,12 +130,16 @@ export class MutationAdmissionGate {
     const next: PersistedSnapshot = { schemaVersion: SCHEMA_VERSION, sequence, gates,
       latestTransition: { fileKey: rawKey, from: previous.state, to: state, at: this.now(), revision: sequence } };
     const tmpPath = `${this.path}.${process.pid}.${Date.now()}.tmp`;
+    let written = false;
     try {
       mkdirSync(dirname(this.path), { recursive: true });
       this.writeFile(tmpPath, JSON.stringify(next));
+      written = true;
       this.rename(tmpPath, this.path);
     } catch (err) {
-      try { unlinkSync(tmpPath); } catch { /* evidence remains in the prior atomic target */ }
+      if (written) {
+        try { unlinkSync(tmpPath); } catch { /* evidence remains in the prior atomic target */ }
+      }
       return this.unavailable((err as Error).message, rawKey, previous.lastTransitionRevision) as MutationGateTransition;
     }
     return { ok: true, fileKey: rawKey, state, previousState: previous.state, lastTransitionRevision: sequence, sequence, health: this.health('healthy') };

--- a/cli/src/transport/private-file-write.ts
+++ b/cli/src/transport/private-file-write.ts
@@ -1,0 +1,20 @@
+import { closeSync, openSync, unlinkSync, writeFileSync } from 'node:fs';
+import { safeCleanup } from '../../../shared/safe-cleanup.ts';
+
+/** Acquire a new private file without following or removing an existing path. */
+export function writePrivateFileExclusive(path: string, contents: string): void {
+  // Open outside cleanup: a failed acquisition gives us no ownership of this path.
+  const fd = openSync(path, 'wx', 0o600);
+  try {
+    writeFileSync(fd, contents, 'utf8');
+  } catch (err) {
+    safeCleanup(err, () => {
+      try { closeSync(fd); } finally { unlinkSync(path); }
+    });
+  }
+  try {
+    closeSync(fd);
+  } catch (err) {
+    safeCleanup(err, () => unlinkSync(path));
+  }
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -108,6 +108,19 @@ separate headroom for the existing 8 MiB image producer's base64 output. These a
 budgets bound validation and forwarding; they do not isolate arbitrary renderer JavaScript
 or establish a whole-process memory limit.
 
+## Runtime snapshot writes
+
+Advertisement, last-plugin and mutation-gate snapshots acquire temporary files exclusively,
+write them with owner-only permissions (`0600`), and rename only after closing the write.
+An existing temporary path is refused without following a symlink or deleting the collision;
+a failed replacement keeps the prior complete snapshot. Mutation-gate write failures continue
+to refuse mutations. The implementation is shared in
+[`private-file-write.ts`](../cli/src/transport/private-file-write.ts).
+
+This protects these snapshot writes on the local filesystem. Runtime locations are unchanged;
+other logs, existing-state reads and processes running as the same OS user require separate
+controls. File permissions do not authenticate broker clients.
+
 ## Troubleshooting
 
 - **Panel says "No broker yet" and never connects** — that's the resting state; it only connects once a CLI

--- a/tests/broker-advertisement-atomic.test.ts
+++ b/tests/broker-advertisement-atomic.test.ts
@@ -8,7 +8,7 @@
 // down a perfectly healthy broker.
 //
 // This test is white-box on purpose: it asserts the fs call SEQUENCE
-// (writeFileSync on a temp path, THEN renameSync onto the real path), which is the
+// (exclusive open of a temp path, descriptor write, THEN rename onto the target), which is the
 // only way to observe atomicity without a real concurrent-reader race. Against
 // pre-fix code (a bare `writeFileSync(path, …)`), `renameSync` is never called and
 // `writeFileSync` targets `path` directly — this test fails there.
@@ -25,6 +25,8 @@ import { join } from 'node:path';
 import type { BrokerAdvertisement } from '../shared/protocol.ts';
 
 const fsSpies = vi.hoisted(() => ({
+  sequence: [] as string[],
+  openSync: vi.fn(),
   writeFileSync: vi.fn(),
   renameSync: vi.fn(),
 }));
@@ -33,11 +35,24 @@ vi.mock('node:fs', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs')>();
   return {
     ...actual,
+    openSync: (...args: Parameters<typeof actual.openSync>) => {
+      const fd = actual.openSync(...args);
+      fsSpies.sequence.push('open');
+      fsSpies.openSync(...args, fd);
+      return fd;
+    },
     writeFileSync: (...args: Parameters<typeof actual.writeFileSync>) => {
+      fsSpies.sequence.push('write');
       fsSpies.writeFileSync(...args);
       return actual.writeFileSync(...args);
     },
+    closeSync: (...args: Parameters<typeof actual.closeSync>) => {
+      const result = actual.closeSync(...args);
+      fsSpies.sequence.push('close');
+      return result;
+    },
     renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+      fsSpies.sequence.push('rename');
       fsSpies.renameSync(...args);
       return actual.renameSync(...args);
     },
@@ -56,6 +71,8 @@ let advertisePath: string;
 beforeEach(() => {
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-advertise-atomic-'));
   advertisePath = join(scratchDir, 'broker.json');
+  fsSpies.openSync.mockClear();
+  fsSpies.sequence.length = 0;
   fsSpies.writeFileSync.mockClear();
   fsSpies.renameSync.mockClear();
 });
@@ -69,7 +86,12 @@ describe('writeAdvertisement — atomic temp-file + rename', () => {
     writeAdvertisement(9410, Date.now(), advertisePath);
 
     expect(fsSpies.writeFileSync).toHaveBeenCalledTimes(1);
-    const [writtenPath] = fsSpies.writeFileSync.mock.calls[0]!;
+    const [writtenFd] = fsSpies.writeFileSync.mock.calls[0]!;
+    expect(fsSpies.openSync).toHaveBeenCalledTimes(1);
+    const [writtenPath, flag, mode, openedFd] = fsSpies.openSync.mock.calls[0]!;
+    expect(flag).toBe('wx');
+    expect(mode).toBe(0o600);
+    expect(writtenFd).toBe(openedFd);
     expect(writtenPath).not.toBe(advertisePath); // never a direct truncating write onto the real file
     expect(String(writtenPath)).toMatch(new RegExp(`^${advertisePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\.\\d+\\.tmp$`));
 
@@ -77,6 +99,7 @@ describe('writeAdvertisement — atomic temp-file + rename', () => {
     const [fromPath, toPath] = fsSpies.renameSync.mock.calls[0]!;
     expect(fromPath).toBe(writtenPath); // renames the SAME temp file it just wrote
     expect(toPath).toBe(advertisePath);
+    expect(fsSpies.sequence).toEqual(['open', 'write', 'close', 'rename']);
 
     // The temp file must be gone (renamed away) — only the real target remains.
     expect(existsSync(String(writtenPath))).toBe(false);

--- a/tests/private-file-write.test.ts
+++ b/tests/private-file-write.test.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, fstatSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const faults = vi.hoisted(() => ({
+  write: null as Error | null,
+  close: null as Error | null,
+  rename: null as Error | null,
+  descriptors: [] as number[],
+}));
+vi.mock('node:fs', async (original) => {
+  const fs = await original<typeof import('node:fs')>();
+  return {
+    ...fs,
+    openSync: (...args: Parameters<typeof fs.openSync>) => {
+      const fd = fs.openSync(...args);
+      if (args[1] === 'wx') faults.descriptors.push(fd);
+      return fd;
+    },
+    writeFileSync: (...args: Parameters<typeof fs.writeFileSync>) => {
+      if (faults.write && typeof args[0] === 'number') {
+        fs.writeSync(args[0], 'partial');
+        throw faults.write;
+      }
+      return fs.writeFileSync(...args);
+    },
+    closeSync: (fd: number) => {
+      fs.closeSync(fd);
+      if (faults.close) throw faults.close;
+    },
+    renameSync: (...args: Parameters<typeof fs.renameSync>) => {
+      if (faults.rename) throw faults.rename;
+      return fs.renameSync(...args);
+    },
+  };
+});
+import { writePrivateFileExclusive } from '../cli/src/transport/private-file-write.ts';
+import { writeAdvertisement } from '../cli/src/transport/broker-discovery.ts';
+import { writeLastPluginsAtomic } from '../cli/src/transport/last-plugins-log.ts';
+import { MutationAdmissionGate } from '../cli/src/transport/mutation-admission-gate.ts';
+
+const fixtures: string[] = [];
+function fixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'fa-private-write-fault-'));
+  fixtures.push(dir);
+  return dir;
+}
+afterEach(() => {
+  faults.write = faults.close = faults.rename = null;
+  faults.descriptors.length = 0;
+  for (const dir of fixtures.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+function expectClosed(): void {
+  expect(faults.descriptors.length).toBeGreaterThan(0);
+  for (const fd of faults.descriptors) expect(() => fstatSync(fd)).toThrow();
+}
+
+describe('exclusive file ownership on I/O failure', () => {
+  it('removes a partial owned write and closes its descriptor while preserving the write error', () => {
+    const target = join(fixture(), 'temporary');
+    const failure = new Error('controlled disk full');
+    faults.write = failure;
+    expect(() => writePrivateFileExclusive(target, 'complete')).toThrow(failure);
+    expect(existsSync(target)).toBe(false);
+    expectClosed();
+  });
+
+  it('removes an owned temporary file when close reports an error', () => {
+    const target = join(fixture(), 'temporary');
+    const failure = new Error('controlled close failure');
+    faults.close = failure;
+    expect(() => writePrivateFileExclusive(target, 'complete')).toThrow(failure);
+    expect(existsSync(target)).toBe(false);
+    expectClosed();
+  });
+
+  it('preserves the write failure when cleanup also reports a close failure', () => {
+    const target = join(fixture(), 'temporary');
+    const failure = new Error('controlled write failure');
+    faults.write = failure;
+    faults.close = new Error('controlled cleanup close failure');
+    expect(() => writePrivateFileExclusive(target, 'complete')).toThrow(failure);
+    expect((failure as Error & { cleanupError?: unknown }).cleanupError).toBe(faults.close);
+    expect(existsSync(target)).toBe(false);
+    expectClosed();
+  });
+});
+
+for (const kind of ['advertisement', 'last plugins', 'mutation gate'] as const) {
+  it(`${kind} keeps its prior complete snapshot if rename fails`, () => {
+    const dir = fixture();
+    const target = join(dir, 'state.json');
+    const write = () => {
+      if (kind === 'advertisement') writeAdvertisement(12345, 1, target);
+      else if (kind === 'last plugins') writeLastPluginsAtomic(target, []);
+      else {
+        const result = new MutationAdmissionGate(target).transition('fixture-key', 'paused');
+        if (!result.ok) throw new Error(result.error.message);
+      }
+    };
+    write();
+    const before = readFileSync(target, 'utf8');
+    const failure = new Error('controlled rename failure');
+    faults.rename = failure;
+    expect(write).toThrow('controlled rename failure');
+    expect(readFileSync(target, 'utf8')).toBe(before);
+    expect(readdirSync(dir)).toEqual(['state.json']);
+    expectClosed();
+  });
+}

--- a/tests/private-runtime-writes.test.ts
+++ b/tests/private-runtime-writes.test.ts
@@ -1,0 +1,83 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { writeAdvertisement } from '../cli/src/transport/broker-discovery.ts';
+import { writeLastPluginsAtomic } from '../cli/src/transport/last-plugins-log.ts';
+import { MutationAdmissionGate } from '../cli/src/transport/mutation-admission-gate.ts';
+
+const fixtures: string[] = [];
+const fixedNow = 1788585900000;
+function fixture(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'fa-private-write-'));
+  fixtures.push(dir);
+  return dir;
+}
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const dir of fixtures.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+const writers = [
+  { name: 'advertisement', temporary: (target: string) => `${target}.${process.pid}.tmp`,
+    write: (target: string) => writeAdvertisement(12345, fixedNow, target) },
+  { name: 'last plugin snapshot', temporary: (target: string) => `${target}.${process.pid}.tmp`,
+    write: (target: string) => writeLastPluginsAtomic(target, [{ instanceId: 'fixture', fileName: 'Fixture', lastSeenAt: fixedNow }]) },
+  { name: 'mutation gate', temporary: (target: string) => `${target}.${process.pid}.${fixedNow}.tmp`,
+    write: (target: string) => {
+      const result = new MutationAdmissionGate(target).transition('fixture-raw-key', 'paused');
+      if (!result.ok) throw new Error(result.error.code);
+    } },
+];
+
+for (const writer of writers) {
+  describe(writer.name, () => {
+    it('preserves a prior complete snapshot and an existing temporary collision', () => {
+      const dir = fixture();
+      const target = join(dir, 'state.json');
+      vi.spyOn(Date, 'now').mockReturnValue(fixedNow);
+      writer.write(target);
+      const before = readFileSync(target, 'utf8');
+      const temporary = writer.temporary(target);
+      writeFileSync(temporary, 'COLLISION');
+      expect(() => writer.write(target)).toThrow();
+      expect(readFileSync(target, 'utf8')).toBe(before);
+      expect(readFileSync(temporary, 'utf8')).toBe('COLLISION');
+    });
+
+    for (const kind of ['file', 'symlink', 'dangling symlink', 'directory'] as const) {
+      it(`refuses a pre-existing temporary ${kind} without touching it or another file`, () => {
+        const dir = fixture();
+        const target = join(dir, 'state.json');
+        const victim = join(dir, 'owned-sentinel.txt');
+        const temporary = writer.temporary(target);
+        writeFileSync(victim, 'KEEP');
+        if (kind === 'file') writeFileSync(temporary, 'COLLISION');
+        else if (kind === 'directory') mkdirSync(temporary);
+        else symlinkSync(kind === 'symlink' ? victim : join(dir, 'absent.txt'), temporary);
+        vi.spyOn(Date, 'now').mockReturnValue(fixedNow);
+        expect(() => writer.write(target)).toThrow();
+        expect(readFileSync(victim, 'utf8')).toBe('KEEP');
+        expect(existsSync(target)).toBe(false);
+        expect(existsSync(join(dir, 'absent.txt'))).toBe(false);
+        const entry = lstatSync(temporary);
+        expect(entry.isSymbolicLink()).toBe(kind.includes('symlink'));
+        if (kind === 'file') expect(readFileSync(temporary, 'utf8')).toBe('COLLISION');
+      });
+    }
+
+    it('creates and replaces a complete owner-only regular file without temporary residue', () => {
+      const dir = fixture();
+      const target = join(dir, 'state.json');
+      vi.spyOn(Date, 'now').mockReturnValue(fixedNow);
+      const priorMask = process.umask(0);
+      try { writer.write(target); } finally { process.umask(priorMask); }
+      expect(() => JSON.parse(readFileSync(target, 'utf8'))).not.toThrow();
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+      chmodSync(target, 0o644);
+      writer.write(target);
+      expect(statSync(target).mode & 0o777).toBe(0o600);
+      expect(lstatSync(target).isFile()).toBe(true);
+      expect(readdirSync(dir)).toEqual(['state.json']);
+    });
+  });
+}


### PR DESCRIPTION
Create broker advertisement, last-plugin and mutation-gate temporary files with exclusive descriptor access and mode `0600`. A pre-existing file or symlink now refuses the write instead of truncating a referenced file; successful writes still close before atomic rename. Failed acquisition leaves the collision intact, and failure cleanup removes only a temporary file acquired by the current write.

Real-filesystem regressions cover regular files, directories, symlinks and dangling symlinks, existing-target preservation, permissive umask, partial-write and close failures, and rename failure. The independent review reproduced 77 focused tests. The final controller checks passed all 2,619 tests, typecheck, build and comment lint; generated plugin artifacts are unchanged.

This repair covers the three snapshot writers. Existing parent-directory permissions, read integrity and other runtime stores remain separate work.

Closes #141.
