### PR TITLE
feat: expose opt-in broker resource snapshots

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -60,6 +60,10 @@ import {
   completeSkippingStale, emptyQueue, enqueue as enqueueJob, queuePosition, remove as removeFromQueue,
   type QueueState,
 } from './file-queue.ts';
+import {
+  collectBrokerResourceSnapshot,
+  type BrokerResourceObserver,
+} from './broker-resource-snapshot.ts';
 import type { ComponentChange } from '../../../shared/figma-changes.ts';
 import type { EditInput, EditSource } from '../../../shared/edit-feed.ts';
 
@@ -503,6 +507,8 @@ export interface BrokerDaemonOptions {
   ports?: readonly number[];
   exit?: (code: number) => never;
   logFile?: string;
+  /** Optional in-process diagnostics. No observer means no snapshot work. */
+  resourceObserver?: BrokerResourceObserver;
 }
 
 function defaultPortRange(): number[] {
@@ -614,6 +620,19 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       ),
     }),
   };
+  let resourceObserverTeardown: (() => void) | null = null;
+  if (options?.resourceObserver) {
+    const teardown = options.resourceObserver(() => collectBrokerResourceSnapshot({
+      pendingChunks: st.pendingChunks,
+      parkedRequestFrames: st.waiting.map((request) => request.rawText),
+      jobTable: st.jobs.resourceSnapshot(),
+      queues: st.queues,
+      pendingRequestReferenceCount: st.pending.size,
+      dispatchedRequestReferenceCount: st.dispatchedTo.size,
+      dispatchReservationReferenceCount: st.dispatchReservations.size,
+    }));
+    if (typeof teardown === 'function') resourceObserverTeardown = teardown;
+  }
   // Sweep leftover `${advertisePath}.<pid>.tmp` files from a prior instance's hard
   // kill (SIGKILL between the temp write and the rename never runs its own cleanup)
   // BEFORE writing our own — startup only, not the heartbeat tick, since this lists
