### PR TITLE
fix(sync): bound reconcile children and preserve uncertain outcomes

### DIFF
--- a/cli/src/transport/bounded-child-output-buffer.ts
+++ b/cli/src/transport/bounded-child-output-buffer.ts
@@ -1,0 +1,104 @@
+import { StringDecoder } from 'node:string_decoder';
+
+export interface BoundedOutputSnapshot {
+  text: string;
+  totalBytes: number;
+  retainedBytes: number;
+  truncated: boolean;
+}
+
+type RetentionMode = 'prefix' | 'head-tail';
+
+/** Omit an incomplete trailing code point without inventing a replacement character. */
+function completePrefix(buffer: Buffer): string {
+  return new StringDecoder('utf8').write(buffer);
+}
+
+function completeTail(buffer: Buffer): string {
+  let start = 0;
+  while (start < buffer.length && (buffer[start]! & 0xc0) === 0x80) start++;
+  return buffer.subarray(start).toString('utf8');
+}
+
+function bytes(chunk: unknown): Buffer {
+  if (Buffer.isBuffer(chunk)) return chunk;
+  if (typeof chunk === 'string') return Buffer.from(chunk);
+  return Buffer.from(String(chunk));
+}
+
+/** Retain either a prefix or non-overlapping head/tail while counting every drained byte. */
+export class BoundedOutputBuffer {
+  private totalBytes = 0;
+  private retainedBytes = 0;
+  private truncated = false;
+  private readonly prefix: Buffer[] = [];
+  private head = Buffer.alloc(0);
+  private tail = Buffer.alloc(0);
+
+  constructor(private readonly limit: number, private readonly mode: RetentionMode) {}
+
+  push(chunk: unknown): void {
+    const buffer = bytes(chunk);
+    const nextBytes = this.totalBytes + buffer.length;
+    if (this.mode === 'prefix') {
+      const available = Math.max(0, this.limit - this.retainedBytes);
+      if (available > 0) {
+        const retained = Buffer.from(buffer.subarray(0, available));
+        this.prefix.push(retained);
+        this.retainedBytes += retained.length;
+      }
+      this.totalBytes = nextBytes;
+      this.truncated = nextBytes > this.limit;
+      return;
+    }
+
+    const headBytes = Math.ceil(this.limit / 2);
+    const tailBytes = Math.floor(this.limit / 2);
+    if (!this.truncated && nextBytes <= this.limit) {
+      const retained = Buffer.from(buffer);
+      this.prefix.push(retained);
+      this.retainedBytes += retained.length;
+    } else if (!this.truncated) {
+      const previous = Buffer.concat(this.prefix);
+      const neededHead = Math.max(0, headBytes - previous.length);
+      this.head = previous.length >= headBytes
+        ? Buffer.from(previous.subarray(0, headBytes))
+        : Buffer.concat([previous, Buffer.from(buffer.subarray(0, neededHead))]);
+      if (tailBytes > 0) {
+        this.tail = buffer.length >= tailBytes
+          ? Buffer.from(buffer.subarray(buffer.length - tailBytes))
+          : Buffer.concat([previous.subarray(Math.max(0, previous.length - (tailBytes - buffer.length))), buffer]);
+      }
+      this.prefix.length = 0;
+      this.retainedBytes = this.head.length + this.tail.length;
+      this.truncated = true;
+    } else if (tailBytes > 0) {
+      if (buffer.length >= tailBytes) {
+        this.tail = Buffer.from(buffer.subarray(buffer.length - tailBytes));
+      } else {
+        const combined = Buffer.concat([this.tail, buffer]);
+        this.tail = Buffer.from(combined.subarray(Math.max(0, combined.length - tailBytes)));
+      }
+    }
+    this.totalBytes = nextBytes;
+  }
+
+  snapshot(): BoundedOutputSnapshot {
+    const text = this.truncated && this.mode === 'head-tail'
+      ? completePrefix(this.head) + completeTail(this.tail)
+      : this.truncated
+        ? completePrefix(Buffer.concat(this.prefix))
+        : Buffer.concat(this.prefix).toString('utf8');
+    // Invalid source bytes may expand to UTF-8 replacement characters when decoded.
+    const decodingTruncated = Buffer.byteLength(text) > this.limit;
+    const boundedText = decodingTruncated
+      ? completePrefix(Buffer.from(text).subarray(0, this.limit))
+      : text;
+    return {
+      text: boundedText,
+      totalBytes: this.totalBytes,
+      retainedBytes: this.retainedBytes,
+      truncated: this.truncated || decodingTruncated,
+    };
+  }
+}

