### PR TITLE
fix: write binding restart cache privately and report failures

### DIFF
--- a/cli/src/commands/bind.ts
+++ b/cli/src/commands/bind.ts
@@ -110,7 +110,7 @@ export async function run(args: CommandArgs): Promise<unknown> {
   const marker = readBindMarker(projectDir) ?? { v: 1 as const, bindings: [] };
   const entry = upsertBinding(marker, fileName, fileKey);
   writeBindMarker(projectDir, marker);
-  writeBindCache([...readBindCache().projectDirs, projectDir]);
+  const cacheWrite = writeBindCache([...readBindCache().projectDirs, projectDir]);
 
   return {
     projectDir,
@@ -120,5 +120,9 @@ export async function run(args: CommandArgs): Promise<unknown> {
     migratedCount,
     migratedEditCount,
     marker: bindMarkerPath(projectDir),
+    ...(!cacheWrite.ok ? { warnings: [{
+      code: 'E_BIND_CACHE_WRITE', cause: cacheWrite.error.code,
+      message: 'Binding saved, but restart cache was not updated. Inspect the cache directory and reported filesystem cause before retrying bind.',
+    }] } : {}),
   };
 }

--- a/cli/src/transport/bind-cache.ts
+++ b/cli/src/transport/bind-cache.ts
@@ -1,0 +1,44 @@
+import { existsSync, readFileSync, renameSync, unlinkSync } from 'node:fs';
+import { writePrivateFileExclusive } from './private-file-write.ts';
+
+export interface BindCache {
+  v: 1;
+  projectDirs: string[];
+}
+
+export type BindCacheWriteResult = { ok: true } | { ok: false; error: { code: string } };
+
+/** Restart hint only; each project's binding marker remains authoritative. */
+export function bindCacheFile(): string {
+  return process.env['FIGMA_AGENT_BINDS_FILE'] || '/tmp/figma-agent-binds.json';
+}
+
+export function readBindCache(): BindCache {
+  const path = bindCacheFile();
+  if (!existsSync(path)) return { v: 1, projectDirs: [] };
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
+    const dirs = parsed && typeof parsed === 'object' ? (parsed as BindCache).projectDirs : undefined;
+    if (Array.isArray(dirs)) return { v: 1, projectDirs: dirs.filter((d): d is string => typeof d === 'string') };
+  } catch { /* An unreadable hint must not prevent a fresh binding. */ }
+  return { v: 1, projectDirs: [] };
+}
+
+/** Failure preserves the prior cache and reports a cause without invalidating durable bindings. */
+export function writeBindCache(projectDirs: readonly string[]): BindCacheWriteResult {
+  const destination = bindCacheFile();
+  const temporary = `${destination}.${process.pid}.tmp`;
+  try {
+    writePrivateFileExclusive(temporary, JSON.stringify({ v: 1, projectDirs: [...new Set(projectDirs)] }));
+    try {
+      renameSync(temporary, destination);
+    } catch (error) {
+      try { unlinkSync(temporary); } catch { /* Preserve the replacement error. */ }
+      throw error;
+    }
+    return { ok: true };
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException | null)?.code;
+    return { ok: false, error: { code: typeof code === 'string' && /^[A-Z][A-Z0-9_]{0,63}$/.test(code) ? code : 'EIO' } };
+  }
+}

--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -246,6 +246,11 @@ function log(line: string): void {
   } catch { /* logging is best-effort */ }
 }
 
