### PR TITLE
fix(sync): record and reuse the selected kernel executable

### DIFF
--- a/cli/src/transport/figma-sync-apply.ts
+++ b/cli/src/transport/figma-sync-apply.ts
@@ -18,6 +18,7 @@
 // thrown; a second click while one apply is in flight is ignored (broker-daemon).
 import { rmSync } from 'node:fs';
 import { dirname } from 'node:path';
+import { selectReconcileExecutable, type ReconcileExecutable } from './reconcile-executable.ts';
 import {
   countsFromApplyReport,
   emptyCounts,
@@ -35,7 +36,9 @@ import {
   type ChildOutcome,
 } from './bounded-child-process.ts';
 
-interface SyncApplyEvidence {
+type ReconcileOutcome = ChildOutcome & ReconcileExecutable;
+
+interface SyncApplyEvidence extends ReconcileExecutable {
   phase: 'dry' | 'apply';
   exitCode: number | null;
   signal: NodeJS.Signals | null;
@@ -65,36 +68,33 @@ export interface SyncApplyResult {
   evidence?: SyncApplyEvidence;
 }
 
-/** Resolve the `ui` kernel binary — env override (tests) → PATH lookup by name. */
-function uiBin(): string {
-  return process.env['FIGMA_AGENT_UI_BIN'] || process.env['DESIGN_OS_UI_BIN'] || 'ui';
-}
-
 /** Run `ui figma reconcile …` and hand back the parsed envelope. Never throws. */
 function runReconcile(
   projectDir: string,
   extra: string[],
   bounds: Readonly<ChildBounds>,
-  done: (env: Record<string, unknown> | null, outcome: ChildOutcome) => void,
+  executable: ReconcileExecutable,
+  done: (env: Record<string, unknown> | null, outcome: ReconcileOutcome) => void,
 ): void {
   runBoundedChild(
-    uiBin(), ['figma', 'reconcile', '--dir', projectDir, '--json', ...extra],
+    executable.uiExecutable ?? executable.uiCommand, ['figma', 'reconcile', '--dir', projectDir, '--json', ...extra],
     { cwd: projectDir, bounds }, (outcome) => {
       let env: Record<string, unknown> | null = null;
       try {
         const parsed = JSON.parse(outcome.stdout.trim());
         if (parsed && typeof parsed === 'object') env = parsed as Record<string, unknown>;
       } catch { /* non-JSON stdout — the exit-code path below reports it */ }
-      done(env, outcome);
+      done(env, { ...outcome, ...executable });
     },
   );
 }
 
 function evidence(
-  phase: 'dry' | 'apply', outcome: ChildOutcome, env: Record<string, unknown> | null,
+  phase: 'dry' | 'apply', outcome: ReconcileOutcome, env: Record<string, unknown> | null,
   capturePath?: string, captureCleanupError?: string,
 ): SyncApplyEvidence {
   return {
+    uiCommand: outcome.uiCommand, uiExecutable: outcome.uiExecutable,
     phase, exitCode: outcome.exitCode, signal: outcome.signal, timedOut: outcome.timedOut,
     stdoutBytes: outcome.stdoutBytes, stdoutTruncated: outcome.stdoutTruncated,
     stderrBytes: outcome.stderrBytes, stderrTruncated: outcome.stderrTruncated,
@@ -105,7 +105,7 @@ function evidence(
 }
 
 function failure(
-  phase: 'dry' | 'apply', outcome: ChildOutcome, env: Record<string, unknown> | null,
+  phase: 'dry' | 'apply', outcome: ReconcileOutcome, env: Record<string, unknown> | null,
   capturePath?: string,
 ): SyncApplyResult | null {
   const meta = evidence(phase, outcome, env, capturePath);
@@ -180,8 +180,9 @@ export function spawnReconcileApply(
     settled = true;
     done(result);
   };
+  const executable = selectReconcileExecutable(projectDir);
   const fileSlugArgs = fileSlug !== undefined ? ['--file-slug', fileSlug] : [];
-  runReconcile(projectDir, ['--dry-run', ...fileSlugArgs], bounds, (env, outcome) => {
+  runReconcile(projectDir, ['--dry-run', ...fileSlugArgs], bounds, executable, (env, outcome) => {
     const dryFailure = failure('dry', outcome, env);
     if (dryFailure) { finish(dryFailure); return; }
     const data = envelopeData(env)!;
@@ -192,7 +193,7 @@ export function spawnReconcileApply(
     const targets = mergeTargetsPendingFirst(pendingFirst, targetsFromDelta(data));
     void Promise.resolve().then(() => captureMirror(targets, fileName)).then((cap) => {
       const extra = ['--apply', ...fileSlugArgs, ...(cap.file !== undefined ? ['--mirror-file', cap.file] : [])];
-      runReconcile(projectDir, extra, bounds, (aEnv, aOutcome) => {
+      runReconcile(projectDir, extra, bounds, executable, (aEnv, aOutcome) => {
         const retainedPath = cap.file !== undefined && aOutcome.spawned ? cap.file : undefined;
         const applyFailure = failure('apply', aOutcome, aEnv, retainedPath);
         if (applyFailure) {
@@ -220,7 +221,7 @@ export function spawnReconcileApply(
         });
       });
     }).catch((error: unknown) => finish({
-      ok: false, code: 'RECONCILE_CAPTURE_FAILED',
+      ok: false, code: 'RECONCILE_CAPTURE_FAILED', evidence: evidence('dry', outcome, env),
       summary: `could not prepare mirror capture: ${(error as Error).message}`,
     }));
   });

--- a/cli/src/transport/reconcile-executable.ts
+++ b/cli/src/transport/reconcile-executable.ts
@@ -1,0 +1,27 @@
+import { accessSync, constants, statSync } from 'node:fs';
+import { delimiter, isAbsolute, resolve } from 'node:path';
+
+/** Selected launch path, not an attestation of immutable executable contents. */
+export interface ReconcileExecutable {
+  uiCommand: string;
+  uiExecutable: string | null;
+}
+
+/** Preserve override precedence and resolve once against the child's cwd and PATH. */
+export function selectReconcileExecutable(cwd: string, env: NodeJS.ProcessEnv = process.env): ReconcileExecutable {
+  const uiCommand = env['FIGMA_AGENT_UI_BIN'] || env['DESIGN_OS_UI_BIN'] || 'ui';
+  if (isAbsolute(uiCommand) || uiCommand.includes('/') || (process.platform === 'win32' && uiCommand.includes('\\'))) {
+    return { uiCommand, uiExecutable: resolve(cwd, uiCommand) };
+  }
+  // Leave Windows native command lookup intact; its resolved identity is unqualified.
+  if (process.platform === 'win32') return { uiCommand, uiExecutable: null };
+  for (const directory of (env['PATH'] ?? '/usr/bin:/bin').split(delimiter)) {
+    const candidate = resolve(cwd, directory, uiCommand);
+    try {
+      accessSync(candidate, constants.X_OK);
+      if (statSync(candidate).isFile()) return { uiCommand, uiExecutable: candidate };
+    } catch { /* native lookup also skips inaccessible or absent PATH candidates */ }
+  }
+  // Native spawn retains its original failure when there is no resolvable executable.
+  return { uiCommand, uiExecutable: null };
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -75,6 +75,18 @@ count. An apply with unreliable completion evidence is reported as outcome unkno
 capture path remains available for inspection, and `ui figma reconcile --dry-run` must verify state before
 retry. If direct-child exit cannot be confirmed, the current broker keeps the sync lane closed. This hold
 does not survive broker restart; independently confirm that the child ended before restarting or retrying.
+
+Reconcile evidence records `uiCommand` and `uiExecutable`. On POSIX, the broker selects one absolute
+launch path before preview and reuses it for apply. `uiExecutable: null` means native command lookup
+was unresolved or delegated (including a bare command on Windows); it is never a fabricated identity.
+The path identifies the selected command, not immutable binary contents or its interpreter. Selection
+keeps `FIGMA_AGENT_UI_BIN`, then `DESIGN_OS_UI_BIN`, then `ui` on the broker's inherited PATH. An npm
+context can put the panel-test dependency's older `ui` ahead of the global kernel. Check the recorded
+executable with `--version`; a version printed in another shell may belong to a different command.
+To select a known install, set `FIGMA_AGENT_UI_BIN` to its absolute executable path in the environment
+that starts the broker. An already running broker retains its original environment; follow the child-exit
+checks above before restarting. An override is one executable path or name, never a shell command.
+
 Unresolved failures show as a red count next to the line; that count is
 the button that marks them seen, which clears it and the orb's *Needs attention*. Nothing is deleted — the failures stay in the edit
 feed and in `figma-agent errors` — and the next failure re-arms both. Every icon action is a locally

--- a/tests/figma-sync-executable.test.ts
+++ b/tests/figma-sync-executable.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnReconcileApply, type SyncApplyResult } from '../cli/src/transport/figma-sync-apply.ts';
+
+const capture = vi.hoisted(() => vi.fn());
+vi.mock('../cli/src/transport/figma-mirror-capture-run.ts', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../cli/src/transport/figma-mirror-capture-run.ts')>()),
+  captureMirror: capture,
+}));
+let scratch: string;
+
+function kernel(folder: string, name = 'ui', malformed = false): string {
+  const directory = join(scratch, folder);
+  mkdirSync(directory, { recursive: true });
+  const file = join(directory, name);
+  writeFileSync(file, `#!${process.execPath}\nconst fs=require('node:fs');
+    fs.appendFileSync(${JSON.stringify(join(scratch, 'invocations.jsonl'))},JSON.stringify({file:__filename,dry:process.argv.includes('--dry-run')})+'\\n');
+    console.log(${malformed ? "'invalid JSON'" : "JSON.stringify({ok:true,data:{delta:{added:[],updated:[]},pending:[],apply:{added:[],updated:[],deprecated:[],mirrored:[],pending:[],skipped:[],mirrorSkipped:[]}}})"});\n`);
+  chmodSync(file, 0o755);
+  return file;
+}
+
+function run(): Promise<SyncApplyResult> {
+  return new Promise((resolve) => spawnReconcileApply(scratch, undefined, undefined, resolve));
+}
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'reconcile-executable-'));
+  vi.stubEnv('FIGMA_AGENT_UI_BIN', undefined);
+  vi.stubEnv('DESIGN_OS_UI_BIN', undefined);
+  capture.mockReset().mockResolvedValue({ captured: 0, failed: 0, dropped: 0, droppedTargets: [] });
+});
+afterEach(() => { vi.unstubAllEnvs(); rmSync(scratch, { recursive: true, force: true }); });
+
+describe.skipIf(process.platform === 'win32')('reconcile executable evidence on POSIX', () => {
+  it('records the first executable on PATH and keeps it when PATH changes before apply', async () => {
+    const selected = kernel('local-bin');
+    const alternative = kernel('global-bin');
+    vi.stubEnv('PATH', `${join(scratch, 'local-bin')}:${join(scratch, 'global-bin')}`);
+    capture.mockImplementation(async () => {
+      process.env.PATH = join(scratch, 'global-bin');
+      process.env.FIGMA_AGENT_UI_BIN = alternative;
+      return { captured: 0, failed: 0, dropped: 0, droppedTargets: [] };
+    });
+    const result = await run();
+    expect(result.ok).toBe(true);
+    const invocations = readFileSync(join(scratch, 'invocations.jsonl'), 'utf8').trim().split('\n').map((line) => JSON.parse(line));
+    expect(invocations).toEqual([{ file: realpathSync(selected), dry: true }, { file: realpathSync(selected), dry: false }]);
+    expect(result.evidence).toMatchObject({ uiCommand: 'ui', uiExecutable: selected });
+  });
+
+  it.each(['relative', 'absolute'])('honors the primary %s override ahead of legacy override and PATH', async (kind) => {
+    const selected = kernel('chosen', 'ui with spaces');
+    kernel('other');
+    const requested = kind === 'relative' ? './chosen/ui with spaces' : selected;
+    vi.stubEnv('FIGMA_AGENT_UI_BIN', requested);
+    vi.stubEnv('DESIGN_OS_UI_BIN', join(scratch, 'other', 'ui'));
+    vi.stubEnv('PATH', join(scratch, 'other'));
+    const result = await run();
+    expect(result.ok).toBe(true);
+    expect(result.evidence).toMatchObject({ uiCommand: requested, uiExecutable: selected });
+  });
+
+  it('records a legacy override and reports incomplete preview without starting apply', async () => {
+    const selected = kernel('legacy', 'ui', true);
+    vi.stubEnv('DESIGN_OS_UI_BIN', selected);
+    const result = await run();
+    expect(result.ok).toBe(false);
+    expect(result.evidence).toMatchObject({ phase: 'dry', envelopeParsed: false, uiExecutable: selected });
+    expect(capture).not.toHaveBeenCalled();
+    expect(readFileSync(join(scratch, 'invocations.jsonl'), 'utf8').trim().split('\n')).toHaveLength(1);
+  });
+
+  it('records an explicit missing path as the attempted executable without claiming successful start', async () => {
+    const selected = join(scratch, 'missing', 'ui');
+    vi.stubEnv('FIGMA_AGENT_UI_BIN', selected);
+    const result = await run();
+    expect(result.ok).toBe(false);
+    expect(result.evidence).toMatchObject({ uiCommand: selected, uiExecutable: selected, exitCode: null, envelopeParsed: false });
+    expect(capture).not.toHaveBeenCalled();
+  });
+
+  it('does not invent a resolved identity for a missing bare command', async () => {
+    vi.stubEnv('PATH', scratch);
+    const result = await run();
+    expect(result.ok).toBe(false);
+    expect(result.evidence).toMatchObject({ uiCommand: 'ui', uiExecutable: null, envelopeParsed: false });
+    expect(capture).not.toHaveBeenCalled();
+  });
+});

--- a/tests/reconcile-executable.test.ts
+++ b/tests/reconcile-executable.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chmodSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { selectReconcileExecutable } from '../cli/src/transport/reconcile-executable.ts';
+
+let root: string;
+beforeEach(() => { root = mkdtempSync(join(tmpdir(), 'kernel-selection-')); });
+afterEach(() => { rmSync(root, { recursive: true, force: true }); });
+function executable(directory: string, executable = true): string {
+  const dir = join(root, directory);
+  mkdirSync(dir, { recursive: true });
+  const file = join(dir, 'ui');
+  writeFileSync(file, 'fixture');
+  chmodSync(file, executable ? 0o700 : 0o600);
+  return file;
+}
+
+describe.skipIf(process.platform === 'win32')('POSIX executable selection', () => {
+  it('skips nonexecutables, directories and dangling links without losing PATH order', () => {
+    executable('nonexecutable', false);
+    mkdirSync(join(root, 'directory', 'ui'), { recursive: true });
+    mkdirSync(join(root, 'dangling'));
+    symlinkSync(join(root, 'missing'), join(root, 'dangling', 'ui'));
+    const selected = executable('valid');
+    executable('later');
+    const PATH = ['nonexecutable', 'directory', 'dangling', 'valid', 'later'].join(':');
+    expect(selectReconcileExecutable(root, { PATH })).toEqual({ uiCommand: 'ui', uiExecutable: selected });
+  });
+  it('resolves an empty PATH entry against the child cwd', () => {
+    const selected = executable('');
+    expect(selectReconcileExecutable(root, { PATH: '' })).toEqual({ uiCommand: 'ui', uiExecutable: selected });
+  });
+  it('preserves a selected symlink as the absolute launch path', () => {
+    const target = executable('actual');
+    mkdirSync(join(root, 'linked'));
+    const selected = join(root, 'linked', 'ui');
+    symlinkSync(target, selected);
+    expect(selectReconcileExecutable(root, { PATH: 'linked' })).toEqual({ uiCommand: 'ui', uiExecutable: selected });
+  });
+  it('resolves an override command name through PATH without splitting arguments', () => {
+    const selected = executable('bin');
+    expect(selectReconcileExecutable(root, { FIGMA_AGENT_UI_BIN: 'ui', PATH: 'bin' })).toEqual({ uiCommand: 'ui', uiExecutable: selected });
+    expect(selectReconcileExecutable(root, { FIGMA_AGENT_UI_BIN: 'ui --flag', PATH: 'bin' })).toEqual({ uiCommand: 'ui --flag', uiExecutable: null });
+  });
+});


### PR DESCRIPTION
Reconcile could preview with one `ui` executable and apply with another if its inherited PATH or override changed between phases. The result also omitted which executable ran, allowing an npm-local 0.5.0 binary to be mistaken for a global 0.6.0 installation during diagnosis.

Resolve the selected POSIX launch path once and reuse it for both phases. Evidence now includes the requested `uiCommand` and selected `uiExecutable`; a missing bare command or delegated Windows lookup reports a null resolved identity. Preserve override precedence, native launch errors and literal paths containing spaces. Operations guidance explains PATH shadowing and explicit executable selection without changing dependencies or a running broker.

Validation: test-first six failing production-path cases, then 34 focused tests and all 2,654 tests passed with typecheck, build and comment lint. Independent read-only review approved the frozen five-file change. Two controlled global 0.6.0 runs passed all four 1k/10k preview/apply cases each; the local 0.5.0 negative control consistently reproduced incomplete 65,536-byte output. Temporary fixtures were removed.

The path is launch evidence, not immutable binary/interpreter attestation. Windows native lookup is preserved and its resolved identity remains unqualified; no live Figma or owner-registry acceptance is claimed.

Closes #144.