@@ -783,6 +802,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
 
   const shutdown = (code: number, reason: string): never => {
     log(`shutdown (${reason})`);
+    const teardown = resourceObserverTeardown;
+    resourceObserverTeardown = null;
+    if (teardown) {
+      try { teardown(); } catch (err) { log(`resource observer teardown failed: ${(err as Error).message}`); }
+    }
     // Drop ownership BEFORE unlinking — a refresh-interval tick racing this shutdown
     // (the `exit` stub in tests throws rather than truly halting the process, so later
     // ticks are reachable) must see `ownsAdvertisement === false` and skip re-writing

--- a/cli/src/transport/broker-resource-snapshot.ts
+++ b/cli/src/transport/broker-resource-snapshot.ts
@@ -1,0 +1,181 @@
+export interface FrameResourceUsage {
+  readonly frameReferences: number;
+  readonly utf8Bytes: number;
+}
+
+export interface JobTableResourceSnapshot {
+  readonly jobCount: number;
+  /** Non-evictable ownership, including held terminal records and excluding released unknown outcomes. */
+  readonly liveJobCount: number;
+  /** Public-state counts below are independent of retention liveness. */
+  readonly queuedJobCount: number;
+  readonly runningJobCount: number;
+  readonly outcomeUnknownJobCount: number;
+  readonly finishedJobCount: number;
+  readonly retentionHeldJobCount: number;
+  readonly requestFrames: FrameResourceUsage;
+  readonly replyFrames: FrameResourceUsage;
+}
+
+export interface BrokerResourceSnapshot {
+  readonly pendingChunks: FrameResourceUsage & {
+    readonly connectionCount: number;
+    readonly incompleteIdCount: number;
+    readonly perConnection: readonly Readonly<FrameResourceUsage & {
+      ordinal: number;
+      incompleteIdCount: number;
+    }>[];
+  };
+  readonly parkedRequests: FrameResourceUsage & { readonly requestCount: number };
+  readonly jobTable: JobTableResourceSnapshot;
+  readonly fileQueues: {
+    readonly fileQueueCount: number;
+    readonly occupiedSlotReferenceCount: number;
+    readonly waitingJobReferenceCount: number;
+    readonly perFile: readonly Readonly<{
+      ordinal: number;
+      occupiedSlotReferenceCount: number;
+      waitingJobReferenceCount: number;
+    }>[];
+  };
+  readonly correlations: {
+    readonly pendingRequestReferenceCount: number;
+    readonly dispatchedRequestReferenceCount: number;
+    readonly dispatchReservationReferenceCount: number;
+  };
+  /** These are references to ownership represented elsewhere, never additional bytes. */
+  readonly duplicateOwnershipReferences: {
+    readonly jobReferencesFromOccupiedQueueSlots: number;
+    readonly jobReferencesFromQueueWaitingLists: number;
+    readonly requestReferencesFromPendingCorrelations: number;
+    readonly requestReferencesFromDispatchCorrelations: number;
+    readonly jobReferencesFromDispatchReservations: number;
+  };
+}
+
+export type BrokerResourceSnapshotGetter = () => BrokerResourceSnapshot;
+export type BrokerResourceObserver = (
+  getSnapshot: BrokerResourceSnapshotGetter,
+) => void | (() => void);
+
+type PendingChunkBuffers<Connection> = ReadonlyMap<
+  Connection,
+  ReadonlyMap<string, { readonly frames: readonly string[] }>
+>;
+
+type QueueResources = ReadonlyMap<
+  string,
+  { readonly running: string | null; readonly waiting: readonly string[] }
+>;
+
+export function countFrameResources(frames: readonly string[]): FrameResourceUsage {
+  let utf8Bytes = 0;
+  for (const frame of frames) utf8Bytes += Buffer.byteLength(frame, 'utf8');
+  return Object.freeze({ frameReferences: frames.length, utf8Bytes });
+}
+
+export function freezeJobTableResourceSnapshot(
+  snapshot: JobTableResourceSnapshot,
+): JobTableResourceSnapshot {
+  return Object.freeze({
+    jobCount: snapshot.jobCount,
+    liveJobCount: snapshot.liveJobCount,
+    queuedJobCount: snapshot.queuedJobCount,
+    runningJobCount: snapshot.runningJobCount,
+    outcomeUnknownJobCount: snapshot.outcomeUnknownJobCount,
+    finishedJobCount: snapshot.finishedJobCount,
+    retentionHeldJobCount: snapshot.retentionHeldJobCount,
+    requestFrames: Object.freeze({ ...snapshot.requestFrames }),
+    replyFrames: Object.freeze({ ...snapshot.replyFrames }),
+  });
+}
+
+export function collectBrokerResourceSnapshot<Connection>(input: {
+  pendingChunks: PendingChunkBuffers<Connection>;
+  parkedRequestFrames: readonly string[];
+  jobTable: JobTableResourceSnapshot;
+  queues: QueueResources;
+  pendingRequestReferenceCount: number;
+  dispatchedRequestReferenceCount: number;
+  dispatchReservationReferenceCount: number;
+}): BrokerResourceSnapshot {
+  let pendingFrameReferences = 0;
+  let pendingUtf8Bytes = 0;
+  let incompleteIdCount = 0;
+  const perConnection: Array<Readonly<FrameResourceUsage & {
+    ordinal: number;
+    incompleteIdCount: number;
+  }>> = [];
+  let ordinal = 0;
+  for (const chunks of input.pendingChunks.values()) {
+    ordinal += 1;
+    let connectionFrameReferences = 0;
+    let connectionUtf8Bytes = 0;
+    for (const entry of chunks.values()) {
+      const usage = countFrameResources(entry.frames);
+      connectionFrameReferences += usage.frameReferences;
+      connectionUtf8Bytes += usage.utf8Bytes;
+    }
+    incompleteIdCount += chunks.size;
+    pendingFrameReferences += connectionFrameReferences;
+    pendingUtf8Bytes += connectionUtf8Bytes;
+    perConnection.push(Object.freeze({
+      ordinal,
+      incompleteIdCount: chunks.size,
+      frameReferences: connectionFrameReferences,
+      utf8Bytes: connectionUtf8Bytes,
+    }));
+  }
+
+  let occupiedSlotReferenceCount = 0;
+  let waitingJobReferenceCount = 0;
+  const perFile: Array<Readonly<{
+    ordinal: number;
+    occupiedSlotReferenceCount: number;
+    waitingJobReferenceCount: number;
+  }>> = [];
+  let fileOrdinal = 0;
+  for (const queue of input.queues.values()) {
+    fileOrdinal += 1;
+    const occupied = queue.running === null ? 0 : 1;
+    occupiedSlotReferenceCount += occupied;
+    waitingJobReferenceCount += queue.waiting.length;
+    perFile.push(Object.freeze({
+      ordinal: fileOrdinal,
+      occupiedSlotReferenceCount: occupied,
+      waitingJobReferenceCount: queue.waiting.length,
+    }));
+  }
+  const parkedFrames = countFrameResources(input.parkedRequestFrames);
+  const correlations = Object.freeze({
+    pendingRequestReferenceCount: input.pendingRequestReferenceCount,
+    dispatchedRequestReferenceCount: input.dispatchedRequestReferenceCount,
+    dispatchReservationReferenceCount: input.dispatchReservationReferenceCount,
+  });
+
+  return Object.freeze({
+    pendingChunks: Object.freeze({
+      connectionCount: input.pendingChunks.size,
+      incompleteIdCount,
+      frameReferences: pendingFrameReferences,
+      utf8Bytes: pendingUtf8Bytes,
+      perConnection: Object.freeze(perConnection),
+    }),
+    parkedRequests: Object.freeze({ requestCount: input.parkedRequestFrames.length, ...parkedFrames }),
+    jobTable: freezeJobTableResourceSnapshot(input.jobTable),
+    fileQueues: Object.freeze({
+      fileQueueCount: input.queues.size,
+      occupiedSlotReferenceCount,
+      waitingJobReferenceCount,
+      perFile: Object.freeze(perFile),
+    }),
+    correlations,
+    duplicateOwnershipReferences: Object.freeze({
+      jobReferencesFromOccupiedQueueSlots: occupiedSlotReferenceCount,
+      jobReferencesFromQueueWaitingLists: waitingJobReferenceCount,
+      requestReferencesFromPendingCorrelations: correlations.pendingRequestReferenceCount,
+      requestReferencesFromDispatchCorrelations: correlations.dispatchedRequestReferenceCount,
+      jobReferencesFromDispatchReservations: correlations.dispatchReservationReferenceCount,
+    }),
+  });
+}

--- a/cli/src/transport/job-table.ts
+++ b/cli/src/transport/job-table.ts
@@ -13,6 +13,11 @@
 // ever touches a real WebSocket.
 import type WebSocket from 'ws';
 import type { JobInfo, JobRecovery } from '../../../shared/protocol.ts';
+import {
+  countFrameResources,
+  freezeJobTableResourceSnapshot,
+  type JobTableResourceSnapshot,
+} from './broker-resource-snapshot.ts';
 
 export const JOB_TTL_MS = 10 * 60_000;               // finished results stay retrievable this long — BEST EFFORT
 export const JOB_FINISHED_CAP = 200;                 // hard cap on FINISHED records; live jobs are NEVER capped
@@ -422,6 +427,47 @@ export class JobTable {
       .filter((r) => fileSlug === undefined || r.fileSlug === fileSlug)
       .sort((a, b) => b.createdAt - a.createdAt);
     return all.map(toJobInfo);
+  }
+
+  /** Numeric, copy-only retained-frame projection for the optional in-process observer. */
+  resourceSnapshot(): JobTableResourceSnapshot {
+    let liveJobCount = 0;
+    let queuedJobCount = 0;
+    let runningJobCount = 0;
+    let outcomeUnknownJobCount = 0;
+    let finishedJobCount = 0;
+    let retentionHeldJobCount = 0;
+    let requestFrameReferences = 0;
+    let requestUtf8Bytes = 0;
+    let replyFrameReferences = 0;
+    let replyUtf8Bytes = 0;
+    for (const job of this.jobs.values()) {
+      if (job.state === 'queued' || job.state === 'running'
+        || (job.state === 'outcome-unknown' && job.forceReleased !== true)
+        || job.retentionHeld === true) liveJobCount += 1;
+      if (job.state === 'queued') queuedJobCount += 1;
+      else if (job.state === 'running') runningJobCount += 1;
+      else if (job.state === 'outcome-unknown') outcomeUnknownJobCount += 1;
+      else if (isFinishedState(job.state)) finishedJobCount += 1;
+      if (job.retentionHeld === true) retentionHeldJobCount += 1;
+      const request = countFrameResources(job.requestFrames);
+      requestFrameReferences += request.frameReferences;
+      requestUtf8Bytes += request.utf8Bytes;
+      const reply = countFrameResources(job.replyFrames);
+      replyFrameReferences += reply.frameReferences;
+      replyUtf8Bytes += reply.utf8Bytes;
+    }
+    return freezeJobTableResourceSnapshot({
+      jobCount: this.jobs.size,
+      liveJobCount,
+      queuedJobCount,
+      runningJobCount,
+      outcomeUnknownJobCount,
+      finishedJobCount,
+      retentionHeldJobCount,
+      requestFrames: { frameReferences: requestFrameReferences, utf8Bytes: requestUtf8Bytes },
+      replyFrames: { frameReferences: replyFrameReferences, utf8Bytes: replyUtf8Bytes },
+    });
   }
 
   private evict(jobId: string): void {

--- a/tests/broker-resource-inspection-harness.test.ts
+++ b/tests/broker-resource-inspection-harness.test.ts
@@ -1,0 +1,200 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import WebSocket from 'ws';
+import { makeRequestFrame, type EventMsg, type JobInfo, type ReplyMsg, type WireMsg } from '../shared/protocol.ts';
+import { sendWireMsg } from '../cli/src/transport/protocol-helpers.ts';
+import type { BrokerResourceSnapshot, BrokerResourceSnapshotGetter } from '../cli/src/transport/broker-resource-snapshot.ts';
+
+vi.setConfig({ testTimeout: 30_000 });
+
+let scratch: string;
+let advertisePath: string;
+let sockets: WebSocket[];
+let getSnapshot: BrokerResourceSnapshotGetter | undefined;
+let observerTornDown: boolean;
+const priorEnv = new Map<string, string | undefined>();
+const rawFileKey = 'retained-resource-test-key';
+const env = {
+  FIGMA_AGENT_PLUGIN_WAIT_MS: '160', FIGMA_AGENT_APP_READINESS_MS: '500',
+  FIGMA_AGENT_HEARTBEAT_MS: '1000', FIGMA_AGENT_IDLE_SHUTDOWN_MS: '600000',
+  FIGMA_AGENT_LAST_PLUGINS_DEBOUNCE_MS: '50',
+};
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'fa-resource-inspection-'));
+  advertisePath = join(scratch, 'broker.json');
+  sockets = [];
+  getSnapshot = undefined;
+  observerTornDown = false;
+  const paths = {
+    FIGMA_AGENT_CHANGES_DIR: join(scratch, 'changes'), FIGMA_AGENT_BINDS_FILE: join(scratch, 'binds.json'),
+    FIGMA_AGENT_UNBOUND_DIR: join(scratch, 'unbound'), ...env,
+  };
+  for (const [key, value] of Object.entries(paths)) {
+    priorEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+});
+
+afterEach(async () => {
+  for (const ws of sockets) if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' }));
+  await new Promise((resolve) => setTimeout(resolve, 60));
+  for (const ws of sockets) try { ws.terminate(); } catch { /* already closed */ }
+  rmSync(scratch, { recursive: true, force: true });
+  for (const [key, value] of priorEnv) value === undefined ? delete process.env[key] : process.env[key] = value;
+  priorEnv.clear();
+});
+
+async function startBroker(observe: boolean): Promise<number> {
+  vi.resetModules();
+  const { runBrokerDaemon } = await import('../cli/src/transport/broker-daemon.ts');
+  await runBrokerDaemon({
+    advertisePath, mutationGatePath: join(scratch, 'gates.json'), ports: [0],
+    logFile: join(scratch, 'broker.log'), exit: (code): never => { throw new Error(`test exit ${code}`); },
+    ...(observe && { resourceObserver: (getter: BrokerResourceSnapshotGetter) => {
+      getSnapshot = getter;
+      return () => { getSnapshot = undefined; observerTornDown = true; };
+    } }),
+  });
+  const ad = JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number; pid: number };
+  expect(ad.pid).toBe(process.pid);
+  expect(ad.port < 9410 || ad.port > 9419).toBe(true);
+  return ad.port;
+}
+
+function connect(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    sockets.push(ws);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+
+function nextFrame<T extends WireMsg>(ws: WebSocket, predicate: (frame: WireMsg) => boolean): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error('frame timed out')), 10_000);
+    const onMessage = (raw: WebSocket.RawData): void => {
+      const frame = JSON.parse(raw.toString()) as WireMsg;
+      if (predicate(frame)) finish(undefined, frame as T);
+    };
+    const finish = (error?: Error, frame?: T): void => {
+      clearTimeout(timer); ws.off('message', onMessage);
+      if (error) reject(error); else resolve(frame!);
+    };
+    ws.on('message', onMessage);
+  });
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 10_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition timed out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+async function registerPlugin(port: number): Promise<{ ws: WebSocket; received: WireMsg[] }> {
+  const ws = await connect(port);
+  const received: WireMsg[] = [];
+  ws.on('message', (raw) => received.push(JSON.parse(raw.toString()) as WireMsg));
+  const ack = nextFrame<EventMsg>(ws, (frame) => (frame as EventMsg).type === 'SYNC_CONFIG');
+  ws.send(JSON.stringify({ type: 'PLUGIN_HELLO', data: { instanceId: 'resource-plugin', fileName: 'Resource', fileKey: rawFileKey, caps: ['fileGuard'] } } satisfies EventMsg));
+  await ack;
+  return { ws, received };
+}
+
+async function sendJob(ws: WebSocket, id: string): Promise<string> {
+  const state = nextFrame<EventMsg>(ws, (frame) => (frame as EventMsg).type === 'JOB_STATE' && (frame as EventMsg).data.jobId !== undefined);
+  ws.send(JSON.stringify(makeRequestFrame(id, 'SET_TEXT', { text: id }, undefined, undefined, undefined, undefined, undefined, undefined, rawFileKey)));
+  return ((await state).data as unknown as JobInfo).jobId;
+}
+
+describe('broker retained-resource observer — actual daemon', () => {
+  it('leaves default startup and relay behavior unchanged without an observer', async () => {
+    const port = await startBroker(false);
+    expect(getSnapshot).toBeUndefined();
+    const plugin = await registerPlugin(port);
+    const cli = await connect(port);
+    const request = makeRequestFrame('default-read', 'GET_SELECTION', { value: 'unchanged' });
+    const reachedPlugin = nextFrame<typeof request>(plugin.ws, (frame) => 'id' in frame && frame.id === request.id);
+    cli.send(JSON.stringify(request));
+    await reachedPlugin;
+    const reply = nextFrame<ReplyMsg>(cli, (frame) => 'id' in frame && frame.id === request.id && 'ok' in frame);
+    plugin.ws.send(JSON.stringify({ id: request.id, ok: true, result: { value: 'unchanged' } }));
+    expect((await reply).ok).toBe(true);
+  });
+
+  it('observes chunk, parked, queue, reply, cancellation, and recovery transitions', async () => {
+    const port = await startBroker(true);
+    expect(getSnapshot).toBeTypeOf('function');
+    const partial = await connect(port);
+    const large = makeRequestFrame('partial-unicode', 'GET_SELECTION', { text: '🧪'.repeat(300_000) });
+    const chunkFrames: string[] = [];
+    sendWireMsg({ send: (frame) => chunkFrames.push(frame) }, large);
+    partial.send(chunkFrames[0]!);
+    await waitFor(() => getSnapshot!().pendingChunks.incompleteIdCount === 1);
+    expect(getSnapshot!().pendingChunks.utf8Bytes).toBe(Buffer.byteLength(chunkFrames[0]!));
+    partial.terminate();
+    await waitFor(() => getSnapshot!().pendingChunks.incompleteIdCount === 0);
+
+    const parkedClient = await connect(port);
+    const parked = JSON.stringify(makeRequestFrame('parked-unicode', 'GET_SELECTION', { text: '你好' }));
+    parkedClient.send(parked);
+    await waitFor(() => getSnapshot!().parkedRequests.requestCount === 1);
+    expect(getSnapshot!().parkedRequests.utf8Bytes).toBe(Buffer.byteLength(parked));
+    const plugin = await registerPlugin(port);
+    await waitFor(() => plugin.received.some((frame) => 'id' in frame && frame.id === 'parked-unicode'));
+    expect(getSnapshot!().jobTable.runningJobCount).toBe(1);
+    plugin.ws.send(JSON.stringify({ id: 'parked-unicode', ok: true, result: {} }));
+    await waitFor(() => getSnapshot!().jobTable.finishedJobCount === 1);
+
+    const cli = await connect(port);
+    const headJob = await sendJob(cli, 'head');
+    await waitFor(() => plugin.received.some((frame) => 'id' in frame && frame.id === 'head'));
+    const queuedJob = await sendJob(cli, 'queued');
+    const cancelledJob = await sendJob(cli, 'cancelled');
+    let snapshot = getSnapshot!();
+    expect(snapshot.jobTable.runningJobCount).toBe(1);
+    expect(snapshot.jobTable.queuedJobCount).toBe(2);
+    expect(snapshot.fileQueues.waitingJobReferenceCount).toBe(2);
+
+    const cancelReply = nextFrame<ReplyMsg>(cli, (frame) => 'id' in frame && frame.id === 'cancel-command' && 'ok' in frame);
+    cli.send(JSON.stringify(makeRequestFrame('cancel-command', 'JOB', { mode: 'cancel', jobId: cancelledJob })));
+    expect((await cancelReply).ok).toBe(true);
+    snapshot = getSnapshot!();
+    expect(snapshot.fileQueues.waitingJobReferenceCount).toBe(1);
+    expect(snapshot.jobTable.finishedJobCount).toBe(2);
+
+    const replyFrames: string[] = [];
+    sendWireMsg({ send: (frame) => replyFrames.push(frame) }, { id: 'head', ok: true, result: { text: '🧪'.repeat(300_000) } });
+    expect(replyFrames.length).toBeGreaterThan(1);
+    plugin.ws.send(replyFrames[0]!);
+    await waitFor(() => getSnapshot!().jobTable.replyFrames.frameReferences === 1);
+    expect(getSnapshot!().jobTable.runningJobCount).toBe(1);
+    for (const frame of replyFrames.slice(1)) plugin.ws.send(frame);
+    await waitFor(() => plugin.received.some((frame) => 'id' in frame && frame.id === 'queued'));
+    snapshot = getSnapshot!();
+    expect(snapshot.jobTable.finishedJobCount).toBe(3);
+    expect(snapshot.jobTable.runningJobCount).toBe(1);
+    expect(snapshot.duplicateOwnershipReferences.jobReferencesFromOccupiedQueueSlots).toBe(1);
+
+    const closed = new Promise<void>((resolve) => cli.once('close', () => resolve()));
+    cli.terminate();
+    await closed;
+    plugin.ws.send(JSON.stringify({ id: 'queued', ok: true, result: { recovered: true } }));
+    await waitFor(() => getSnapshot!().correlations.dispatchedRequestReferenceCount === 0);
+    const recovery = await connect(port);
+    const poll = nextFrame<ReplyMsg>(recovery, (frame) => 'id' in frame && frame.id === 'poll-recovery' && 'ok' in frame);
+    recovery.send(JSON.stringify(makeRequestFrame('poll-recovery', 'JOB', { mode: 'poll', jobId: queuedJob })));
+    const recovered = await poll;
+    expect(recovered.ok && (recovered.result as { resultFrames: string[] }).resultFrames.length).toBe(1);
+    expect(headJob).not.toBe(queuedJob);
+
+    plugin.ws.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' }));
+    await waitFor(() => observerTornDown && !existsSync(advertisePath));
+    expect(getSnapshot).toBeUndefined();
+  });
+});

