### PR TITLE
fix(broker): validate and release request chunks by connection

### DIFF
--- a/cli/src/transport/broker-daemon.ts
+++ b/cli/src/transport/broker-daemon.ts
@@ -21,8 +21,9 @@ import {
   cleanupOrphanedAdvertisementTempFiles, isPidAlive, readAdvertisement, selfBuildMtime, writeAdvertisement,
 } from './broker-discovery.ts';
 import {
-  ChunkAssembler, deleteConnectionChunk, envMs, getConnectionChunks, isChunkMsg, isEventMsg, isReplyMsg, isRequestMsg,
-  parseWireMsg, rawToString, sendWireMsg, sweepAbandonedChunks, type ChunkBuffers,
+  ChunkAssembler, deleteConnectionChunk, deleteConnectionChunks, envMs, getConnectionChunks, isChunkMsg, isEventMsg,
+  isReplyMsg, isRequestMsg, parseWireMsg, rawToString, requestChunkCandidateId, sendWireMsg, summarizeChunkCleanups,
+  sweepAbandonedChunks, validateRequestChunkFrame, type ChunkBuffers, type ChunkCleanup,
 } from './protocol-helpers.ts';
 import { PluginRegistry, appReadiness, suspectedZombie, type PluginEntry } from './plugin-registry.ts';
 import { createSessionTallies, type SessionTallies } from './session-tallies.ts';
@@ -1471,7 +1472,17 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
    * invent a synthetic `CHUNKED` pseudo-command: that would misroute a filtered request
    * and put false metadata in `status`.
    */
