### PR TITLE
fix(broker): close listeners when observer startup fails

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -627,16 +627,28 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
   };
   let resourceObserverTeardown: (() => void) | null = null;
   if (options?.resourceObserver) {
-    const teardown = options.resourceObserver(() => collectBrokerResourceSnapshot({
-      pendingChunks: st.pendingChunks,
-      parkedRequestFrames: st.waiting.map((request) => request.rawText),
-      jobTable: st.jobs.resourceSnapshot(),
-      queues: st.queues,
-      pendingRequestReferenceCount: st.pending.size,
-      dispatchedRequestReferenceCount: st.dispatchedTo.size,
-      dispatchReservationReferenceCount: st.dispatchReservations.size,
-    }));
-    if (typeof teardown === 'function') resourceObserverTeardown = teardown;
+    try {
+      const teardown = options.resourceObserver(() => collectBrokerResourceSnapshot({
+        pendingChunks: st.pendingChunks,
+        parkedRequestFrames: st.waiting.map((request) => request.rawText),
+        jobTable: st.jobs.resourceSnapshot(),
+        queues: st.queues,
+        pendingRequestReferenceCount: st.pending.size,
+        dispatchedRequestReferenceCount: st.dispatchedTo.size,
+        dispatchReservationReferenceCount: st.dispatchReservations.size,
+      }));
+      if (typeof teardown === 'function') resourceObserverTeardown = teardown;
+    } catch (error) {
+      // Startup has not installed its ordinary shutdown handlers or published an advertisement.
+      const listeners = wss6 ? [wss, wss6] : [wss];
+      const closed = await Promise.allSettled(listeners.map((server) => new Promise<void>((resolve, reject) => {
+        for (const client of server.clients) client.terminate();
+        server.close((closeError) => closeError ? reject(closeError) : resolve());
+      })));
+      const failures = closed.filter((result) => result.status === 'rejected').length;
+      if (failures > 0) log(`observer startup cleanup failed for ${failures} listener(s); inspect the broker process before retrying`);
+      throw error;
+    }
   }
   // Sweep leftover `${advertisePath}.<pid>.tmp` files from a prior instance's hard
   // kill (SIGKILL between the temp write and the rename never runs its own cleanup)

--- a/tests/broker-observer-startup-cleanup.test.ts
+++ b/tests/broker-observer-startup-cleanup.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { createServer, type AddressInfo } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { WebSocketServer } from 'ws';
+
+let scratch: string;
+const listeners: { server: WebSocketServer; address: AddressInfo }[] = [];
+const previousEnv = new Map<string, string | undefined>();
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'fa-observer-startup-'));
+  for (const [key, leaf] of Object.entries({
+    FIGMA_AGENT_BINDS_FILE: 'binds.json', FIGMA_AGENT_UNBOUND_DIR: 'unbound', FIGMA_AGENT_CHANGES_DIR: 'changes',
+  })) {
+    previousEnv.set(key, process.env[key]);
+    process.env[key] = join(scratch, leaf);
+  }
+  const emit = WebSocketServer.prototype.emit;
+  vi.spyOn(WebSocketServer.prototype, 'emit').mockImplementation(function (this: WebSocketServer, event, ...args) {
+    if (event === 'listening') listeners.push({ server: this, address: this.address() as AddressInfo });
+    return emit.call(this, event, ...args);
+  });
+});
+
+afterEach(async () => {
+  // The failing pre-fix case owns its leaked listeners too.
+  for (const { server } of listeners) {
+    for (const client of server.clients) client.terminate();
+    if (server.address()) await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+  listeners.length = 0;
+  vi.restoreAllMocks();
+  for (const [key, value] of previousEnv) value === undefined ? delete process.env[key] : process.env[key] = value;
+  previousEnv.clear();
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+it('releases every acquired listener before rejecting observer registration with the original error', async () => {
+  vi.resetModules();
+  const { runBrokerDaemon } = await import('../cli/src/transport/broker-daemon.ts');
+  const original = new Error('owned diagnostics registration refusal');
+  const signals = ['SIGTERM', 'SIGINT', 'uncaughtException'] as const;
+  const signalCounts = signals.map((signal) => process.listenerCount(signal));
+  const intervals = vi.spyOn(globalThis, 'setInterval');
+  const advertisePath = join(scratch, 'broker.json');
+  await expect(runBrokerDaemon({
+    advertisePath, mutationGatePath: join(scratch, 'gates.json'), ports: [0], logFile: join(scratch, 'broker.log'),
+    exit: (code): never => { throw new Error(`unexpected exit ${code}`); },
+    resourceObserver: (getSnapshot) => {
+      expect(getSnapshot().jobTable.jobCount).toBe(0);
+      throw original;
+    },
+  })).rejects.toBe(original);
+  expect(listeners.length).toBeGreaterThanOrEqual(1);
+  expect(listeners.every(({ server }) => server.address() === null)).toBe(true);
+  expect(existsSync(advertisePath)).toBe(false);
+  expect(intervals).not.toHaveBeenCalled();
+  expect(signals.map((signal) => process.listenerCount(signal))).toEqual(signalCounts);
+  for (const { address } of listeners) {
+    const probe = createServer();
+    try {
+      await new Promise<void>((resolve, reject) => {
+        probe.once('error', reject);
+        probe.listen(address.port, address.address, () => resolve());
+      });
+    } finally {
+      if (probe.listening) await new Promise<void>((resolve) => probe.close(() => resolve()));
+    }
+  }
+});


### PR DESCRIPTION
When the optional synchronous resource observer throws during broker startup, the broker now closes its acquired WebSocket listeners before rejecting with the original error. Failed startup cannot leave those ports occupied, and does not publish an advertisement or install ordinary lifetime timers and signal handlers.

Validation: 2,678 tests pass after integration with current main, including a regression that failed against the previous implementation. TypeScript checks, bundle generation, comment lint and whitespace checks pass. An owned Darwin replay confirms IPv4 and IPv6 listener closure, exact-port reuse, the original error, and scratch cleanup. Independent review approved the bounded change; an unrelated intermittent resource-harness assertion is tracked separately in #154.

This repair covers the synchronous observer registration boundary. It does not claim rollback of every possible startup failure or cleanup of external resources created by an observer.

Closes #150.