--- a/tests/broker-resource-lifecycle.test.ts
+++ b/tests/broker-resource-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { JOB_TTL_MS, JobTable } from '../cli/src/transport/job-table.ts';
+
+function fixture() {
+  let now = 100;
+  const table = new JobTable(() => now, () => 'owned-job');
+  const job = table.create({
+    requestId: 'owned-request', cmd: 'SET_TEXT', fileSlug: 'owned-file', readOnly: false,
+    requestFrames: ['request'], from: null, targetInstanceId: 'owned-plugin',
+  });
+  return { table, job, expire: () => { now += JOB_TTL_MS + 1; return table.sweep(); } };
+}
+
+function counts(table: JobTable): number[] {
+  const s = table.resourceSnapshot();
+  return [s.liveJobCount, s.queuedJobCount, s.runningJobCount,
+    s.outcomeUnknownJobCount, s.finishedJobCount, s.retentionHeldJobCount];
+}
+
+describe('resource liveness follows retained job ownership', () => {
+  it('keeps an unknown outcome live until its inspected release, then allows retention expiry', () => {
+    const { table, job, expire } = fixture();
+    expect(counts(table)).toEqual([1, 1, 0, 0, 0, 0]);
+    table.transitionQueuedToRunning(job.jobId);
+    expect(counts(table)).toEqual([1, 0, 1, 0, 0, 0]);
+    table.markOutcomeUnknown(job.jobId, 'reply channel lost');
+    expect(counts(table)).toEqual([1, 0, 0, 1, 0, 0]);
+    expect(expire()).toBe(0);
+    expect(counts(table)).toEqual([1, 0, 0, 1, 0, 0]);
+    expect(table.settleOutcomeUnknownRelease(job.jobId)).toBe(true);
+    expect(counts(table)).toEqual([0, 0, 0, 1, 0, 0]);
+    expect(table.resourceSnapshot().requestFrames).toEqual({ frameReferences: 1, utf8Bytes: 7 });
+    expect(expire()).toBe(1);
+    expect(table.resourceSnapshot().jobCount).toBe(0);
+    expect(counts(table)).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it.each([true, false])('counts held terminal ownership until release when ok=%s', (ok) => {
+    const { table, job, expire } = fixture();
+    table.transitionQueuedToRunning(job.jobId);
+    expect(table.finishHeld(job.jobId, ok, ['reply'])).toBe(true);
+    expect(counts(table)).toEqual([1, 0, 0, 0, 1, 1]);
+    expect(expire()).toBe(0);
+    expect(counts(table)).toEqual([1, 0, 0, 0, 1, 1]);
+    expect(table.settleHeldTerminalRelease(job.jobId)).toBe(true);
+    expect(counts(table)).toEqual([0, 0, 0, 0, 1, 0]);
+    expect(table.resourceSnapshot().replyFrames).toEqual({ frameReferences: 1, utf8Bytes: 5 });
+    expect(expire()).toBe(1);
+    expect(counts(table)).toEqual([0, 0, 0, 0, 0, 0]);
+  });
+
+  it.each(['done', 'failed', 'cancelled'] as const)('excludes ordinary %s records while retaining their evidence', (state) => {
+    const { table, job, expire } = fixture();
+    if (state === 'cancelled') table.cancelQueued(job.jobId, ['reply']);
+    else {
+      table.transitionQueuedToRunning(job.jobId);
+      table.finish(job.jobId, state === 'done', ['reply']);
+    }
+    expect(counts(table)).toEqual([0, 0, 0, 0, 1, 0]);
+    expect(table.resourceSnapshot().jobCount).toBe(1);
+    expect(expire()).toBe(1);
+    expect(table.resourceSnapshot().jobCount).toBe(0);
+  });
+});

--- a/tests/broker-resource-snapshot.test.ts
+++ b/tests/broker-resource-snapshot.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest';
+import { JobTable } from '../cli/src/transport/job-table.ts';
+import {
+  collectBrokerResourceSnapshot,
+  type BrokerResourceSnapshot,
+} from '../cli/src/transport/broker-resource-snapshot.ts';
+
+describe('broker retained-resource snapshot', () => {
+  it('counts exact UTF-8 frame ownership without claiming a unique-memory total', () => {
+    const duplicateFrame = JSON.stringify({ id: 'duplicate', text: '🧪' });
+    const pendingFrame = JSON.stringify({ id: 'pending', text: '你好' });
+    const parkedFrame = JSON.stringify({ id: 'parked', text: 'café' });
+    const connectionA = {};
+    const connectionB = {};
+    const pendingChunks = new Map([
+      [connectionA, new Map([
+        ['incomplete-a', { frames: [duplicateFrame, duplicateFrame], lastFrameAt: 1 }],
+      ])],
+      [connectionB, new Map([
+        ['incomplete-b', { frames: [pendingFrame], lastFrameAt: 2 }],
+      ])],
+    ]);
+
+    const jobs = new JobTable(() => 100, (() => {
+      let id = 0;
+      return () => `job-${++id}`;
+    })());
+    const queued = jobs.create({
+      requestId: 'request-queued', cmd: 'SET_TEXT', fileSlug: 'secret-a', readOnly: false,
+      requestFrames: [duplicateFrame, duplicateFrame], from: null, targetInstanceId: 'instance-a',
+    });
+    const running = jobs.create({
+      requestId: 'request-running', cmd: 'GET_SELECTION', fileSlug: 'secret-b', readOnly: true,
+      requestFrames: [pendingFrame], from: null, targetInstanceId: 'instance-b',
+    });
+    jobs.transitionQueuedToRunning(running.jobId);
+    const finished = jobs.create({
+      requestId: 'request-finished', cmd: 'GET_SELECTION', fileSlug: 'secret-c', readOnly: true,
+      requestFrames: [parkedFrame], from: null, targetInstanceId: 'instance-c',
+    });
+    jobs.transitionQueuedToRunning(finished.jobId);
+    jobs.finish(finished.jobId, true, [duplicateFrame]);
+
+    const snapshot = collectBrokerResourceSnapshot({
+      pendingChunks,
+      parkedRequestFrames: [parkedFrame],
+      jobTable: jobs.resourceSnapshot(),
+      queues: new Map([
+        ['secret-a', { running: queued.jobId, waiting: [running.jobId] }],
+        ['secret-b', { running: null, waiting: [] }],
+      ]),
+      pendingRequestReferenceCount: 2,
+      dispatchedRequestReferenceCount: 1,
+      dispatchReservationReferenceCount: 1,
+    });
+
+    expect(snapshot).toEqual({
+      pendingChunks: {
+        connectionCount: 2,
+        incompleteIdCount: 2,
+        frameReferences: 3,
+        utf8Bytes: Buffer.byteLength(duplicateFrame) * 2 + Buffer.byteLength(pendingFrame),
+        perConnection: [
+          { ordinal: 1, incompleteIdCount: 1, frameReferences: 2, utf8Bytes: Buffer.byteLength(duplicateFrame) * 2 },
+          { ordinal: 2, incompleteIdCount: 1, frameReferences: 1, utf8Bytes: Buffer.byteLength(pendingFrame) },
+        ],
+      },
+      parkedRequests: { requestCount: 1, frameReferences: 1, utf8Bytes: Buffer.byteLength(parkedFrame) },
+      jobTable: {
+        jobCount: 3, liveJobCount: 2, queuedJobCount: 1, runningJobCount: 1,
+        outcomeUnknownJobCount: 0, finishedJobCount: 1, retentionHeldJobCount: 0,
+        requestFrames: {
+          frameReferences: 4,
+          utf8Bytes: Buffer.byteLength(duplicateFrame) * 2 + Buffer.byteLength(pendingFrame) + Buffer.byteLength(parkedFrame),
+        },
+        replyFrames: { frameReferences: 1, utf8Bytes: Buffer.byteLength(duplicateFrame) },
+      },
+      fileQueues: {
+        fileQueueCount: 2, occupiedSlotReferenceCount: 1, waitingJobReferenceCount: 1,
+        perFile: [
+          { ordinal: 1, occupiedSlotReferenceCount: 1, waitingJobReferenceCount: 1 },
+          { ordinal: 2, occupiedSlotReferenceCount: 0, waitingJobReferenceCount: 0 },
+        ],
+      },
+      correlations: {
+        pendingRequestReferenceCount: 2,
+        dispatchedRequestReferenceCount: 1,
+        dispatchReservationReferenceCount: 1,
+      },
+      duplicateOwnershipReferences: {
+        jobReferencesFromOccupiedQueueSlots: 1,
+        jobReferencesFromQueueWaitingLists: 1,
+        requestReferencesFromPendingCorrelations: 2,
+        requestReferencesFromDispatchCorrelations: 1,
+        jobReferencesFromDispatchReservations: 1,
+      },
+    });
+    expect(snapshot).not.toHaveProperty('totalBytes');
+    const serialized = JSON.stringify(snapshot);
+    expect(serialized).not.toContain('secret-');
+    expect(serialized).not.toContain('request-');
+    expect(serialized).not.toContain('instance-');
+    expect(serialized).not.toContain('"id":"duplicate"');
+  });
+
+  it('returns deeply frozen copies that cannot mutate owner state', () => {
+    const ownerFrames = ['{"id":"x","text":"🧊"}'];
+    const jobs = new JobTable(() => 1, () => 'job-1');
+    jobs.create({
+      requestId: 'request-1', cmd: 'GET_SELECTION', fileSlug: 'private-file', readOnly: true,
+      requestFrames: ownerFrames, from: null, targetInstanceId: 'private-instance',
+    });
+    const makeSnapshot = (): BrokerResourceSnapshot => collectBrokerResourceSnapshot({
+      pendingChunks: new Map([[{}, new Map([['private-id', { frames: ownerFrames, lastFrameAt: 1 }]])]]),
+      parkedRequestFrames: [], jobTable: jobs.resourceSnapshot(), queues: new Map(),
+      pendingRequestReferenceCount: 0, dispatchedRequestReferenceCount: 0,
+      dispatchReservationReferenceCount: 0,
+    });
+
+    const snapshot = makeSnapshot();
+    expect(Object.isFrozen(snapshot)).toBe(true);
+    expect(Object.isFrozen(snapshot.pendingChunks)).toBe(true);
+    expect(Object.isFrozen(snapshot.pendingChunks.perConnection)).toBe(true);
+    expect(() => (snapshot.pendingChunks.perConnection as unknown[]).push({})).toThrow(TypeError);
+    expect(() => ((snapshot.jobTable as { jobCount: number }).jobCount = 99)).toThrow(TypeError);
+    expect(makeSnapshot().jobTable.jobCount).toBe(1);
+    expect(ownerFrames).toEqual(['{"id":"x","text":"🧊"}']);
+  });
+});


### PR DESCRIPTION
The broker had no read-only way to inspect which pending chunks, parked requests, jobs and file queues retained data. Add an optional in-process observer returning deeply frozen numeric snapshots, exact UTF-8 frame-reference bytes and lifecycle-aware live-job counts. Raw identities, paths, payloads and sockets do not escape. The default broker installs no observer or sampling work.

Validation: behavioral RED for observer registration and three lifecycle cases;157 focused tests and all2664 tests pass, with TypeScript, bundle generation, comment lint and whitespace checks. Independent review approved all six final files. Two sequential current-source socket runs passed seven scenarios each, including checked-in HTML and PNG roundtrips, queue, poll, reconnect and a48MiB synthetic slow consumer. Owned processes, ports and scratch files were cleaned.

Logical reference counts are not unique-memory totals. Physical measurements include observer and harness overhead and one-machine synthetic-workload limits. No production budget, SLO or live Figma qualification is claimed. Trusted observer registration cleanup is tracked separately in #150.

Closes #145.