+function persistBindCache(projectDirs: readonly string[]): void {
+  const result = writeBindCache(projectDirs);
+  if (!result.ok) log(`BIND_CACHE write failed (${result.error.code}); restart discovery may require rebinding. Inspect the cache directory and reported filesystem cause.`);
+}
+
 function tryBind(port: number, host: string): Promise<WebSocketServer | null> {
   return new Promise((resolve) => {
     const wss = new WebSocketServer({ host, port });
@@ -561,7 +566,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   // cache + each survivor project's own marker, then immediately rewrite the cache with
   // only the dirs that still look like projects — a stale entry is dropped, never trusted.
   const { index: bindIndex, usableDirs } = loadBindIndex();
-  writeBindCache(usableDirs);
+  persistBindCache(usableDirs);
 
   // One-time startup migration (issue #7 / backlog 5.6 ruling: migrate, never silently
   // orphan) — anything staged under the OLD cwd-relative unbound root, from a broker
@@ -912,7 +917,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     recordBinding(st.bindIndex, identity, { projectDir, source: 'request', at: Date.now() });
     if (!st.knownProjectDirs.has(projectDir)) {
       st.knownProjectDirs.add(projectDir);
-      writeBindCache([...st.knownProjectDirs]);
+      persistBindCache([...st.knownProjectDirs]);
     }
   };
 
@@ -957,7 +962,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     if (fileKey) recordBinding(st.bindIndex, fileKey, { projectDir, source: 'bind', at });
     if (!st.knownProjectDirs.has(projectDir)) {
       st.knownProjectDirs.add(projectDir);
-      writeBindCache([...st.knownProjectDirs]);
+      persistBindCache([...st.knownProjectDirs]);
     }
     // Fix round (finding 1 — BLOCKER): migrate whatever staged while this file was
     // unbound into the now-bound component log, exactly once — `migrateStagedChanges` is

--- a/cli/src/transport/project-bind.ts
+++ b/cli/src/transport/project-bind.ts
@@ -13,6 +13,8 @@
 //     bind would silently stop working until the next CLI request re-teaches it.
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { readBindCache } from './bind-cache.ts';
+export { bindCacheFile, readBindCache, writeBindCache, type BindCache, type BindCacheWriteResult } from './bind-cache.ts';
 
 export type BindSource = 'bind' | 'request';
 
@@ -155,39 +157,6 @@ export function readBindMarker(projectDir: string): BindMarkerFile | null {
 export function writeBindMarker(projectDir: string, marker: BindMarkerFile): void {
   mkdirSync(join(projectDir, 'design'), { recursive: true });
   writeFileSync(bindMarkerPath(projectDir), `${JSON.stringify(marker, null, 2)}\n`, 'utf8');
-}
-
-// ── Restart-survival cache: `/tmp/figma-agent-binds.json` ───────────────────────────
-export interface BindCache {
-  v: 1;
-  projectDirs: string[];
-}
-
-/** Overridable for tests (mirrors FIGMA_AGENT_CHANGES_DIR's precedent); defaults beside
- *  the broker advertisement (BROKER_FILE). */
-export function bindCacheFile(): string {
-  return process.env['FIGMA_AGENT_BINDS_FILE'] || '/tmp/figma-agent-binds.json';
-}
-
-export function readBindCache(): BindCache {
-  const path = bindCacheFile();
-  if (!existsSync(path)) return { v: 1, projectDirs: [] };
-  try {
-    const parsed: unknown = JSON.parse(readFileSync(path, 'utf8'));
-    const dirs = parsed && typeof parsed === 'object' ? (parsed as BindCache).projectDirs : undefined;
-    if (Array.isArray(dirs)) return { v: 1, projectDirs: dirs.filter((d): d is string => typeof d === 'string') };
-    return { v: 1, projectDirs: [] };
-  } catch {
-    return { v: 1, projectDirs: [] }; // a corrupt cache never crashes the broker — start empty
-  }
-}
-
-/** Best-effort write: a failed cache write only costs a slower re-learn after the next
- *  broker restart, never a broken bind (the durable marker is unaffected). */
-export function writeBindCache(projectDirs: readonly string[]): void {
-  try {
-    writeFileSync(bindCacheFile(), JSON.stringify({ v: 1, projectDirs: [...new Set(projectDirs)] }), 'utf8');
-  } catch { /* best-effort */ }
 }
 
 /**

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -137,6 +137,14 @@ This protects these snapshot writes on the local filesystem. Runtime locations a
 other logs, existing-state reads and processes running as the same OS user require separate
 controls. File permissions do not authenticate broker clients.
 
+The binding restart cache uses the same exclusive private temporary-file boundary and
+atomic replacement through [`bind-cache.ts`](../cli/src/transport/bind-cache.ts). A failure
+preserves the previous cache; the daemon logs its filesystem cause and `bind` adds an
+`E_BIND_CACHE_WRITE` warning while reporting the durable binding that was actually saved.
+Inspect the cache directory and reported cause before retrying. Cache locations and project
+binding markers are unchanged; existing live files are not migrated by installing this code.
+A destination symlink is replaced as a directory entry without writing its referent.
+
 ## Troubleshooting
 
 - **Panel says "No broker yet" and never connects** — that's the resting state; it only connects once a CLI

--- a/tests/bind-cache-command-warning.test.ts
+++ b/tests/bind-cache-command-warning.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { parseArgs } from '../cli/src/arg-parse.ts';
+
+vi.mock('../cli/src/transport/broker-client.ts', () => ({
+  runCommand: vi.fn(async () => ({ fileKey: 'OwnedKey', migratedCount: 0, migratedEditCount: 0 })),
+}));
+import { run } from '../cli/src/commands/bind.ts';
+
+let dir: string;
+let project: string;
+const previous = process.env['FIGMA_AGENT_BINDS_FILE'];
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-bind-cache-command-'));
+  project = join(dir, 'project');
+  mkdirSync(project);
+  process.env['FIGMA_AGENT_BINDS_FILE'] = join(dir, 'binds.json');
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+  if (previous === undefined) delete process.env['FIGMA_AGENT_BINDS_FILE'];
+  else process.env['FIGMA_AGENT_BINDS_FILE'] = previous;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+it('returns an honest cache warning while retaining the successful durable binding', async () => {
+  const cache = process.env['FIGMA_AGENT_BINDS_FILE']!;
+  writeFileSync(`${cache}.${process.pid}.tmp`, 'COLLISION');
+  const stdout = vi.spyOn(process.stdout, 'write');
+  const result = await run(parseArgs(['--file', 'Owned file', '--dir', project]));
+  expect(result).toMatchObject({ fileKey: 'OwnedKey', pendingKey: false,
+    warnings: [{ code: 'E_BIND_CACHE_WRITE', cause: 'EEXIST' }] });
+  expect(JSON.parse(readFileSync(join(project, 'design', 'figma-bind.json'), 'utf8')).bindings)
+    .toEqual([expect.objectContaining({ fileKey: 'OwnedKey' })]);
+  expect(readFileSync(`${cache}.${process.pid}.tmp`, 'utf8')).toBe('COLLISION');
+  expect(stdout).not.toHaveBeenCalled();
+});
+
+it('keeps the existing successful command shape without a warning', async () => {
+  const result = await run(parseArgs(['--file', 'Owned file', '--dir', project]));
+  expect(result).toMatchObject({ fileKey: 'OwnedKey', pendingKey: false });
+  expect(result).not.toHaveProperty('warnings');
+});

--- a/tests/bind-cache-failures.test.ts
+++ b/tests/bind-cache-failures.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { fstatSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const faults = vi.hoisted(() => ({ stage: '', descriptors: [] as number[] }));
+vi.mock('node:fs', async (original) => {
+  const fs = await original<typeof import('node:fs')>();
+  const failure = Object.assign(new Error('controlled filesystem refusal'), { code: 'EIO' });
+  return { ...fs,
+    openSync: (...args: Parameters<typeof fs.openSync>) => {
+      const fd = fs.openSync(...args);
+      if (args[1] === 'wx') faults.descriptors.push(fd);
+      return fd;
+    },
+    writeFileSync: (...args: Parameters<typeof fs.writeFileSync>) => {
+      if (faults.stage === 'write') {
+        if (typeof args[0] === 'number') fs.writeSync(args[0], 'partial');
+        else fs.writeFileSync(args[0], 'partial');
+        throw failure;
+      }
+      return fs.writeFileSync(...args);
+    },
+    closeSync: (fd: number) => {
+      fs.closeSync(fd);
+      if (faults.stage === 'close') throw failure;
+    },
+    renameSync: (...args: Parameters<typeof fs.renameSync>) => {
+      if (faults.stage === 'rename') throw failure;
+      return fs.renameSync(...args);
+    },
+  };
+});
+import { writeBindCache } from '../cli/src/transport/project-bind.ts';
+
+let dir: string;
+let destination: string;
+const previous = process.env['FIGMA_AGENT_BINDS_FILE'];
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-bind-cache-fault-'));
+  destination = join(dir, 'binds.json');
+  process.env['FIGMA_AGENT_BINDS_FILE'] = destination;
+  writeFileSync(destination, 'PRIOR');
+});
+afterEach(() => {
+  faults.stage = '';
+  faults.descriptors.length = 0;
+  if (previous === undefined) delete process.env['FIGMA_AGENT_BINDS_FILE'];
+  else process.env['FIGMA_AGENT_BINDS_FILE'] = previous;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+it.each(['write', 'close', 'rename'])('preserves the previous cache and closes owned descriptors after %s refusal', (stage) => {
+  faults.stage = stage;
+  const result = writeBindCache(['owned']);
+  expect(readFileSync(destination, 'utf8')).toBe('PRIOR');
+  expect(result).toEqual({ ok: false, error: { code: 'EIO' } });
+  expect(readdirSync(dir)).toEqual(['binds.json']);
+  expect(faults.descriptors.length).toBeGreaterThan(0);
+  for (const fd of faults.descriptors) expect(() => fstatSync(fd)).toThrow();
+});

--- a/tests/bind-cache-writes.test.ts
+++ b/tests/bind-cache-writes.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { chmodSync, existsSync, lstatSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, symlinkSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { readBindCache, writeBindCache } from '../cli/src/transport/project-bind.ts';
+
+let dir: string;
+let destination: string;
+const previous = process.env['FIGMA_AGENT_BINDS_FILE'];
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), 'fa-bind-cache-write-'));
+  destination = join(dir, 'binds.json');
+  process.env['FIGMA_AGENT_BINDS_FILE'] = destination;
+});
+afterEach(() => {
+  if (previous === undefined) delete process.env['FIGMA_AGENT_BINDS_FILE'];
+  else process.env['FIGMA_AGENT_BINDS_FILE'] = previous;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe('private atomic binding restart cache', () => {
+  it('writes and replaces complete deduplicated snapshots with owner-only mode', () => {
+    const mask = process.umask(0);
+    try { writeBindCache(['owned-a', 'owned-a']); } finally { process.umask(mask); }
+    expect(statSync(destination).mode & 0o777).toBe(0o600);
+    expect(readBindCache()).toEqual({ v: 1, projectDirs: ['owned-a'] });
+    chmodSync(destination, 0o644);
+    expect(writeBindCache(['owned-b'])).toEqual({ ok: true });
+    expect(statSync(destination).mode & 0o777).toBe(0o600);
+    expect(readBindCache()).toEqual({ v: 1, projectDirs: ['owned-b'] });
+    expect(readdirSync(dir)).toEqual(['binds.json']);
+  });
+
+  it.each(['file', 'directory', 'symlink', 'dangling symlink'])('preserves a temporary %s collision and the prior snapshot', (kind) => {
+    writeFileSync(destination, '{"v":1,"projectDirs":["prior"]}');
+    const sentinel = join(dir, 'sentinel');
+    const temporary = `${destination}.${process.pid}.tmp`;
+    writeFileSync(sentinel, 'KEEP');
+    if (kind === 'file') writeFileSync(temporary, 'COLLISION');
+    else if (kind === 'directory') mkdirSync(temporary);
+    else symlinkSync(kind === 'symlink' ? sentinel : join(dir, 'absent'), temporary);
+    expect(writeBindCache(['replacement'])).toMatchObject({ ok: false, error: { code: 'EEXIST' } });
+    expect(readBindCache()).toEqual({ v: 1, projectDirs: ['prior'] });
+    expect(readFileSync(sentinel, 'utf8')).toBe('KEEP');
+    expect(lstatSync(temporary).isSymbolicLink()).toBe(kind.includes('symlink'));
+    if (kind === 'file') expect(readFileSync(temporary, 'utf8')).toBe('COLLISION');
+    expect(existsSync(join(dir, 'absent'))).toBe(false);
+  });
+
+  it('replaces the destination symlink without writing its referent', () => {
+    const sentinel = join(dir, 'sentinel');
+    writeFileSync(sentinel, 'KEEP');
+    symlinkSync(sentinel, destination);
+    writeBindCache(['owned']);
+    expect(readFileSync(sentinel, 'utf8')).toBe('KEEP');
+    expect(lstatSync(destination).isFile()).toBe(true);
+    expect(readBindCache().projectDirs).toEqual(['owned']);
+  });
+
+  it('reports a missing parent without inventing success or creating directories', () => {
+    process.env['FIGMA_AGENT_BINDS_FILE'] = join(dir, 'absent', 'binds.json');
+    expect(writeBindCache(['owned'])).toMatchObject({ ok: false, error: { code: 'ENOENT' } });
+    expect(readdirSync(dir)).toEqual([]);
+  });
+});

--- a/tests/broker-daemon-harness.test.ts
+++ b/tests/broker-daemon-harness.test.ts
@@ -321,6 +321,17 @@ beforeEach(() => {
   sockets = [];
 });
 
+it('logs a binding cache failure while continuing to serve the broker', async () => {
+  const cache = join(scratchDir, 'binds.json');
+  const temporary = `${cache}.${process.pid}.tmp`;
+  writeFileSync(temporary, 'COLLISION');
+  const port = await startTestBroker();
+  const { hello } = await connectAndAwaitBrokerHello(port);
+  expect(hello.type).toBe('BROKER_HELLO');
+  expect(readFileSync(scratchLogFile, 'utf8')).toContain('BIND_CACHE write failed (EEXIST)');
+  expect(readFileSync(temporary, 'utf8')).toBe('COLLISION');
+});
+
 afterEach(async () => {
   // The daemon's OWN designed shutdown path: closes wss/wss6 for real. The `exit` stub's
   // throw is caught by `handleMessage`'s own per-connection try/catch (broker-daemon.ts's


### PR DESCRIPTION
Binding restart hints now use an exclusively acquired private temporary file and atomic replacement. A colliding temporary is preserved, and write, close or rename failures preserve the prior cache. The cache location, schema and durable project binding marker remain unchanged.

The daemon records a bounded filesystem cause when the restart cache cannot be updated. The bind command keeps its successful binding result and adds a machine-readable warning only on a real cache failure. Existing cache state is not migrated; parent-directory integrity and same-user access are outside this write guarantee.

Validation: 2,677 tests pass after integration with current main, including actual filesystem collision and native failure cases; TypeScript checks, bundle generation, comment lint and whitespace checks pass. An owned Darwin filesystem replay confirms mode0600, replacement, deduplication, collision preservation and cleanup. Independent review covers the complete nine-file change.

Closes #149.