--- a/cli/src/transport/bounded-child-process.ts
+++ b/cli/src/transport/bounded-child-process.ts
@@ -1,0 +1,159 @@
+import { spawn } from 'node:child_process';
+import { BoundedOutputBuffer } from './bounded-child-output-buffer.ts';
+
+export interface ChildBounds {
+  stdoutBytes: number;
+  stderrBytes: number;
+  deadlineMs: number;
+  termGraceMs: number;
+  closeGraceMs: number;
+  reapGraceMs: number;
+}
+
+export interface ChildOutcome {
+  spawned: boolean;
+  exited: boolean;
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  stdout: string;
+  stdoutBytes: number;
+  stdoutTruncated: boolean;
+  stderr: string;
+  stderrBytes: number;
+  stderrRetainedBytes: number;
+  stderrTruncated: boolean;
+  launchError?: string;
+  launchErrorKind?: 'throw' | 'error';
+}
+
+export const RECONCILE_CHILD_BOUNDS: Readonly<ChildBounds> = Object.freeze({
+  stdoutBytes: 128 * 1024 * 1024,
+  stderrBytes: 1024 * 1024,
+  deadlineMs: 120_000,
+  termGraceMs: 2_000,
+  closeGraceMs: 1_000,
+  reapGraceMs: 5_000,
+});
+
+interface RunOptions {
+  cwd?: string;
+  bounds?: Readonly<ChildBounds>;
+}
+
+function ignoreLateChildError(): void { /* exit evidence already settled the result */ }
+
+/** Spawn one child with independently bounded output and exit-evidenced settlement. */
+export function runBoundedChild(
+  command: string,
+  args: readonly string[],
+  options: RunOptions,
+  done: (outcome: ChildOutcome) => void,
+): void {
+  const bounds = options.bounds ?? RECONCILE_CHILD_BOUNDS;
+  let child: ReturnType<typeof spawn>;
+  try {
+    child = spawn(command, [...args], {
+      cwd: options.cwd,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+  } catch (error) {
+    done(emptyOutcome((error as Error).message, 'throw'));
+    return;
+  }
+
+  let settled = false;
+  let spawned = false;
+  let exited = false;
+  let exitCode: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let timedOut = false;
+  let launchError: string | undefined;
+  let launchErrorKind: 'throw' | 'error' | undefined;
+  const stdoutBuffer = new BoundedOutputBuffer(bounds.stdoutBytes, 'prefix');
+  const stderrBuffer = new BoundedOutputBuffer(bounds.stderrBytes, 'head-tail');
+  let deadlineTimer: ReturnType<typeof setTimeout> | null = null;
+  let termTimer: ReturnType<typeof setTimeout> | null = null;
+  let closeTimer: ReturnType<typeof setTimeout> | null = null;
+  let reapTimer: ReturnType<typeof setTimeout> | null = null;
+
+  const clearTimers = (): void => {
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+    if (termTimer) clearTimeout(termTimer);
+    if (closeTimer) clearTimeout(closeTimer);
+    if (reapTimer) clearTimeout(reapTimer);
+    deadlineTimer = termTimer = closeTimer = reapTimer = null;
+  };
+  const onStdout = (chunk: unknown): void => stdoutBuffer.push(chunk);
+  const onStderr = (chunk: unknown): void => stderrBuffer.push(chunk);
+  const onSpawn = (): void => { spawned = true; };
+  const onError = (error: Error): void => {
+    launchError ??= error.message;
+    launchErrorKind ??= 'error';
+    if (!spawned) settle();
+  };
+  const onExit = (code: number | null, childSignal: NodeJS.Signals | null): void => {
+    exited = true;
+    exitCode = code ?? null;
+    signal = childSignal ?? null;
+    if (deadlineTimer) clearTimeout(deadlineTimer);
+    if (termTimer) clearTimeout(termTimer);
+    if (reapTimer) clearTimeout(reapTimer);
+    deadlineTimer = termTimer = reapTimer = null;
+    closeTimer = setTimeout(settle, bounds.closeGraceMs);
+  };
+  const onClose = (code: number | null, childSignal: NodeJS.Signals | null): void => {
+    if (!launchError && !spawned) spawned = true;
+    exited = true;
+    exitCode ??= code ?? null;
+    signal ??= childSignal ?? null;
+    settle();
+  };
+  function settle(): void {
+    if (settled) return;
+    settled = true;
+    clearTimers();
+    child.off('spawn', onSpawn);
+    child.off('exit', onExit);
+    child.off('close', onClose);
+    child.stdout?.off('data', onStdout);
+    child.stderr?.off('data', onStderr);
+    child.off('error', onError);
+    child.on('error', ignoreLateChildError);
+    const stdout = stdoutBuffer.snapshot();
+    const stderr = stderrBuffer.snapshot();
+    done({
+      spawned, exited, exitCode, signal, timedOut,
+      stdout: stdout.text, stdoutBytes: stdout.totalBytes, stdoutTruncated: stdout.truncated,
+      stderr: stderr.text, stderrBytes: stderr.totalBytes,
+      stderrRetainedBytes: stderr.retainedBytes, stderrTruncated: stderr.truncated,
+      ...(launchError ? { launchError, launchErrorKind } : {}),
+    });
+  }
+
+  child.stdout?.on('data', onStdout);
+  child.stderr?.on('data', onStderr);
+  child.on('spawn', onSpawn);
+  child.on('error', onError);
+  child.on('exit', onExit);
+  child.on('close', onClose);
+  deadlineTimer = setTimeout(() => {
+    if (exited || settled) return;
+    timedOut = true;
+    try { child.kill('SIGTERM'); } catch { /* absence of signal delivery is not exit evidence */ }
+    termTimer = setTimeout(() => {
+      if (exited || settled) return;
+      try { child.kill('SIGKILL'); } catch { /* reap grace still bounds the reply */ }
+      reapTimer = setTimeout(settle, bounds.reapGraceMs);
+    }, bounds.termGraceMs);
+  }, bounds.deadlineMs);
+}
+
+function emptyOutcome(launchError: string, launchErrorKind: 'throw'): ChildOutcome {
+  return {
+    spawned: false, exited: false, exitCode: null, signal: null, timedOut: false,
+    stdout: '', stdoutBytes: 0, stdoutTruncated: false,
+    stderr: '', stderrBytes: 0, stderrRetainedBytes: 0, stderrTruncated: false,
+    launchError, launchErrorKind,
+  };
+}

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -749,7 +749,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // file's own targets in a change-log the project may share with another file; `fileName`
     // (nullable → undefined) pins the live scan back to the SAME plugin instance.
     spawnReconcileApply(bound, slug, fileName ?? undefined, (r) => {
-      syncInFlight = false;
+      if (r.childExited === false) {
+        log(`sync lane HELD — reconcile child not confirmed dead: ${r.summary}`);
+      } else {
+        syncInFlight = false;
+      }
       log(`SYNC_RESULT ok=${r.ok} — ${r.summary}`);
       sendEvent(ws, 'SYNC_RESULT', { ...r });
     });

--- a/cli/src/transport/figma-sync-apply.ts
+++ b/cli/src/transport/figma-sync-apply.ts
@@ -16,7 +16,6 @@
 //
 // Best-effort + debounced: a spawn failure (no `ui` on PATH) is reported back, never
 // thrown; a second click while one apply is in flight is ignored (broker-daemon).
-import { spawn } from 'node:child_process';
 import { rmSync } from 'node:fs';
 import { dirname } from 'node:path';
 import {
@@ -29,6 +28,27 @@ import {
 import {
   captureMirror, mergeTargetsPendingFirst, pendingTargetsFromEnvelope, targetsFromDelta,
 } from './figma-mirror-capture-run.ts';
+import {
+  RECONCILE_CHILD_BOUNDS,
+  runBoundedChild,
+  type ChildBounds,
+  type ChildOutcome,
+} from './bounded-child-process.ts';
+
+interface SyncApplyEvidence {
+  phase: 'dry' | 'apply';
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  timedOut: boolean;
+  stdoutBytes: number;
+  stdoutTruncated: boolean;
+  stderrBytes: number;
+  stderrTruncated: boolean;
+  stderrExcerpt?: string;
+  envelopeParsed: boolean;
+  capturePath?: string;
+  captureCleanupError?: string;
+}
 
 /** Outcome the broker sends back to the plugin as SYNC_RESULT.data. */
 export interface SyncApplyResult {
@@ -40,6 +60,9 @@ export interface SyncApplyResult {
   /** The kernel's apply report when it succeeded. */
   applied?: unknown;
   code?: string;
+  /** Present only when a child started but direct-process exit was never confirmed. */
+  childExited?: false;
+  evidence?: SyncApplyEvidence;
 }
 
 /** Resolve the `ui` kernel binary — env override (tests) → PATH lookup by name. */
@@ -51,46 +74,79 @@ function uiBin(): string {
 function runReconcile(
   projectDir: string,
   extra: string[],
-  done: (env: Record<string, unknown> | null, err: string, exit: number) => void,
+  bounds: Readonly<ChildBounds>,
+  done: (env: Record<string, unknown> | null, outcome: ChildOutcome) => void,
 ): void {
-  let settled = false;
-  const settle = (env: Record<string, unknown> | null, err: string, exit: number): void => {
-    if (settled) return;
-    settled = true;
-    done(env, err, exit);
-  };
-  let child;
-  try {
-    child = spawn(uiBin(), ['figma', 'reconcile', '--dir', projectDir, '--json', ...extra], {
-      cwd: projectDir,
-      stdio: ['ignore', 'pipe', 'pipe'],
-    });
-  } catch (err) {
-    settle(null, `could not launch ui: ${(err as Error).message}`, -1);
-    return;
-  }
-  let out = '';
-  let err = '';
-  child.stdout?.on('data', (d) => { out += String(d); });
-  child.stderr?.on('data', (d) => { err += String(d); });
-  child.on('error', (e) => settle(null, `ui not runnable: ${e.message} (is the kernel linked?)`, -1));
-  child.on('close', (exit) => {
-    let env: Record<string, unknown> | null = null;
-    try {
-      const parsed = JSON.parse(out.trim());
-      if (parsed && typeof parsed === 'object') env = parsed as Record<string, unknown>;
-    } catch { /* non-JSON stdout — the exit-code path below reports it */ }
-    settle(env, err, exit ?? -1);
-  });
+  runBoundedChild(
+    uiBin(), ['figma', 'reconcile', '--dir', projectDir, '--json', ...extra],
+    { cwd: projectDir, bounds }, (outcome) => {
+      let env: Record<string, unknown> | null = null;
+      try {
+        const parsed = JSON.parse(outcome.stdout.trim());
+        if (parsed && typeof parsed === 'object') env = parsed as Record<string, unknown>;
+      } catch { /* non-JSON stdout — the exit-code path below reports it */ }
+      done(env, outcome);
+    },
+  );
 }
 
-/** Envelope → failure result (shared by both kernel steps). */
-function envelopeFailure(env: Record<string, unknown> | null, err: string, exit: number): SyncApplyResult {
+function evidence(
+  phase: 'dry' | 'apply', outcome: ChildOutcome, env: Record<string, unknown> | null,
+  capturePath?: string, captureCleanupError?: string,
+): SyncApplyEvidence {
+  return {
+    phase, exitCode: outcome.exitCode, signal: outcome.signal, timedOut: outcome.timedOut,
+    stdoutBytes: outcome.stdoutBytes, stdoutTruncated: outcome.stdoutTruncated,
+    stderrBytes: outcome.stderrBytes, stderrTruncated: outcome.stderrTruncated,
+    ...(outcome.stderr ? { stderrExcerpt: outcome.stderr } : {}),
+    envelopeParsed: env !== null, ...(capturePath ? { capturePath } : {}),
+    ...(captureCleanupError ? { captureCleanupError } : {}),
+  };
+}
+
+function failure(
+  phase: 'dry' | 'apply', outcome: ChildOutcome, env: Record<string, unknown> | null,
+  capturePath?: string,
+): SyncApplyResult | null {
+  const meta = evidence(phase, outcome, env, capturePath);
+  const suffix = capturePath ? ` Capture kept for inspection: ${capturePath}.` : '';
+  if (outcome.spawned && !outcome.exited) {
+    return { ok: false, code: 'RECONCILE_CHILD_UNKILLABLE', childExited: false, evidence: meta,
+      summary: `ui reconcile child exit not confirmed after SIGKILL.${suffix}` };
+  }
+  if (!outcome.spawned) {
+    const detail = outcome.launchError ?? 'unknown launch failure';
+    const summary = outcome.launchErrorKind === 'throw'
+      ? `could not launch ui: ${detail}`
+      : `ui not runnable: ${detail} (is the kernel linked?)`;
+    return { ok: false, summary, code: 'RECONCILE_FAILED', evidence: meta };
+  }
+  if (outcome.timedOut) {
+    if (phase === 'dry') return { ok: false, code: 'RECONCILE_DRY_TIMEOUT', evidence: meta, summary: 'reconcile preview timed out; apply was not started' };
+    return { ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN', evidence: meta,
+      summary: `apply outcome unknown after timeout; verify with ui figma reconcile --dry-run before retrying.${suffix}` };
+  }
+  if (outcome.stdoutTruncated) {
+    if (phase === 'dry') return { ok: false, code: 'RECONCILE_DRY_OUTPUT_OVERFLOW', evidence: meta, summary: 'reconcile preview output exceeded the bounded stdout limit; apply was not started' };
+    return { ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN', evidence: meta,
+      summary: `apply outcome unknown because stdout exceeded the bounded limit; verify with ui figma reconcile --dry-run before retrying.${suffix}` };
+  }
   if (env && env['ok'] === false && env['error'] && typeof env['error'] === 'object') {
     const e = env['error'] as { code?: unknown; message?: unknown };
-    return { ok: false, summary: String(e.message ?? 'reconcile failed'), code: String(e.code ?? 'RECONCILE_FAILED') };
+    return { ok: false, summary: `${String(e.message ?? 'reconcile failed')}${suffix}`, code: String(e.code ?? 'RECONCILE_FAILED'), evidence: meta };
   }
-  return { ok: false, summary: err.trim() || `ui exited ${exit}`, code: 'RECONCILE_FAILED' };
+  if (outcome.signal !== null || outcome.exitCode !== 0) {
+    const ended = outcome.signal !== null ? `ui killed by ${outcome.signal}` : `ui exited ${outcome.exitCode}`;
+    if (phase === 'dry') return { ok: false, summary: outcome.stderr.trim() || ended, code: 'RECONCILE_FAILED', evidence: meta };
+    return { ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN', evidence: meta,
+      summary: `apply outcome unknown: ${ended}; verify with ui figma reconcile --dry-run before retrying.${suffix}` };
+  }
+  if (envelopeData(env) === null) {
+    if (phase === 'dry') return { ok: false, summary: outcome.stderr.trim() || 'ui exited 0', code: 'RECONCILE_FAILED', evidence: meta };
+    return { ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN', evidence: meta,
+      summary: `apply outcome unknown: ui exited 0 without a valid success envelope; verify with ui figma reconcile --dry-run before retrying.${suffix}` };
+  }
+  return null;
 }
 
 function envelopeData(env: Record<string, unknown> | null): Record<string, unknown> | null {
@@ -116,34 +172,67 @@ export function spawnReconcileApply(
   fileSlug: string | undefined,
   fileName: string | undefined,
   done: (r: SyncApplyResult) => void,
+  bounds: Readonly<ChildBounds> = RECONCILE_CHILD_BOUNDS,
 ): void {
+  let settled = false;
+  const finish = (result: SyncApplyResult): void => {
+    if (settled) return;
+    settled = true;
+    done(result);
+  };
   const fileSlugArgs = fileSlug !== undefined ? ['--file-slug', fileSlug] : [];
-  runReconcile(projectDir, ['--dry-run', ...fileSlugArgs], (env, err, exit) => {
-    const data = envelopeData(env);
-    if (data === null) {
-      done(envelopeFailure(env, err, exit));
-      return;
-    }
+  runReconcile(projectDir, ['--dry-run', ...fileSlugArgs], bounds, (env, outcome) => {
+    const dryFailure = failure('dry', outcome, env);
+    if (dryFailure) { finish(dryFailure); return; }
+    const data = envelopeData(env)!;
     // Registry-integrity phase 02 (5.3), §4: the kernel's retry queue (`pending`) is
     // captured FIRST, or the same MAX_SCANS names win every run and the queue never
     // drains. Read from the SAME dry-run envelope `targetsFromDelta` already reads.
     const pendingFirst = pendingTargetsFromEnvelope(data);
     const targets = mergeTargetsPendingFirst(pendingFirst, targetsFromDelta(data));
-    void captureMirror(targets, fileName).then((cap) => {
+    void Promise.resolve().then(() => captureMirror(targets, fileName)).then((cap) => {
       const extra = ['--apply', ...fileSlugArgs, ...(cap.file !== undefined ? ['--mirror-file', cap.file] : [])];
-      runReconcile(projectDir, extra, (aEnv, aErr, aExit) => {
-        if (cap.file !== undefined) {
-          try { rmSync(dirname(cap.file), { recursive: true, force: true }); } catch { /* tmp — leave it */ }
-        }
-        const aData = envelopeData(aEnv);
-        if (aData === null) {
-          done(envelopeFailure(aEnv, aErr, aExit));
+      runReconcile(projectDir, extra, bounds, (aEnv, aOutcome) => {
+        const retainedPath = cap.file !== undefined && aOutcome.spawned ? cap.file : undefined;
+        const applyFailure = failure('apply', aOutcome, aEnv, retainedPath);
+        if (applyFailure) {
+          if (cap.file !== undefined && !aOutcome.spawned) {
+            const cleanupError = removeCapture(cap.file);
+            if (cleanupError) {
+              finish({
+                ...applyFailure,
+                summary: `${applyFailure.summary} Capture cleanup failed; kept for inspection: ${cap.file}.`,
+                evidence: evidence('apply', aOutcome, aEnv, cap.file, cleanupError),
+              });
+              return;
+            }
+          }
+          finish(applyFailure);
           return;
         }
-        done(applyResult(aData['apply'], cap.dropped));
+        const aData = envelopeData(aEnv)!;
+        const result = applyResult(aData['apply'], cap.dropped);
+        const cleanupError = cap.file !== undefined ? removeCapture(cap.file) : undefined;
+        finish({
+          ...result,
+          ...(cleanupError ? { summary: `${result.summary} — capture cleanup failed; kept for inspection: ${cap.file}` } : {}),
+          evidence: evidence('apply', aOutcome, aEnv, cleanupError ? cap.file : undefined, cleanupError),
+        });
       });
-    });
+    }).catch((error: unknown) => finish({
+      ok: false, code: 'RECONCILE_CAPTURE_FAILED',
+      summary: `could not prepare mirror capture: ${(error as Error).message}`,
+    }));
   });
+}
+
+function removeCapture(file: string): string | undefined {
+  try {
+    rmSync(dirname(file), { recursive: true, force: true });
+    return undefined;
+  } catch (error) {
+    return (error as Error).message;
+  }
 }
 
 /** Shape the panel-facing result from the kernel's apply report. */

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -71,8 +71,12 @@ Whatever the line had no room for stays readable in its tooltip. Full history li
 
 Pending edits show as a count badge on the sync button, and clicking it runs the sync; the result lands in
 the sentence. A failed or unbound sync keeps the button for the retry, and only a genuine success clears the
-count. Unresolved failures show as a red count next to the line; that count is the button that marks them
-seen, which clears it and the orb's *Needs attention*. Nothing is deleted — the failures stay in the edit
+count. An apply with unreliable completion evidence is reported as outcome unknown: its private temporary
+capture path remains available for inspection, and `ui figma reconcile --dry-run` must verify state before
+retry. If direct-child exit cannot be confirmed, the current broker keeps the sync lane closed. This hold
+does not survive broker restart; independently confirm that the child ended before restarting or retrying.
+Unresolved failures show as a red count next to the line; that count is
+the button that marks them seen, which clears it and the orb's *Needs attention*. Nothing is deleted — the failures stay in the edit
 feed and in `figma-agent errors` — and the next failure re-arms both. Every icon action is a locally
 vendored Lucide SVG with a tooltip, accessible name, keyboard focus, and a 32px target. The orb canvas is
 decorative; its labelled cell announces the semantic status (and carries the build identity in its tooltip),

--- a/tests/bounded-child-output-buffer.test.ts
+++ b/tests/bounded-child-output-buffer.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { BoundedOutputBuffer } from '../cli/src/transport/bounded-child-output-buffer.ts';
+
+describe('bounded diagnostic UTF-8 output', () => {
+  it('never joins disjoint byte fragments into an invented code point', () => {
+    const output = new BoundedOutputBuffer(4, 'head-tail');
+    output.push(Buffer.from('🙂€'));
+    const result = output.snapshot();
+    expect(result.text).toBe('');
+    expect(result.totalBytes).toBe(7);
+    expect(result.retainedBytes).toBe(4);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('retains complete characters on each side of a discarded middle', () => {
+    const output = new BoundedOutputBuffer(8, 'head-tail');
+    output.push(Buffer.from('é漢🙂a'));
+    expect(output.snapshot().text).toBe('éa');
+  });
+
+  it('decodes an untruncated code point split across incoming chunks', () => {
+    const output = new BoundedOutputBuffer(8, 'head-tail');
+    const bytes = Buffer.from('🙂€');
+    for (const byte of bytes) output.push(Buffer.from([byte]));
+    expect(output.snapshot().text).toBe('🙂€');
+  });
+
+  it.each(['prefix', 'head-tail'] as const)('bounds decoded %s bytes even for malformed UTF-8', (mode) => {
+    const output = new BoundedOutputBuffer(4, mode);
+    output.push(Buffer.from([255, 255, 255, 255, 255]));
+    const result = output.snapshot();
+    expect(Buffer.byteLength(result.text)).toBeLessThanOrEqual(4);
+    expect(result.retainedBytes).toBe(4);
+    expect(result.totalBytes).toBe(5);
+    expect(result.truncated).toBe(true);
+  });
+
+  it('reports truncation when decoding expansion requires clipping', () => {
+    const output = new BoundedOutputBuffer(4, 'head-tail');
+    output.push(Buffer.from([255, 255]));
+    const result = output.snapshot();
+    expect(Buffer.byteLength(result.text)).toBeLessThanOrEqual(4);
+    expect(result.totalBytes).toBe(2);
+    expect(result.truncated).toBe(true);
+  });
+});

--- a/tests/bounded-child-process.test.ts
+++ b/tests/bounded-child-process.test.ts
@@ -1,0 +1,224 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from 'node:events';
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { ChildBounds, ChildOutcome } from '../cli/src/transport/bounded-child-process.ts';
+
+type RunnerModule = typeof import('../cli/src/transport/bounded-child-process.ts');
+type FakeChild = EventEmitter & {
+  stdout: EventEmitter;
+  stderr: EventEmitter;
+  kill: ReturnType<typeof vi.fn>;
+};
+
+const spawnMock = vi.fn();
+const fixtureDirs: string[] = [];
+const fixturePids = new Set<number>();
+const fastBounds: ChildBounds = {
+  stdoutBytes: 64,
+  stderrBytes: 16,
+  deadlineMs: 80,
+  termGraceMs: 50,
+  closeGraceMs: 40,
+  reapGraceMs: 60,
+};
+const realChildBounds: ChildBounds = {
+  ...fastBounds,
+  deadlineMs: 2_500,
+  termGraceMs: 250,
+  closeGraceMs: 300,
+  reapGraceMs: 250,
+};
+
+function fakeChild(killResult = true): FakeChild {
+  const child = new EventEmitter() as FakeChild;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn(() => killResult);
+  return child;
+}
+
+async function loadWithSpawnMock(): Promise<RunnerModule> {
+  vi.resetModules();
+  vi.doMock('node:child_process', () => ({ spawn: spawnMock }));
+  return import('../cli/src/transport/bounded-child-process.ts');
+}
+
+async function loadWithRealSpawn(): Promise<RunnerModule> {
+  vi.resetModules();
+  vi.doUnmock('node:child_process');
+  return import('../cli/src/transport/bounded-child-process.ts');
+}
+
+function run(
+  mod: RunnerModule,
+  command: string,
+  args: string[] = [],
+  bounds: ChildBounds = fastBounds,
+): Promise<{ outcome: ChildOutcome; calls: number }> {
+  return new Promise((resolve) => {
+    let calls = 0;
+    let first: ChildOutcome | undefined;
+    mod.runBoundedChild(command, args, { bounds }, (outcome) => {
+      calls += 1;
+      first ??= outcome;
+      setImmediate(() => resolve({ outcome: first!, calls }));
+    });
+  });
+}
+
+function writeChild(source: string): { script: string; pidFile: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'bounded-child-'));
+  fixtureDirs.push(dir);
+  const script = join(dir, 'child');
+  const pidFile = join(dir, 'pid');
+  writeFileSync(script, `#!${process.execPath}\nrequire('node:fs').writeFileSync(${JSON.stringify(pidFile)},String(process.pid));\n${source}\n`);
+  chmodSync(script, 0o755);
+  return { script, pidFile };
+}
+
+function rememberPid(pidFile: string): number {
+  const pid = Number(readFileSync(pidFile, 'utf8'));
+  fixturePids.add(pid);
+  return pid;
+}
+
+afterEach(() => {
+  vi.doUnmock('node:child_process');
+  vi.resetModules();
+  spawnMock.mockReset();
+  for (const pid of fixturePids) {
+    try { process.kill(pid, 'SIGKILL'); } catch { /* already reaped */ }
+  }
+  fixturePids.clear();
+  for (const dir of fixtureDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('runBoundedChild', () => {
+  it('counts drained bytes, caps streams independently, and decodes split UTF-8 once', async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const resultPromise = run(await loadWithSpawnMock(), 'fake');
+    child.emit('spawn');
+    const utf8 = Buffer.from('Đèn');
+    child.stdout.emit('data', utf8.subarray(0, 1));
+    child.stdout.emit('data', Buffer.concat([utf8.subarray(1), Buffer.alloc(70, 97)]));
+    child.stderr.emit('data', Buffer.from('HEAD----middle----TAIL'));
+    child.emit('close', 0, null);
+
+    const { outcome } = await resultPromise;
+    expect(outcome).toMatchObject({ spawned: true, exited: true, exitCode: 0, stdoutBytes: 75, stdoutTruncated: true, stderrBytes: 22, stderrTruncated: true });
+    expect(outcome.stdout.startsWith('Đèn')).toBe(true);
+    expect(outcome.stderr).toBe('HEAD--------TAIL');
+    expect(Buffer.byteLength(outcome.stderr)).toBeLessThanOrEqual(fastBounds.stderrBytes);
+    expect(outcome).toMatchObject({ stderrRetainedBytes: fastBounds.stderrBytes });
+  });
+
+  it('preserves split UTF-8 stderr exactly when observed bytes fit the cap', async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const diagnostic = Buffer.from('Đèn sáng');
+    const resultPromise = run(await loadWithSpawnMock(), 'fake', [], {
+      ...fastBounds,
+      stderrBytes: diagnostic.length,
+    });
+    child.emit('spawn');
+    child.stderr.emit('data', diagnostic.subarray(0, 1));
+    child.stderr.emit('data', diagnostic.subarray(1));
+    child.emit('close', 0, null);
+
+    expect((await resultPromise).outcome).toMatchObject({
+      stderr: 'Đèn sáng',
+      stderrBytes: diagnostic.length,
+      stderrRetainedBytes: diagnostic.length,
+      stderrTruncated: false,
+    });
+  });
+
+  it('distinguishes a synchronous throw and pre-spawn error, settling each once', async () => {
+    spawnMock.mockImplementationOnce(() => { throw new Error('sync failure'); });
+    const thrown = await run(await loadWithSpawnMock(), 'fake');
+    expect(thrown).toMatchObject({ calls: 1, outcome: { spawned: false, exited: false, launchError: 'sync failure' } });
+
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const resultPromise = run(await loadWithSpawnMock(), 'fake');
+    child.emit('error', new Error('ENOENT'));
+    child.emit('close', -2, null);
+    child.emit('error', new Error('late error'));
+    const failed = await resultPromise;
+    expect(failed).toMatchObject({ calls: 1, outcome: { spawned: false, exited: false, launchError: 'ENOENT' } });
+  });
+
+  it('treats close as exit evidence when a test double omits exit and removes listeners', async () => {
+    const child = fakeChild();
+    spawnMock.mockReturnValue(child);
+    const resultPromise = run(await loadWithSpawnMock(), 'fake');
+    child.emit('spawn');
+    child.emit('close', 3, null);
+    const { outcome } = await resultPromise;
+    expect(outcome).toMatchObject({ spawned: true, exited: true, exitCode: 3 });
+    await new Promise((resolve) => setTimeout(resolve, fastBounds.deadlineMs + 10));
+    expect(child.kill).not.toHaveBeenCalled();
+    expect(() => child.emit('error', new Error('late after cleanup'))).not.toThrow();
+    expect(child.eventNames()).toEqual(['error']);
+    expect(child.stdout.eventNames()).toEqual([]);
+    expect(child.stderr.eventNames()).toEqual([]);
+  });
+
+  it('settles after exit when an inherited pipe prevents close', async () => {
+    const grandchildPidFile = join(mkdtempSync(join(tmpdir(), 'bounded-grandchild-')), 'pid');
+    fixtureDirs.push(join(grandchildPidFile, '..'));
+    const { script } = writeChild(`
+const {spawn}=require('node:child_process');
+const grandchild=spawn(process.execPath,['-e',${JSON.stringify(`require('node:fs').writeFileSync(${JSON.stringify(grandchildPidFile)},String(process.pid));setInterval(()=>{},1000)`)}],{stdio:['ignore',process.stdout,process.stderr]});
+grandchild.unref();
+grandchild.once('spawn',()=>process.exit(0));
+console.log('complete');
+`);
+    const startedAt = Date.now();
+    const { outcome } = await run(await loadWithRealSpawn(), script, [], realChildBounds);
+    fixturePids.add(Number(readFileSync(grandchildPidFile, 'utf8')));
+    expect(outcome).toMatchObject({ spawned: true, exited: true, exitCode: 0, stdout: 'complete\n' });
+    expect(Date.now() - startedAt).toBeLessThan(4_500);
+  });
+
+  it('times out and terminates a real child with TERM', async () => {
+    const term = writeChild('setInterval(()=>{},1000);');
+    const termOutcome = (await run(await loadWithRealSpawn(), term.script, [], realChildBounds)).outcome;
+    expect(termOutcome.launchError, JSON.stringify(termOutcome)).toBeUndefined();
+    expect(termOutcome, JSON.stringify(termOutcome)).toMatchObject({ spawned: true, timedOut: true, exited: true });
+    expect(existsSync(term.pidFile), JSON.stringify(termOutcome)).toBe(true);
+    const termPid = rememberPid(term.pidFile);
+    expect(termOutcome).toMatchObject({ timedOut: true, exited: true, signal: 'SIGTERM' });
+    expect(() => process.kill(termPid, 0)).toThrow();
+  });
+
+  it('escalates a real TERM-refusing child to KILL', async () => {
+    const readyDir = mkdtempSync(join(tmpdir(), 'bounded-child-ready-'));
+    fixtureDirs.push(readyDir);
+    const readyFile = join(readyDir, 'term-handler-ready');
+    const kill = writeChild(`process.on('SIGTERM',()=>{});require('node:fs').writeFileSync(${JSON.stringify(readyFile)},'ready');setInterval(()=>{},1000);`);
+    const killOutcome = (await run(await loadWithRealSpawn(), kill.script, [], realChildBounds)).outcome;
+    const killPid = rememberPid(kill.pidFile);
+    expect(existsSync(readyFile), JSON.stringify(killOutcome)).toBe(true);
+    expect(killOutcome).toMatchObject({ timedOut: true, exited: true, signal: 'SIGKILL' });
+    expect(() => process.kill(killPid, 0)).toThrow();
+  });
+
+  it('bounds an unkillable fake child even when kill reports false', async () => {
+    const child = fakeChild(false);
+    spawnMock.mockReturnValue(child);
+    const resultPromise = run(await loadWithSpawnMock(), 'fake');
+    child.emit('spawn');
+
+    const { outcome, calls } = await resultPromise;
+    expect(calls).toBe(1);
+    expect(outcome).toMatchObject({ spawned: true, exited: false, timedOut: true });
+    expect(child.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']]);
+    child.emit('close', 0, null);
+    expect(() => child.emit('error', new Error('late unconfirmed-child error'))).not.toThrow();
+    expect(child.eventNames()).toEqual(['error']);
+  });
+});

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -21,7 +21,7 @@
 // fresh via `vi.resetModules()` + dynamic `import()` AFTER setting env vars, guaranteeing
 // the constants observe this test's own values regardless of import order across the suite.
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import WebSocket from 'ws';
@@ -72,6 +72,7 @@ let scratchLogFile: string;
 let sockets: WebSocket[];
 let priorPluginWaitMs: string | undefined;
 let priorAppReadinessMs: string | undefined;
+let priorUiBin: string | undefined;
 
 /** Load `broker-daemon.ts` fresh, AFTER the given env vars are set — required for the
  *  module-load-time `envMs(...)` constants (see file header). */
@@ -313,6 +314,7 @@ async function bindProject(
 beforeEach(() => {
   priorPluginWaitMs = process.env[PLUGIN_WAIT_MS_KEY];
   priorAppReadinessMs = process.env[APP_READINESS_MS_KEY];
+  priorUiBin = process.env['FIGMA_AGENT_UI_BIN'];
   scratchDir = mkdtempSync(join(tmpdir(), 'fa-broker-harness-'));
   advertisePath = join(scratchDir, 'broker.json');
   scratchLogFile = join(scratchDir, 'broker.log');
@@ -335,6 +337,67 @@ afterEach(async () => {
   else process.env[PLUGIN_WAIT_MS_KEY] = priorPluginWaitMs;
   if (priorAppReadinessMs === undefined) delete process.env[APP_READINESS_MS_KEY];
   else process.env[APP_READINESS_MS_KEY] = priorAppReadinessMs;
+  if (priorUiBin === undefined) delete process.env['FIGMA_AGENT_UI_BIN'];
+  else process.env['FIGMA_AGENT_UI_BIN'] = priorUiBin;
+  vi.doUnmock('../cli/src/transport/figma-sync-apply.ts');
+});
+
+describe('daemon harness — reconcile child owns the sync lane until confirmed settlement', () => {
+  it('refuses an overlapping real SYNC_REQUEST and releases the lane after normal child exit', async () => {
+    vi.doUnmock('../cli/src/transport/figma-sync-apply.ts');
+    const kernel = join(scratchDir, 'controlled-reconcile');
+    const stages = join(scratchDir, 'controlled-reconcile-stages');
+    writeFileSync(kernel, `#!${process.execPath}\nconst fs=require('node:fs');const dry=process.argv.includes('--dry-run');fs.appendFileSync(${JSON.stringify(stages)},dry?'dry\\n':'apply\\n');const data=dry?{delta:{added:[],updated:[]},pending:[]}:{apply:{}};console.log(JSON.stringify({ok:true,data}));\n`);
+    chmodSync(kernel, 0o755);
+    process.env['FIGMA_AGENT_UI_BIN'] = kernel;
+    const projectDir = join(scratchDir, 'bound-project');
+    mkdirSync(join(projectDir, 'design'), { recursive: true });
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'sync-bounds-plugin', 'Sync Bounds File');
+    const cli = await connectSocket(port);
+    await bindProject(cli, 'Sync Bounds File', projectDir, 'sync-bounds-bind');
+    const frames = collectFrames(plugin);
+
+    plugin.send(JSON.stringify({ type: 'SYNC_REQUEST', data: {} } satisfies EventMsg));
+    plugin.send(JSON.stringify({ type: 'SYNC_REQUEST', data: {} } satisfies EventMsg));
+    await waitFor(() => frames.frames.filter((frame) => (frame as EventMsg).type === 'SYNC_RESULT').length === 2);
+    const results = frames.frames.filter((frame) => (frame as EventMsg).type === 'SYNC_RESULT') as EventMsg[];
+    expect(results.some((result) => (result.data as { summary?: string }).summary === 'a sync is already running')).toBe(true);
+    expect(results.some((result) => (result.data as { ok?: boolean }).ok === true)).toBe(true);
+
+    const released = nextFrame<EventMsg>(plugin, (frame) => (frame as EventMsg).type === 'SYNC_RESULT');
+    plugin.send(JSON.stringify({ type: 'SYNC_REQUEST', data: {} } satisfies EventMsg));
+    expect((await released).data).toMatchObject({ ok: true });
+    expect(readFileSync(stages, 'utf8')).toBe('dry\napply\ndry\napply\n');
+  });
+
+  it('holds the lane when the reconcile result says the spawned child exit is unconfirmed', async () => {
+    const reconcileMock = vi.fn((
+      _projectDir: string, _fileSlug: string | undefined, _fileName: string | undefined,
+      done: (result: Record<string, unknown>) => void,
+    ) => queueMicrotask(() => done({
+      ok: false, code: 'RECONCILE_CHILD_UNKILLABLE', childExited: false,
+      summary: 'ui reconcile child exit not confirmed after SIGKILL.',
+    })));
+    vi.doMock('../cli/src/transport/figma-sync-apply.ts', () => ({ spawnReconcileApply: reconcileMock }));
+    const projectDir = join(scratchDir, 'bound-held-project');
+    mkdirSync(join(projectDir, 'design'), { recursive: true });
+    const port = await startTestBroker();
+    const plugin = await connectSocket(port);
+    await helloPlugin(plugin, 'sync-held-plugin', 'Sync Held File');
+    const cli = await connectSocket(port);
+    await bindProject(cli, 'Sync Held File', projectDir, 'sync-held-bind');
+
+    const first = nextFrame<EventMsg>(plugin, (frame) => (frame as EventMsg).type === 'SYNC_RESULT');
+    plugin.send(JSON.stringify({ type: 'SYNC_REQUEST', data: {} } satisfies EventMsg));
+    expect((await first).data).toMatchObject({ code: 'RECONCILE_CHILD_UNKILLABLE', childExited: false });
+    const second = nextFrame<EventMsg>(plugin, (frame) => (frame as EventMsg).type === 'SYNC_RESULT');
+    plugin.send(JSON.stringify({ type: 'SYNC_REQUEST', data: {} } satisfies EventMsg));
+    expect((await second).data).toMatchObject({ ok: false, summary: 'a sync is already running' });
+    expect(reconcileMock).toHaveBeenCalledTimes(1);
+    expect(readFileSync(scratchLogFile, 'utf8')).toContain('sync lane HELD — reconcile child not confirmed dead');
+  });
 });
 
 describe('daemon harness — mutation admission', () => {

--- a/tests/figma-sync-apply.test.ts
+++ b/tests/figma-sync-apply.test.ts
@@ -1,21 +1,50 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from 'node:events';
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 type SyncModule = typeof import('../cli/src/transport/figma-sync-apply.ts');
+type SyncResult = import('../cli/src/transport/figma-sync-apply.ts').SyncApplyResult;
+type ChildBounds = import('../cli/src/transport/bounded-child-process.ts').ChildBounds;
 
 const spawnMock = vi.fn();
+const captureMock = vi.fn();
+const rmMock = vi.fn();
 let scratchDir: string;
 let priorUiBin: string | undefined;
 let observedClose: Promise<void> | undefined;
 
-function fakeChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter } {
-  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+function fakeChild(): EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; kill: ReturnType<typeof vi.fn> } {
+  const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; kill: ReturnType<typeof vi.fn> };
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
+  child.kill = vi.fn(() => true);
   return child;
+}
+
+async function loadWithCaptureMock(): Promise<SyncModule> {
+  vi.resetModules();
+  vi.doMock('node:child_process', () => ({ spawn: spawnMock }));
+  vi.doMock('../cli/src/transport/figma-mirror-capture-run.ts', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../cli/src/transport/figma-mirror-capture-run.ts')>()),
+    captureMirror: captureMock,
+  }));
+  return import('../cli/src/transport/figma-sync-apply.ts');
+}
+
+async function loadWithCaptureAndRmMock(): Promise<SyncModule> {
+  vi.resetModules();
+  vi.doMock('node:child_process', () => ({ spawn: spawnMock }));
+  vi.doMock('node:fs', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('node:fs')>()),
+    rmSync: rmMock,
+  }));
+  vi.doMock('../cli/src/transport/figma-mirror-capture-run.ts', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('../cli/src/transport/figma-mirror-capture-run.ts')>()),
+    captureMirror: captureMock,
+  }));
+  return import('../cli/src/transport/figma-sync-apply.ts');
 }
 
 async function loadWithSpawnMock(): Promise<SyncModule> {
@@ -47,14 +76,14 @@ async function loadWithObservedRealSpawn(): Promise<SyncModule> {
   return import('../cli/src/transport/figma-sync-apply.ts');
 }
 
-async function runSync(mod: SyncModule): Promise<Awaited<ReturnType<typeof resultOnce>>> {
-  return resultOnce((done) => mod.spawnReconcileApply(scratchDir, undefined, undefined, done));
+async function runSync(mod: SyncModule, bounds?: ChildBounds): Promise<Awaited<ReturnType<typeof resultOnce>>> {
+  return resultOnce((done) => mod.spawnReconcileApply(scratchDir, undefined, undefined, done, bounds));
 }
 
-function resultOnce(start: (done: (result: { ok: boolean; summary: string }) => void) => void): Promise<{ result: { ok: boolean; summary: string }; calls: number }> {
+function resultOnce(start: (done: (result: SyncResult) => void) => void): Promise<{ result: SyncResult; calls: number }> {
   return new Promise((resolve) => {
     let calls = 0;
-    let first: { ok: boolean; summary: string } | undefined;
+    let first: SyncResult | undefined;
     start((result) => {
       calls += 1;
       first ??= result;
@@ -63,13 +92,38 @@ function resultOnce(start: (done: (result: { ok: boolean; summary: string }) => 
   });
 }
 
-function writeKernel(mode: 'success' | 'malformed' | 'nonzero', stageLog?: string): string {
+function emitSuccess(child: ReturnType<typeof fakeChild>, envelope: unknown, exitCode = 0): void {
+  queueMicrotask(() => {
+    child.emit('spawn');
+    child.stdout.emit('data', Buffer.from(JSON.stringify(envelope)));
+    child.emit('exit', exitCode, null);
+    child.emit('close', exitCode, null);
+  });
+}
+
+function stagedCapture(): string {
+  const dir = join(scratchDir, 'private-capture');
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const file = join(dir, 'capture.json');
+  writeFileSync(file, '{}');
+  return file;
+}
+
+function writeKernel(
+  mode: 'success' | 'malformed' | 'nonzero' | 'valid-nonzero-preview' | 'valid-nonzero-apply',
+  stageLog?: string,
+): string {
   const script = join(scratchDir, 'controlled-reconcile');
+  const validOutput = `const dry=process.argv.includes('--dry-run'); require('node:fs').appendFileSync(${JSON.stringify(stageLog)}, dry ? 'dry\\n' : 'apply\\n'); console.log(JSON.stringify(dry ? {ok:true,data:{delta:{added:[],updated:[]},pending:[]}} : {ok:true,data:{apply:{added:[],updated:[],deprecated:[],mirrored:[],pending:[],skipped:[],mirrorSkipped:[]}}}));`;
   const output = mode === 'success'
-    ? `const dry=process.argv.includes('--dry-run'); require('node:fs').appendFileSync(${JSON.stringify(stageLog)}, dry ? 'dry\\n' : 'apply\\n'); console.log(JSON.stringify(dry ? {ok:true,data:{delta:{added:[],updated:[]},pending:[]}} : {ok:true,data:{apply:{added:[],updated:[],deprecated:[],mirrored:[],pending:[],skipped:[],mirrorSkipped:[]}}}));`
+    ? validOutput
     : mode === 'malformed'
       ? "console.log('not json');"
-      : "process.exit(7);";
+      : mode === 'nonzero'
+        ? 'process.exit(7);'
+        : mode === 'valid-nonzero-preview'
+          ? `${validOutput} if (dry) process.exitCode=7;`
+          : `${validOutput} if (!dry) process.exitCode=7;`;
   writeFileSync(script, `#!${process.execPath}\n${output}\n`, 'utf8');
   chmodSync(script, 0o755);
   return script;
@@ -79,11 +133,15 @@ beforeEach(() => {
   scratchDir = mkdtempSync(join(tmpdir(), 'figma-sync-apply-'));
   priorUiBin = process.env['FIGMA_AGENT_UI_BIN'];
   spawnMock.mockReset();
+  captureMock.mockReset();
+  rmMock.mockReset();
   observedClose = undefined;
 });
 
 afterEach(() => {
   vi.doUnmock('node:child_process');
+  vi.doUnmock('node:fs');
+  vi.doUnmock('../cli/src/transport/figma-mirror-capture-run.ts');
   vi.resetModules();
   if (priorUiBin === undefined) delete process.env['FIGMA_AGENT_UI_BIN'];
   else process.env['FIGMA_AGENT_UI_BIN'] = priorUiBin;
@@ -176,5 +234,224 @@ describe('spawnReconcileApply', () => {
     process.env['FIGMA_AGENT_UI_BIN'] = writeKernel('nonzero');
     const nonzero = await runSync(await loadWithRealSpawn());
     expect(nonzero).toMatchObject({ calls: 1, result: { ok: false, summary: 'ui exited 7' } });
+  });
+
+  it('never advances from a valid preview envelope whose controlled child exits nonzero', async () => {
+    const log = join(scratchDir, 'nonzero-preview-stages.log');
+    process.env['FIGMA_AGENT_UI_BIN'] = writeKernel('valid-nonzero-preview', log);
+
+    const result = await runSync(await loadWithRealSpawn());
+
+    expect(result.calls).toBe(1);
+    expect(result.result).toMatchObject({ ok: false, code: 'RECONCILE_FAILED' });
+    expect(result.result.summary).toContain('ui exited 7');
+    expect(readFileSync(log, 'utf8')).toBe('dry\n');
+  });
+
+  it('reports a valid apply envelope with nonzero exit as unknown without counts', async () => {
+    const log = join(scratchDir, 'nonzero-apply-stages.log');
+    process.env['FIGMA_AGENT_UI_BIN'] = writeKernel('valid-nonzero-apply', log);
+
+    const result = await runSync(await loadWithRealSpawn());
+
+    expect(result.calls).toBe(1);
+    expect(result.result).toMatchObject({ ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN' });
+    expect(result.result).not.toHaveProperty('applied');
+    expect(result.result).not.toHaveProperty('landed');
+    expect(readFileSync(log, 'utf8')).toBe('dry\napply\n');
+  });
+
+  it('preserves a component name whose UTF-8 bytes arrive across chunks', async () => {
+    let capturedName: string | undefined;
+    captureMock.mockImplementation(async (targets: Array<{ name: string }>) => {
+      capturedName = targets[0]?.name;
+      return { captured: 1, failed: 0, dropped: 0, droppedTargets: [] };
+    });
+    const dry = fakeChild();
+    const apply = fakeChild();
+    spawnMock.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        dry.emit('spawn');
+        const payload = Buffer.from(JSON.stringify({ ok: true, data: { delta: { added: [{ nodeId: '1:1', name: 'Đèn' }], updated: [] }, pending: [] } }));
+        const split = payload.indexOf(Buffer.from('Đ')) + 1;
+        dry.stdout.emit('data', payload.subarray(0, split));
+        dry.stdout.emit('data', payload.subarray(split));
+        dry.emit('exit', 0, null);
+        dry.emit('close', 0, null);
+      });
+      return dry;
+    }).mockImplementationOnce(() => {
+      emitSuccess(apply, { ok: true, data: { apply: {} } });
+      return apply;
+    });
+
+    const result = await runSync(await loadWithCaptureMock());
+
+    expect(result.result.ok).toBe(true);
+    expect(capturedName).toBe('Đèn');
+  });
+
+  it('removes capture only on success or known no-start, retaining known failures', async () => {
+    for (const mode of ['success', 'throw-no-start', 'error-no-start', 'nonzero', 'kernel-failure'] as const) {
+      spawnMock.mockReset();
+      captureMock.mockReset();
+      const capture = stagedCapture();
+      captureMock.mockResolvedValue({ file: capture, captured: 1, failed: 0, dropped: 0, droppedTargets: [] });
+      spawnMock.mockImplementationOnce(() => {
+        const child = fakeChild();
+        emitSuccess(child, { ok: true, data: { delta: { added: [], updated: [] }, pending: [] } });
+        return child;
+      }).mockImplementationOnce(() => {
+        if (mode === 'throw-no-start') throw new Error('apply did not start');
+        const child = fakeChild();
+        if (mode === 'error-no-start') {
+          queueMicrotask(() => child.emit('error', new Error('apply unavailable')));
+        } else if (mode === 'kernel-failure') {
+          emitSuccess(child, { ok: false, error: { code: 'READ_ERROR', message: 'capture unreadable' } });
+        } else {
+          emitSuccess(child, { ok: true, data: { apply: {} } }, mode === 'nonzero' ? 7 : 0);
+        }
+        return child;
+      });
+
+      const result = await runSync(await loadWithCaptureMock());
+      const retained = mode === 'nonzero' || mode === 'kernel-failure';
+      expect(existsSync(capture)).toBe(retained);
+      if (retained) {
+        expect(result.result).toMatchObject({
+          ok: false,
+          code: mode === 'nonzero' ? 'RECONCILE_OUTCOME_UNKNOWN' : 'READ_ERROR',
+          evidence: { capturePath: capture },
+        });
+      }
+    }
+  });
+
+  it('classifies unconfirmed exit before timeout, overflow, envelope, and retains capture', async () => {
+    const capture = stagedCapture();
+    captureMock.mockResolvedValue({ file: capture, captured: 1, failed: 0, dropped: 0, droppedTargets: [] });
+    const dry = fakeChild();
+    const apply = fakeChild();
+    spawnMock.mockImplementationOnce(() => {
+      emitSuccess(dry, { ok: true, data: { delta: { added: [], updated: [] }, pending: [] } });
+      return dry;
+    }).mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        apply.emit('spawn');
+        apply.stdout.emit('data', Buffer.from(JSON.stringify({ ok: true, data: { apply: {} }, padding: 'x'.repeat(256) })));
+        apply.emit('error', new Error('post-spawn transport error'));
+      });
+      return apply;
+    });
+    const bounds = { stdoutBytes: 128, stderrBytes: 8, deadlineMs: 20, termGraceMs: 10, closeGraceMs: 10, reapGraceMs: 20 };
+
+    const result = await runSync(await loadWithCaptureMock(), bounds);
+
+    expect(result.result).toMatchObject({
+      ok: false, code: 'RECONCILE_CHILD_UNKILLABLE', childExited: false,
+      evidence: { timedOut: true, stdoutTruncated: true, capturePath: capture },
+    });
+    expect(result.result).not.toHaveProperty('applied');
+    expect(result.result).not.toHaveProperty('landed');
+    expect(existsSync(capture)).toBe(true);
+    expect(apply.kill.mock.calls).toEqual([['SIGTERM'], ['SIGKILL']]);
+  });
+
+  it('distinguishes confirmed dry timeout from unknown apply timeout', async () => {
+    const bounds = { stdoutBytes: 128, stderrBytes: 8, deadlineMs: 20, termGraceMs: 10, closeGraceMs: 10, reapGraceMs: 20 };
+    const timedChild = (): ReturnType<typeof fakeChild> => {
+      const child = fakeChild();
+      child.kill.mockImplementation((signal: NodeJS.Signals) => {
+        if (signal === 'SIGTERM') queueMicrotask(() => {
+          child.emit('exit', null, 'SIGTERM');
+          child.emit('close', null, 'SIGTERM');
+        });
+        return true;
+      });
+      queueMicrotask(() => child.emit('spawn'));
+      return child;
+    };
+
+    spawnMock.mockImplementationOnce(timedChild);
+    const dryTimeout = await runSync(await loadWithSpawnMock(), bounds);
+    expect(dryTimeout.result).toMatchObject({ ok: false, code: 'RECONCILE_DRY_TIMEOUT', evidence: { timedOut: true, signal: 'SIGTERM' } });
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+
+    spawnMock.mockReset();
+    captureMock.mockReset();
+    const capture = stagedCapture();
+    captureMock.mockResolvedValue({ file: capture, captured: 1, failed: 0, dropped: 0, droppedTargets: [] });
+    spawnMock.mockImplementationOnce(() => {
+      const child = fakeChild();
+      emitSuccess(child, { ok: true, data: { delta: { added: [], updated: [] }, pending: [] } });
+      return child;
+    }).mockImplementationOnce(timedChild);
+    const applyTimeout = await runSync(await loadWithCaptureMock(), bounds);
+    expect(applyTimeout.result).toMatchObject({
+      ok: false, code: 'RECONCILE_OUTCOME_UNKNOWN',
+      evidence: { timedOut: true, signal: 'SIGTERM', capturePath: capture },
+    });
+    expect(applyTimeout.result).not.toHaveProperty('applied');
+    expect(applyTimeout.result).not.toHaveProperty('landed');
+    expect(existsSync(capture)).toBe(true);
+  });
+
+  it('contains synchronous and asynchronous capture failures with one completion', async () => {
+    for (const captureFailure of [
+      () => { throw new Error('capture threw'); },
+      () => Promise.reject(new Error('capture rejected')),
+    ]) {
+      spawnMock.mockReset();
+      captureMock.mockReset();
+      captureMock.mockImplementation(captureFailure);
+      spawnMock.mockImplementationOnce(() => {
+        const child = fakeChild();
+        emitSuccess(child, { ok: true, data: { delta: { added: [], updated: [] }, pending: [] } });
+        return child;
+      });
+
+      const result = await runSync(await loadWithCaptureMock());
+      expect(result).toMatchObject({ calls: 1, result: { ok: false, code: 'RECONCILE_CAPTURE_FAILED' } });
+      expect(spawnMock).toHaveBeenCalledTimes(1);
+    }
+  });
+
+  it('keeps successful apply truth while reporting a capture cleanup failure and path', async () => {
+    const capture = stagedCapture();
+    captureMock.mockResolvedValue({ file: capture, captured: 1, failed: 0, dropped: 0, droppedTargets: [] });
+    rmMock.mockImplementation(() => { throw new Error('cleanup denied'); });
+    spawnMock.mockImplementationOnce(() => {
+      const child = fakeChild();
+      emitSuccess(child, { ok: true, data: { delta: { added: [], updated: [] }, pending: [] } });
+      return child;
+    }).mockImplementationOnce(() => {
+      const child = fakeChild();
+      emitSuccess(child, { ok: true, data: { apply: {} } });
+      return child;
+    });
+
+    const result = await runSync(await loadWithCaptureAndRmMock());
+
+    expect(result.result).toMatchObject({
+      ok: true,
+      evidence: { capturePath: capture, captureCleanupError: 'cleanup denied' },
+    });
+    expect(result.result.summary).toContain('capture cleanup failed');
+    expect(result.result).toHaveProperty('applied');
+    expect(result.result).toHaveProperty('landed');
+    expect(existsSync(capture)).toBe(true);
+  });
+
+  it('accepts a valid nine-mebibyte reply under production defaults', async () => {
+    const script = join(scratchDir, 'large-reconcile');
+    const source = `#!${process.execPath}\nconst dry=process.argv.includes('--dry-run');const data=dry?{delta:{added:[],updated:[]},pending:[],padding:'x'.repeat(9*1024*1024)}:{apply:{},padding:'x'.repeat(9*1024*1024)};process.stdout.write(JSON.stringify({ok:true,data}));\n`;
+    writeFileSync(script, source);
+    chmodSync(script, 0o755);
+    process.env['FIGMA_AGENT_UI_BIN'] = script;
+
+    const result = await runSync(await loadWithRealSpawn());
+
+    expect(result.result).toMatchObject({ ok: true, evidence: { stdoutTruncated: false } });
+    expect(result.result.evidence!.stdoutBytes).toBeGreaterThan(9 * 1024 * 1024);
   });
 });


### PR DESCRIPTION
Bound reconcile subprocess output and lifetime, and require reliable exit evidence before accepting a successful JSON envelope. Nonzero previews no longer start apply. Timeouts, truncated output and uncertain apply completion preserve the capture for inspection; an unconfirmed child exit keeps the current broker's sync lane closed. Cleanup failures remain visible without changing a known successful apply result.

The runner counts all drained bytes, retains at most 128 MiB stdout and 1 MiB stderr, and escalates from a 120-second deadline through TERM and KILL. UTF-8 fragments cannot combine into invented characters, and decoded diagnostics stay within their bound. These are provisional engineering limits, not supported-workload promises.

Validation: test-first lifecycle, output, capture and broker-lane regressions; independent read-only review passed 105 focused tests; controller passed all 2,644 tests, typecheck, build and comment lint. Generated plugin artifacts are unchanged.

Compatibility: explicit `/opt/homebrew/bin/ui` 0.6.0 produced complete valid JSON in all four controlled 1k/10k preview/apply cases through both this runner and independent plain Node spawn (261,090–8,862,779 stdout bytes). A negative control identified the npm-local `ui` 0.5.0 binary, which truncates those same outputs at 65,536 bytes. An earlier draft attributed that failure to 0.6.0 without capturing executable identity; this has been corrected. Runtime executable identity and supported-install diagnostics remain #144. Mirror scan adoption and restart/orphan ownership remain #139 and #140. The current sync-lane hold does not survive broker restart.

Closes #138.