-  const admitChunk = (from: WebSocket, id: string, rawText: string, last: boolean): void => {
+  const logChunkRefusal = (
+    code: 'E_INVALID_ARGS' | 'E_CHUNK_LOST', reason: string,
+    retained: ChunkCleanup<WebSocket> | null, rejectedRawText?: string,
+  ): void => {
+    log(`request chunk refused: code=${code} reason=${reason} `
+      + `retainedRequests=${retained?.requestCount ?? 0} retainedFrames=${retained?.frameCount ?? 0} `
+      + `retainedUtf8Bytes=${retained?.utf8Bytes ?? 0} rejectedFrames=${rejectedRawText === undefined ? 0 : 1} `
+      + `rejectedUtf8Bytes=${rejectedRawText === undefined ? 0 : Buffer.byteLength(rejectedRawText, 'utf8')}`);
+  };
+
+  const admitChunk = (from: WebSocket, id: string, rawText: string, candidate: WireMsg): void => {
     const existing = st.jobs.byRequestId(id);
     const parked = st.waiting.find((request) => request.id === id);
     if (existing !== undefined || parked !== undefined) {
@@ -1485,12 +1496,22 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       }
       return;
     }
-    const connChunks = getConnectionChunks(st.pendingChunks, from);
-    const entry = connChunks.get(id);
+    const entry = st.pendingChunks.get(from)?.get(id);
     const buffered = entry?.frames ?? [];
+    const validation = validateRequestChunkFrame(candidate, buffered.length);
+    if (!validation.ok) {
+      const retained = deleteConnectionChunk(st.pendingChunks, from, id);
+      const code = validation.kind === 'sequence' ? 'E_CHUNK_LOST' : 'E_INVALID_ARGS';
+      sendReplyErr(from, id, code, validation.message);
+      logChunkRefusal(code, validation.kind, retained, rawText);
+      return;
+    }
     buffered.push(rawText);
-    if (!last) { connChunks.set(id, { frames: buffered, lastFrameAt: Date.now() }); return; }
-    deleteConnectionChunk(st.pendingChunks, from, id);
+    getConnectionChunks(st.pendingChunks, from).set(id, { frames: buffered, lastFrameAt: Date.now() });
+    if (!validation.frame.last) {
+      return;
+    }
+    const retained = deleteConnectionChunk(st.pendingChunks, from, id);
     let assembled: RequestMsg;
     try {
       const assembler = new ChunkAssembler();
@@ -1506,6 +1527,7 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       if (assembled.id !== id) throw new Error('chunked payload request id does not match its outer chunk id');
     } catch (err) {
       sendReplyErr(from, id, 'E_CHUNK_LOST', `failed to reassemble chunked request: ${(err as Error).message}`);
+      logChunkRefusal('E_CHUNK_LOST', 'reassembly', retained);
       return;
     }
     admitRequest(
@@ -2026,6 +2048,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       st.pending.delete(id);
       st.dispatchedTo.delete(id);
     }
+    const closedChunks = deleteConnectionChunks(st.pendingChunks, ws);
+    if (closedChunks.length > 0) {
+      const released = summarizeChunkCleanups(closedChunks);
+      log(`request chunk close cleanup: requests=${released.requestCount} frames=${released.frameCount} utf8Bytes=${released.utf8Bytes}`);
+    }
     const removedId = st.registry.removeByWs(ws);
     if (removedId !== null) {
       for (const [jobId, reservation] of [...st.dispatchReservations]) {
@@ -2105,7 +2132,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // the transport-only `touch` the raw WS 'pong' handler below uses.
     const isPlugin = st.registry.touchApp(ws);
     if (isPlugin) resumeReadiness(ws, msg);
-    if (isChunkMsg(msg)) {
+    const requestChunkId = isPlugin ? null : requestChunkCandidateId(msg);
+    if (requestChunkId !== null || (isPlugin && isChunkMsg(msg))) {
       // Reply-side chunks (plugin → broker) pass straight to routeFromPlugin, which now
       // accumulates every frame onto the job record itself (concurrency & jobs, backlog
       // 1.1+2.6+4.3) — no reassembly needed here.
@@ -2118,8 +2146,8 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
       // THEN admits the request with its real `cmd`/`readOnly`/`expectedFile`/
       // `projectDir` — never a synthetic pseudo-command that would misroute a filtered
       // request or misclassify its broker-safe-read admission.
-      if (isPlugin) { st.registry.touchActive(ws); routeFromPlugin(msg.id, text, msg.last, ws); }
-      else admitChunk(ws, msg.id, text, msg.last);
+      if (isPlugin && isChunkMsg(msg)) { st.registry.touchActive(ws); routeFromPlugin(msg.id, text, msg.last, ws); }
+      else if (requestChunkId !== null) admitChunk(ws, requestChunkId, text, msg);
     } else if (isReplyMsg(msg)) {
       if (isPlugin) {
         st.registry.touchActive(ws);
@@ -2505,7 +2533,11 @@ export async function runBrokerDaemon(options?: BrokerDaemonOptions): Promise<vo
     // were effectively dead code. The 10-minute TTL is a promise to `figma-agent job`'s
     // caller; a sweep that never runs breaks it silently.
     st.jobs.sweep();
-    sweepAbandonedChunks(st.pendingChunks, now, PARK_SWEEP_INTERVAL_MS);
+    const sweptChunks = sweepAbandonedChunks(st.pendingChunks, now, PARK_SWEEP_INTERVAL_MS);
+    if (sweptChunks.length > 0) {
+      const released = summarizeChunkCleanups(sweptChunks);
+      log(`request chunk sweep cleanup: requests=${released.requestCount} frames=${released.frameCount} utf8Bytes=${released.utf8Bytes}`);
+    }
     for (const [jobId, reservation] of [...st.dispatchReservations]) {
       if (reservation.deadline === undefined || now <= reservation.deadline) continue;
       settleDispatchReservation(jobId, reservation.generation, failedReservation(

--- a/cli/src/transport/protocol-helpers.ts
+++ b/cli/src/transport/protocol-helpers.ts
@@ -148,65 +148,17 @@ export class ChunkAssembler {
   }
 }
 
-/**
- * Concurrency & jobs (backlog 1.1+2.6+4.3), stage-4 fold — a CLI-originated chunked
- * request's frames are buffered (broker-daemon.ts's `admitChunk`) until `last` arrives;
- * a CLI that dies mid-send must not leak that buffer forever. Pure: given each entry's
- * `lastFrameAt` and `now`, which ids are abandoned (no frame in over `boundMs`) — the
- * caller (the SAME park-sweeper interval, no new timer) does the actual `Map.delete`.
- * A still-in-progress send keeps refreshing `lastFrameAt` on every frame and survives.
- */
-export function abandonedChunkIds(
-  pendingChunks: ReadonlyMap<string, { lastFrameAt: number }>,
-  now: number,
-  boundMs: number,
-): string[] {
-  const ids: string[] = [];
-  for (const [id, entry] of pendingChunks) {
-    if (now - entry.lastFrameAt > boundMs) ids.push(id);
-  }
-  return ids;
-}
-
-/**
- * Stage-4 fix round (minor 6) — chunk buffering keyed per CONNECTION (the socket in
- * hand), not by request id alone. Current ids include a random per-process namespace, but
- * the broker does not trust an unassembled frame to honour that contract: legacy or
- * malformed clients can still reuse an id, and a flat map would let their chunk payloads
- * merge into one garbled reassembly. `Conn` is a type param (a real
- * WebSocket in the broker, anything with reference identity in a test) so this stays
- * pure and testable without a socket.
- */
-export type ChunkBuffers<Conn> = Map<Conn, Map<string, { frames: string[]; lastFrameAt: number }>>;
-
-/** Get-or-create the per-connection inner buffer map. */
-export function getConnectionChunks<Conn>(
-  buffers: ChunkBuffers<Conn>,
-  conn: Conn,
-): Map<string, { frames: string[]; lastFrameAt: number }> {
-  let inner = buffers.get(conn);
-  if (!inner) {
-    inner = new Map();
-    buffers.set(conn, inner);
-  }
-  return inner;
-}
-
-/** Drop one id's buffer (fully reassembled, or explicitly abandoned) — and drop the
- *  connection's own outer entry once it has nothing buffered left, so a closed
- *  connection never leaves an empty inner Map sitting in the outer table forever. */
-export function deleteConnectionChunk<Conn>(buffers: ChunkBuffers<Conn>, conn: Conn, id: string): void {
-  const inner = buffers.get(conn);
-  if (!inner) return;
-  inner.delete(id);
-  if (inner.size === 0) buffers.delete(conn);
-}
-
-/** Sweep EVERY connection's own buffer for abandoned entries (reusing `abandonedChunkIds`
- *  per inner map), then prune any connection left holding nothing. */
-export function sweepAbandonedChunks<Conn>(buffers: ChunkBuffers<Conn>, now: number, boundMs: number): void {
-  for (const [conn, inner] of buffers) {
-    for (const id of abandonedChunkIds(inner, now, boundMs)) inner.delete(id);
-    if (inner.size === 0) buffers.delete(conn);
-  }
-}
+// Request-side admission and cleanup live in their own transport boundary. Re-export the
+// established buffer helpers here so existing callers keep the same internal API.
+export {
+  abandonedChunkIds,
+  deleteConnectionChunk,
+  deleteConnectionChunks,
+  getConnectionChunks,
+  requestChunkCandidateId,
+  summarizeChunkCleanups,
+  sweepAbandonedChunks,
+  validateRequestChunkFrame,
+  type ChunkBuffers,
+  type ChunkCleanup,
+} from './request-chunk-admission.ts';

--- a/cli/src/transport/request-chunk-admission.ts
+++ b/cli/src/transport/request-chunk-admission.ts
@@ -1,0 +1,157 @@
+import type { ChunkMsg, WireMsg } from '../../../shared/protocol.ts';
+
+export interface PendingRequestChunk {
+  frames: string[];
+  lastFrameAt: number;
+}
+
+export type ChunkBuffers<Connection> = Map<Connection, Map<string, PendingRequestChunk>>;
+
+export interface ChunkCleanup<Connection> {
+  connection: Connection;
+  id: string;
+  requestCount: 1;
+  frameCount: number;
+  utf8Bytes: number;
+}
+
+export interface ChunkCleanupSummary {
+  requestCount: number;
+  frameCount: number;
+  utf8Bytes: number;
+}
+
+type ChunkValidation =
+  | { ok: true; frame: ChunkMsg }
+  | { ok: false; kind: 'metadata' | 'sequence'; message: string };
+
+function hasOwn(value: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(value, key);
+}
+
+/**
+ * Classify only otherwise-unclassified CLI frames. A valid request or reply keeps its
+ * existing route even if a future envelope adds a top-level chunk-like field.
+ */
+export function requestChunkCandidateId(msg: WireMsg): string | null {
+  const value = msg as unknown as Record<string, unknown>;
+  if (typeof value.id !== 'string') return null;
+  if (typeof value.cmd === 'string' || typeof value.ok === 'boolean') return null;
+  return hasOwn(value, 'seq') || hasOwn(value, 'last') || hasOwn(value, 'chunk') ? value.id : null;
+}
+
+/** Validate request-side metadata and ordering before the raw frame is retained. */
+export function validateRequestChunkFrame(msg: WireMsg, expectedSequence: number): ChunkValidation {
+  const value = msg as unknown as Record<string, unknown>;
+  if (!Number.isSafeInteger(value.seq) || (value.seq as number) < 0) {
+    return { ok: false, kind: 'metadata', message: 'chunk seq must be a nonnegative safe integer' };
+  }
+  if (typeof value.last !== 'boolean') {
+    return { ok: false, kind: 'metadata', message: 'chunk last must be a boolean' };
+  }
+  if (typeof value.chunk !== 'string') {
+    return { ok: false, kind: 'metadata', message: 'chunk payload must be a string' };
+  }
+  if (value.seq !== expectedSequence) {
+    return {
+      ok: false,
+      kind: 'sequence',
+      message: `chunk sequence ${String(value.seq)} does not match expected ${expectedSequence}`,
+    };
+  }
+  return { ok: true, frame: value as unknown as ChunkMsg };
+}
+
+export function getConnectionChunks<Connection>(
+  buffers: ChunkBuffers<Connection>,
+  connection: Connection,
+): Map<string, PendingRequestChunk> {
+  let chunks = buffers.get(connection);
+  if (!chunks) {
+    chunks = new Map();
+    buffers.set(connection, chunks);
+  }
+  return chunks;
+}
+
+function cleanupFor<Connection>(
+  connection: Connection,
+  id: string,
+  entry: PendingRequestChunk,
+): ChunkCleanup<Connection> {
+  let utf8Bytes = 0;
+  for (const frame of entry.frames) utf8Bytes += Buffer.byteLength(frame, 'utf8');
+  return { connection, id, requestCount: 1, frameCount: entry.frames.length, utf8Bytes };
+}
+
+/** Release one connection/id and return its retained usage before deletion. */
+export function deleteConnectionChunk<Connection>(
+  buffers: ChunkBuffers<Connection>,
+  connection: Connection,
+  id: string,
+): ChunkCleanup<Connection> | null {
+  const chunks = buffers.get(connection);
+  const entry = chunks?.get(id);
+  if (!chunks || !entry) return null;
+  const cleanup = cleanupFor(connection, id, entry);
+  chunks.delete(id);
+  if (chunks.size === 0) buffers.delete(connection);
+  return cleanup;
+}
+
+/** Release every partial request owned by one closing connection. */
+export function deleteConnectionChunks<Connection>(
+  buffers: ChunkBuffers<Connection>,
+  connection: Connection,
+): ChunkCleanup<Connection>[] {
+  const chunks = buffers.get(connection);
+  if (!chunks) return [];
+  const cleanups = [...chunks].map(([id, entry]) => cleanupFor(connection, id, entry));
+  buffers.delete(connection);
+  return cleanups;
+}
+
+export function abandonedChunkIds(
+  pendingChunks: ReadonlyMap<string, { lastFrameAt: number }>,
+  now: number,
+  boundMs: number,
+): string[] {
+  const ids: string[] = [];
+  for (const [id, entry] of pendingChunks) {
+    if (now - entry.lastFrameAt > boundMs) ids.push(id);
+  }
+  return ids;
+}
+
+/** Sweep stale partial requests and return exact retained usage for audit/replies. */
+export function sweepAbandonedChunks<Connection>(
+  buffers: ChunkBuffers<Connection>,
+  now: number,
+  boundMs: number,
+): ChunkCleanup<Connection>[] {
+  const cleanups: ChunkCleanup<Connection>[] = [];
+  for (const [connection, chunks] of buffers) {
+    for (const id of abandonedChunkIds(chunks, now, boundMs)) {
+      const entry = chunks.get(id);
+      if (!entry) continue;
+      cleanups.push(cleanupFor(connection, id, entry));
+      chunks.delete(id);
+    }
+    if (chunks.size === 0) buffers.delete(connection);
+  }
+  return cleanups;
+}
+
+export function summarizeChunkCleanups<Connection>(
+  cleanups: readonly ChunkCleanup<Connection>[],
+): ChunkCleanupSummary {
+  let requestCount = 0;
+  let frameCount = 0;
+  let utf8Bytes = 0;
+  for (const cleanup of cleanups) {
+    requestCount += cleanup.requestCount;
+    frameCount += cleanup.frameCount;
+    utf8Bytes += cleanup.utf8Bytes;
+  }
+  return { requestCount, frameCount, utf8Bytes };
+}

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -145,6 +145,15 @@ Inspect the cache directory and reported cause before retrying. Cache locations 
 binding markers are unchanged; existing live files are not migrated by installing this code.
 A destination symlink is replaced as a directory entry without writing its referent.
 
+## Request chunk recovery
+
+CLI request chunks are admitted in strict sequence before retention. A malformed or missing frame
+releases only that connection's affected request; closing the connection releases its partial
+requests immediately. Gap-sweep and close cleanup leave numeric request, frame, and UTF-8-byte
+records in the broker log without payloads or paths. The executable contract lives in
+[`request-chunk-admission.ts`](../cli/src/transport/request-chunk-admission.ts), with daemon coverage
+in [`broker-request-chunk-admission.test.ts`](../tests/broker-request-chunk-admission.test.ts).
+
 ## Troubleshooting
 
 - **Panel says "No broker yet" and never connects** — that's the resting state; it only connects once a CLI

--- a/tests/broker-request-chunk-admission.test.ts
+++ b/tests/broker-request-chunk-admission.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { makeRequestFrame, type EventMsg, type ReplyErr, type WireMsg } from '../shared/protocol.ts';
+import { connect, logPath, nextFrame, registerPlugin, snapshot, startBroker, waitFor } from './broker-request-chunk-fixture';
+
+describe('broker request chunk admission', () => {
+  it('correlates malformed metadata and payload refusals before retention', async () => {
+    const port = await startBroker();
+    const cli = await connect(port);
+    const invalid = [
+      { id: 'negative', seq: -1, last: false, chunk: 'DO_NOT_LOG' },
+      { id: 'missing-seq', last: false, chunk: 'DO_NOT_LOG' },
+      { id: 'fractional', seq: 0.5, last: false, chunk: 'DO_NOT_LOG' },
+      { id: 'unsafe', seq: Number.MAX_SAFE_INTEGER + 1, last: false, chunk: 'DO_NOT_LOG' },
+      { id: 'bad-last', seq: 0, last: 'false', chunk: 'DO_NOT_LOG' },
+      { id: 'bad-payload', seq: 0, last: false, chunk: 42 },
+    ];
+
+    for (const candidate of invalid) {
+      const refusal = nextFrame<ReplyErr>(cli, (frame) => 'id' in frame && frame.id === candidate.id && 'ok' in frame);
+      cli.send(JSON.stringify(candidate));
+      expect((await refusal).error.code).toBe('E_INVALID_ARGS');
+      expect(snapshot().pendingChunks.incompleteIdCount).toBe(0);
+    }
+    const log = readFileSync(logPath, 'utf8');
+    expect(log).not.toContain('DO_NOT_LOG');
+    expect(log).toMatch(/request chunk refused: code=E_INVALID_ARGS .*retainedFrames=0 retainedUtf8Bytes=0 rejectedFrames=1 rejectedUtf8Bytes=\d+/);
+  });
+
+  it('releases an out-of-order id, then accepts a fresh Unicode assembly with an empty fragment', async () => {
+    const port = await startBroker();
+    const plugin = await registerPlugin(port);
+    const cli = await connect(port);
+    const id = 'arbitrary / 🧪 id';
+    const request = JSON.stringify(makeRequestFrame(id, 'GET_SELECTION', { text: '你好🧪' }));
+    cli.send(JSON.stringify({ id, seq: 0, last: false, chunk: request.slice(0, 10) }));
+    const other = await connect(port);
+    const healthy = {
+      ...makeRequestFrame('healthy-request-shape', 'GET_SELECTION', { text: 'still routed as a request' }),
+      seq: 99,
+      last: 'request metadata',
+      chunk: 'request metadata',
+    };
+    other.send(JSON.stringify(healthy));
+    await waitFor(() => plugin.frames.some((frame) => 'id' in frame && frame.id === healthy.id));
+    expect(snapshot().pendingChunks.incompleteIdCount).toBe(1);
+    const refusal = nextFrame<ReplyErr>(cli, (frame) => 'id' in frame && frame.id === id && 'ok' in frame);
+    cli.send(JSON.stringify({ id, seq: 0, last: true, chunk: request.slice(10) }));
+    expect((await refusal).error.code).toBe('E_CHUNK_LOST');
+    expect(snapshot().pendingChunks.incompleteIdCount).toBe(0);
+    cli.send(JSON.stringify({ id, seq: 0, last: false, chunk: '' }));
+    cli.send(JSON.stringify({ id, seq: 1, last: true, chunk: request }));
+    await waitFor(() => plugin.frames.some((frame) => 'id' in frame && frame.id === id));
+    expect(plugin.frames.find((frame) => 'id' in frame && frame.id === id)).toMatchObject({ params: { text: '你好🧪' } });
+  });
+
+  it('runs the existing owner guard before malformed-frame refusal', async () => {
+    const port = await startBroker();
+    const plugin = await registerPlugin(port);
+    const owner = await connect(port);
+    const other = await connect(port);
+    const id = 'owned-before-validation';
+    const state = nextFrame<EventMsg>(owner, (frame) => (frame as EventMsg).type === 'JOB_STATE');
+    owner.send(JSON.stringify(makeRequestFrame(id, 'GET_SELECTION', {})));
+    await state;
+    await waitFor(() => plugin.frames.some((frame) => 'id' in frame && frame.id === id));
+    const ownerFrames: WireMsg[] = [];
+    owner.on('message', (raw) => ownerFrames.push(JSON.parse(raw.toString()) as WireMsg));
+    owner.send(JSON.stringify({ id, seq: 'bad', last: 'bad', chunk: 42 }));
+    const duplicate = nextFrame<ReplyErr>(other, (frame) => 'id' in frame && frame.id === id && 'ok' in frame);
+    other.send(JSON.stringify({ id, seq: 'bad', last: 'bad', chunk: 42 }));
+    expect((await duplicate).error).toMatchObject({ code: 'E_INVALID_ARGS', message: expect.stringContaining('duplicate request id') });
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(ownerFrames.some((frame) => 'id' in frame && frame.id === id && 'ok' in frame)).toBe(false);
+    expect(plugin.frames.filter((frame) => 'id' in frame && frame.id === id)).toHaveLength(1);
+  });
+
+  it('releases partial chunks immediately on close and audits exact retained usage', async () => {
+    const port = await startBroker();
+    const cli = await connect(port);
+    const raw = JSON.stringify({ id: 'close-partial', seq: 0, last: false, chunk: '你好🧪' });
+    cli.send(raw);
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 1);
+    const closed = new Promise<void>((resolve) => cli.once('close', () => resolve()));
+    cli.terminate();
+    await closed;
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 0);
+    expect(readFileSync(logPath, 'utf8')).toContain(
+      `request chunk close cleanup: requests=1 frames=1 utf8Bytes=${Buffer.byteLength(raw, 'utf8')}`,
+    );
+  });
+
+  it('keeps gap-sweep cleanup wire-silent and audits exact retained usage', async () => {
+    const port = await startBroker();
+    const cli = await connect(port);
+    const raw = JSON.stringify({ id: 'sweep-partial', seq: 0, last: false, chunk: 'café🧪' });
+    const received: WireMsg[] = [];
+    cli.on('message', (frame) => received.push(JSON.parse(frame.toString()) as WireMsg));
+    cli.send(raw);
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 1);
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 0);
+    expect(received.some((frame) => 'id' in frame && frame.id === 'sweep-partial')).toBe(false);
+    expect(readFileSync(logPath, 'utf8')).toContain(
+      `request chunk sweep cleanup: requests=1 frames=1 utf8Bytes=${Buffer.byteLength(raw, 'utf8')}`,
+    );
+  });
+
+  it('releases request chunks on close after the socket registers as a plugin', async () => {
+    const port = await startBroker();
+    const cli = await connect(port);
+    await connect(port);
+    const raw = JSON.stringify({ id: 'promoted-partial', seq: 0, last: false, chunk: 'held' });
+    cli.send(raw);
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 1);
+    await registerPlugin(port, cli);
+    const closed = new Promise<void>((resolve) => cli.once('close', () => resolve()));
+    cli.terminate();
+    await closed;
+    await waitFor(() => readFileSync(logPath, 'utf8').includes('plugin [strict-chunk-plugin] disconnected'));
+    expect(snapshot().pendingChunks.incompleteIdCount).toBe(0);
+    expect(readFileSync(logPath, 'utf8')).toContain(
+      `request chunk close cleanup: requests=1 frames=1 utf8Bytes=${Buffer.byteLength(raw, 'utf8')}`,
+    );
+  });
+
+  it('does not settle an admitted request when stale partial chunks reuse its id', async () => {
+    const port = await startBroker();
+    const plugin = await registerPlugin(port);
+    const cli = await connect(port);
+    const id = 'partial-then-admitted';
+    const received: WireMsg[] = [];
+    cli.on('message', (raw) => received.push(JSON.parse(raw.toString()) as WireMsg));
+    cli.send(JSON.stringify({ id, seq: 0, last: false, chunk: '{' }));
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 1);
+    cli.send(JSON.stringify(makeRequestFrame(id, 'GET_SELECTION', {})));
+    await waitFor(() => plugin.frames.some((frame) => 'id' in frame && frame.id === id));
+    await waitFor(() => snapshot().pendingChunks.incompleteIdCount === 0);
+    expect(received.filter((frame) => 'id' in frame && frame.id === id && 'ok' in frame)).toEqual([]);
+    const reply = nextFrame(cli, (frame) => 'id' in frame && frame.id === id && 'ok' in frame);
+    plugin.ws.send(JSON.stringify({ id, ok: true, result: { preserved: true } }));
+    expect(await reply).toMatchObject({ id, ok: true, result: { preserved: true } });
+    expect(plugin.frames.filter((frame) => 'id' in frame && frame.id === id)).toHaveLength(1);
+  });
+});

--- a/tests/broker-request-chunk-fixture.ts
+++ b/tests/broker-request-chunk-fixture.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, vi } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import WebSocket from 'ws';
+import type { EventMsg, WireMsg } from '../shared/protocol.ts';
+import type { BrokerResourceSnapshotGetter } from '../cli/src/transport/broker-resource-snapshot.ts';
+vi.setConfig({ testTimeout: 20_000 });
+let scratch: string;
+let advertisePath: string;
+export let logPath: string;
+let sockets: WebSocket[];
+export let snapshot: BrokerResourceSnapshotGetter;
+const priorEnv = new Map<string, string | undefined>();
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), 'fa-strict-request-chunks-'));
+  advertisePath = join(scratch, 'broker.json');
+  logPath = join(scratch, 'broker.log');
+  sockets = [];
+  const env = {
+    FIGMA_AGENT_PLUGIN_WAIT_MS: '160',
+    FIGMA_AGENT_HEARTBEAT_MS: '1000',
+    FIGMA_AGENT_IDLE_SHUTDOWN_MS: '600000',
+    FIGMA_AGENT_CHANGES_DIR: join(scratch, 'changes'),
+    FIGMA_AGENT_BINDS_FILE: join(scratch, 'binds.json'),
+    FIGMA_AGENT_UNBOUND_DIR: join(scratch, 'unbound'),
+  };
+  for (const [key, value] of Object.entries(env)) {
+    priorEnv.set(key, process.env[key]);
+    process.env[key] = value;
+  }
+});
+afterEach(async () => {
+  for (const ws of sockets) {
+    if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify({ type: 'BROKER_SHUTDOWN_REQUEST' }));
+  }
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  for (const ws of sockets) try { ws.terminate(); } catch { /* already closed */ }
+  rmSync(scratch, { recursive: true, force: true });
+  for (const [key, value] of priorEnv) value === undefined ? delete process.env[key] : process.env[key] = value;
+  priorEnv.clear();
+});
+export async function startBroker(): Promise<number> {
+  vi.resetModules();
+  const { runBrokerDaemon } = await import('../cli/src/transport/broker-daemon.ts');
+  await runBrokerDaemon({
+    advertisePath,
+    mutationGatePath: join(scratch, 'gates.json'),
+    ports: [0],
+    logFile: logPath,
+    exit: (code): never => { throw new Error(`test exit ${code}`); },
+    resourceObserver: (getSnapshot) => { snapshot = getSnapshot; },
+  });
+  return (JSON.parse(readFileSync(advertisePath, 'utf8')) as { port: number }).port;
+}
+export function connect(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    sockets.push(ws);
+    ws.once('open', () => resolve(ws));
+    ws.once('error', reject);
+  });
+}
+export function nextFrame<T extends WireMsg>(ws: WebSocket, predicate: (frame: WireMsg) => boolean): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => finish(new Error('frame timed out')), 2_000);
+    const onMessage = (raw: WebSocket.RawData): void => {
+      const frame = JSON.parse(raw.toString()) as WireMsg;
+      if (predicate(frame)) finish(undefined, frame as T);
+    };
+    const finish = (error?: Error, frame?: T): void => {
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      if (error) reject(error); else resolve(frame!);
+    };
+    ws.on('message', onMessage);
+  });
+}
+export async function waitFor(predicate: () => boolean, timeoutMs = 3_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('condition timed out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+export async function registerPlugin(port: number, existingSocket?: WebSocket): Promise<{ ws: WebSocket; frames: WireMsg[] }> {
+  const ws = existingSocket ?? await connect(port);
+  const frames: WireMsg[] = [];
+  ws.on('message', (raw) => frames.push(JSON.parse(raw.toString()) as WireMsg));
+  const ready = nextFrame<EventMsg>(ws, (frame) => (frame as EventMsg).type === 'SYNC_CONFIG');
+  ws.send(JSON.stringify({
+    type: 'PLUGIN_HELLO',
+    data: { instanceId: 'strict-chunk-plugin', fileName: 'Strict Chunks', fileKey: 'strict-chunks-key', caps: ['fileGuard'] },
+  } satisfies EventMsg));
+  await ready;
+  return { ws, frames };
+}

--- a/tests/chunk-buffer-sweep.test.ts
+++ b/tests/chunk-buffer-sweep.test.ts
@@ -4,7 +4,8 @@
 // interval acts on (no new timer).
 import { describe, expect, it } from 'vitest';
 import {
-  abandonedChunkIds, deleteConnectionChunk, getConnectionChunks, sweepAbandonedChunks, type ChunkBuffers,
+  abandonedChunkIds, deleteConnectionChunk, deleteConnectionChunks, getConnectionChunks, summarizeChunkCleanups,
+  sweepAbandonedChunks, type ChunkBuffers,
 } from '../cli/src/transport/protocol-helpers.ts';
 
 describe('abandonedChunkIds', () => {
@@ -86,6 +87,23 @@ describe('getConnectionChunks / deleteConnectionChunk — per-connection scoping
     const buffers: ChunkBuffers<string> = new Map();
     expect(() => deleteConnectionChunk(buffers, 'never-seen', 'id')).not.toThrow();
   });
+
+  it('returns exact UTF-8 accounting while releasing every id owned by one connection', () => {
+    const buffers: ChunkBuffers<string> = new Map();
+    getConnectionChunks(buffers, 'closing').set('one', { frames: ['a', '你好'], lastFrameAt: 1 });
+    getConnectionChunks(buffers, 'closing').set('two', { frames: ['🧪'], lastFrameAt: 1 });
+    getConnectionChunks(buffers, 'survivor').set('three', { frames: ['safe'], lastFrameAt: 1 });
+
+    const released = summarizeChunkCleanups(deleteConnectionChunks(buffers, 'closing'));
+
+    expect(released).toEqual({
+      requestCount: 2,
+      frameCount: 3,
+      utf8Bytes: Buffer.byteLength('a你好🧪', 'utf8'),
+    });
+    expect(buffers.has('closing')).toBe(false);
+    expect(buffers.has('survivor')).toBe(true);
+  });
 });
 
 describe('sweepAbandonedChunks — per-connection sweep', () => {
@@ -93,9 +111,10 @@ describe('sweepAbandonedChunks — per-connection sweep', () => {
     const buffers: ChunkBuffers<string> = new Map();
     getConnectionChunks(buffers, 'conn-A').set('id-old', { frames: ['a'], lastFrameAt: 0 });
     getConnectionChunks(buffers, 'conn-B').set('id-fresh', { frames: ['b'], lastFrameAt: 900 });
-    sweepAbandonedChunks(buffers, 1_000, 500);
+    const swept = sweepAbandonedChunks(buffers, 1_000, 500);
     expect(buffers.has('conn-A')).toBe(false); // abandoned entry swept, connection pruned
     expect(getConnectionChunks(buffers, 'conn-B').has('id-fresh')).toBe(true); // untouched
+    expect(summarizeChunkCleanups(swept)).toEqual({ requestCount: 1, frameCount: 1, utf8Bytes: 1 });
   });
 
   it('a connection with a mix of stale and fresh entries keeps only the fresh one', () => {


### PR DESCRIPTION
Validate request chunk metadata and exact sequence before retaining frames. Malformed or out-of-order input releases only the affected connection/request, while the existing owner guard protects already admitted jobs and valid request/reply routing remains unchanged.

Connection close now immediately releases its partial chunks even when that socket subsequently registered as a plugin. Close and stale-sweep cleanup record numeric request, frame and UTF-8 byte counts without logging payloads or paths. The existing sweep stays wire-silent so a stale partial cannot terminate a legitimate admitted request using the same ID.

Validation includes real daemon regressions for metadata, ordering, Unicode and empty fragments, duplicate ownership, same-ID sweep preservation, ordinary disconnect and role-promotion disconnect. The role-promotion regression failed against the pre-fix implementation. No new quota, retention deadline, authentication policy or wire format is introduced.

Final validation: 2,686 tests pass, along with TypeScript checks, bundle generation, comment lint and whitespace checks. A fresh owned daemon run passed eight fixture/pressure/recovery scenarios and confirmed process, port and scratch cleanup.

Closes #152.
