### PR TITLE
fix(renderer): isolate shader rendering and validate PNG input

### DIFF
--- a/cli/src/commands/shader-gradient.ts
+++ b/cli/src/commands/shader-gradient.ts
@@ -15,7 +15,7 @@ import { SHADER_GRADIENT_PRESETS } from '../../../shared/shader-gradient-presets
  * Pinned renderer, recorded onto the node so a stale bake stays identifiable.
  * The PUBLISHED version — upstream's package.json at the read revision says 2.4.24,
  * which was never released and 404s everywhere. Keep this in step with
- * RENDERER_VERSION in plugin/src/ui/gradient-host.ts.
+ * RENDERER_VERSION in plugin/src/ui/gradient-render-document.ts.
  */
 const RENDERER = '@shadergradient/react@2.4.20';
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -124,6 +124,23 @@ separate headroom for the existing 8 MiB image producer's base64 output. These a
 budgets bound validation and forwarding; they do not isolate arbitrary renderer JavaScript
 or establish a whole-process memory limit.
 
+## Shader renderer boundary
+
+ShaderGradient runs in an opaque `allow-scripts` child so renderer code cannot share the
+panel origin. The boundary and its exact-source lifecycle live in
+[`gradient-host.ts`](../plugin/src/ui/gradient-host.ts); the pinned renderer document stays
+separate in [`gradient-render-document.ts`](../plugin/src/ui/gradient-render-document.ts).
+The child remains in the panel viewport at zero opacity because Chromium suspends animation
+frames for an opaque offscreen child; hiding it with `visibility:hidden` has the same failure.
+
+PNG admission is shared by the UI and main executor in
+[`gradient-image-admission.ts`](../shared/gradient-image-admission.ts). Its shader-specific
+limit is derived from the supported 4096px RGBA envelope plus PNG/zlib and ancillary-chunk
+headroom; it is intentionally separate from HTML image-fetch budgets. Encoded and decoded
+ceilings bound allocation; signature and IHDR checks bound the image shape, while Figma's
+native decoder remains the final decodability check. `figma-agent shader-gradient --self-test` is read-only, but only a live
+supported Figma host can qualify WebGL availability.
+
 ## Runtime snapshot writes
 
 Advertisement, last-plugin and mutation-gate snapshots acquire temporary files exclusively,

--- a/plugin/code.js
+++ b/plugin/code.js
@@ -7344,20 +7344,92 @@
     return { sourceId: source.id, targetId: target.id, traits, applied, skipped };
   }
 
+  // shared/gradient-image-admission.ts
+  var MAX_GRADIENT_IMAGE_SIDE = 4096;
+  var MAX_GRADIENT_PNG_BYTES = 68 * 1024 * 1024;
+  var MAX_GRADIENT_PNG_BASE64_CHARS = 4 * Math.ceil(MAX_GRADIENT_PNG_BYTES / 3);
+  var PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+  var PNG_HEADER_BYTES = 33;
+  var GradientImageAdmissionError = class extends Error {
+    constructor(message) {
+      super(message);
+      __publicField(this, "code", "E_INVALID_ARGS");
+      this.name = "GradientImageAdmissionError";
+    }
+  };
+  function assertGradientPngByteLength(length) {
+    if (!Number.isSafeInteger(length) || length < PNG_HEADER_BYTES || length > MAX_GRADIENT_PNG_BYTES) {
+      throw new GradientImageAdmissionError(`gradient PNG must be ${PNG_HEADER_BYTES}-${MAX_GRADIENT_PNG_BYTES} bytes`);
+    }
+  }
+  function readUint32(bytes, offset) {
+    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, false);
+  }
+  function validateGradientPngHeader(bytes, expected) {
+    assertGradientPngByteLength(bytes.length);
+    for (let index = 0; index < PNG_SIGNATURE.length; index++) {
+      if (bytes[index] !== PNG_SIGNATURE[index]) {
+        throw new GradientImageAdmissionError("gradient image is missing the PNG signature");
+      }
+    }
+    if (readUint32(bytes, 8) !== 13 || bytes[12] !== 73 || bytes[13] !== 72 || bytes[14] !== 68 || bytes[15] !== 82) {
+      throw new GradientImageAdmissionError("gradient image is missing a canonical IHDR chunk");
+    }
+    const width = readUint32(bytes, 16);
+    const height = readUint32(bytes, 20);
+    if (width < 1 || height < 1 || width > MAX_GRADIENT_IMAGE_SIDE || height > MAX_GRADIENT_IMAGE_SIDE) {
+      throw new GradientImageAdmissionError("gradient PNG dimensions are outside the supported bound");
+    }
+    if (expected && (width !== expected.width || height !== expected.height)) {
+      throw new GradientImageAdmissionError(
+        `gradient PNG dimensions ${width}x${height} do not match requested ${expected.width}x${expected.height}`
+      );
+    }
+    return { width, height };
+  }
+  function validateByte(value, index) {
+    if (typeof value !== "number" || !Number.isInteger(value) || value < 0 || value > 255) {
+      throw new GradientImageAdmissionError(`gradient image byte ${index} is not an integer from 0 to 255`);
+    }
+  }
+  function gradientBytesFromUnknown(raw2) {
+    if (raw2 instanceof Uint8Array) {
+      assertGradientPngByteLength(raw2.length);
+      return raw2;
+    }
+    if (Array.isArray(raw2)) {
+      assertGradientPngByteLength(raw2.length);
+      const keys = Object.keys(raw2);
+      if (keys.length !== raw2.length) throw new GradientImageAdmissionError("gradient image array must be dense and carry no extra keys");
+      for (let index = 0; index < raw2.length; index++) {
+        if (keys[index] !== String(index)) throw new GradientImageAdmissionError("gradient image array keys must be contiguous");
+        validateByte(raw2[index], index);
+      }
+      return new Uint8Array(raw2);
+    }
+    if (raw2 !== null && typeof raw2 === "object") {
+      const keys = Reflect.ownKeys(raw2);
+      assertGradientPngByteLength(keys.length);
+      const source = raw2;
+      for (let index = 0; index < keys.length; index++) {
+        if (keys[index] !== String(index)) throw new GradientImageAdmissionError("gradient image object keys must be contiguous canonical integers");
+        validateByte(source[String(index)], index);
+      }
+      const bytes = new Uint8Array(keys.length);
+      for (let index = 0; index < keys.length; index++) bytes[index] = source[String(index)];
+      return bytes;
+    }
+    throw new GradientImageAdmissionError("gradient image bytes must be a Uint8Array, dense array, or numeric-keyed object");
+  }
+
   // plugin/src/main/executor-gradient.ts
   var GRADIENT_DATA_KEY = "shaderGradientConfig";
   function toBytes(raw2) {
-    if (raw2 instanceof Uint8Array) return raw2;
-    if (Array.isArray(raw2)) return new Uint8Array(raw2);
-    if (raw2 !== null && typeof raw2 === "object") {
-      const values = Object.values(raw2).filter((v) => typeof v === "number");
-      if (values.length > 0) return new Uint8Array(values);
-    }
-    throw new Error("IMPORT_GRADIENT: params.bytes did not carry image data");
+    return gradientBytesFromUnknown(raw2);
   }
   async function importGradient(params) {
     const bytes = toBytes(params.bytes);
-    if (bytes.length === 0) throw new Error("IMPORT_GRADIENT: refusing to bake an empty image");
+    validateGradientPngHeader(bytes);
     let target = null;
     if (typeof params.nodeId === "string" && params.nodeId !== "") {
       const node = await figma.getNodeByIdAsync(params.nodeId);

--- a/plugin/src/main/executor-gradient.ts
+++ b/plugin/src/main/executor-gradient.ts
@@ -10,11 +10,16 @@
 // which renderer revision. Storing the query string means a later command can re-bake the
 // same field at a new size instead of asking the user to remember what they chose.
 
+import {
+  gradientBytesFromUnknown,
+  validateGradientPngHeader,
+} from '../../../shared/gradient-image-admission';
+
 /** Namespace key for the stored config. Read by any later re-bake. */
 export const GRADIENT_DATA_KEY = 'shaderGradientConfig';
 
 export interface ImportGradientParams {
-  /** PNG bytes from the UI render host. Arrives as a plain object across postMessage. */
+  /** PNG bytes from the UI render host. Older senders may use an array or numeric object. */
   bytes?: unknown;
   /** Target node id, or absent to use the current selection. */
   nodeId?: string;
@@ -34,18 +39,11 @@ export interface ImportGradientResult {
 }
 
 /**
- * postMessage does not preserve Uint8Array — a typed array crosses the boundary as a
- * plain object with numeric keys. Reconstructing it is mandatory; handing that object to
- * figma.createImage throws a type error far from its cause.
+ * Figma supports Uint8Array messages. Arrays and numeric-keyed objects remain accepted
+ * for older panels, but every representation is bounded and validated before allocation.
  */
 export function toBytes(raw: unknown): Uint8Array {
-  if (raw instanceof Uint8Array) return raw;
-  if (Array.isArray(raw)) return new Uint8Array(raw as number[]);
-  if (raw !== null && typeof raw === 'object') {
-    const values = Object.values(raw as Record<string, unknown>).filter((v): v is number => typeof v === 'number');
-    if (values.length > 0) return new Uint8Array(values);
-  }
-  throw new Error('IMPORT_GRADIENT: params.bytes did not carry image data');
+  return gradientBytesFromUnknown(raw);
 }
 
 /**
@@ -57,7 +55,7 @@ export function toBytes(raw: unknown): Uint8Array {
  */
 export async function importGradient(params: ImportGradientParams): Promise<ImportGradientResult> {
   const bytes = toBytes(params.bytes);
-  if (bytes.length === 0) throw new Error('IMPORT_GRADIENT: refusing to bake an empty image');
+  validateGradientPngHeader(bytes);
 
   let target: SceneNode | null = null;
   if (typeof params.nodeId === 'string' && params.nodeId !== '') {

--- a/plugin/src/ui/gradient-host.ts
+++ b/plugin/src/ui/gradient-host.ts
@@ -1,242 +1,146 @@
-// Offscreen ShaderGradient render host: draws one gradient field at a given size in a
-// hidden iframe and returns PNG bytes for main to turn into an image fill.
-//
-// Runs in the plugin UI iframe — pure DOM + WebGL, no Figma Plugin API here. Same shape
-// as render-host.ts (HTML_TO_FIGMA), and deliberately so: an offscreen iframe is already
-// this repo's proven way to run untrusted-ish rendering without touching the panel.
-//
-// The renderer is upstream's published ESM, fetched at render time from a CDN the plugin
-// manifest ALREADY allows for the html-to-figma iframe. It is not vendored, because
-// vendoring three + R3F + the renderer would add roughly a megabyte to a UI bundle that
-// is otherwise inlined into the plugin, for a feature most sessions never invoke.
-//
-// What this file will NOT do: follow upstream's own Figma plugin, which loads its whole
-// renderer UI from `shadergradient.co/figma-plugin` in a nested iframe. That makes the
-// feature a live dependency on a third party's marketing site — it breaks when their page
-// changes, and it sends the user's config off-machine. Pinned package, pinned version,
-// loud failure is the trade we take instead.
-
+// Opaque ShaderGradient host: the sandboxed child owns WebGL; the panel accepts one
+// correlated, bounded PNG and never reads the child DOM.
 import type { ShaderGradientProps } from '../../../shared/shader-gradient-presets';
-
-/**
- * Pinned exactly. A range would let a background republish change what a bake produces.
- *
- * This is the PUBLISHED version, which is NOT the version in upstream's package.json at
- * the revision the presets were read from. That file says 2.4.24; changesets bumped it
- * in-repo without a release, so 2.4.24 exists only as source and 404s on every registry
- * and CDN. Read the source version from the repo, but always render with a version that
- * was actually published — see THIRD-PARTY.md for the full record.
- */
-const RENDERER_VERSION = '2.4.20';
-
-/**
- * esm.sh, not a plain CDN bundle, and this is load-bearing rather than a preference.
- *
- * A per-package ESM bundle resolves its OWN copy of react. Import the renderer and react
- * as separate bundles and the page ends up with two react instances, so the renderer's
- * hooks read from an instance that was never mounted and the first render dies on
- * `Cannot read properties of null (reading 'useState')`. esm.sh's `?deps=` pins the
- * shared dependencies so every module resolves to ONE build of each.
- *
- * `@react-three/fiber` is pinned for a second, separate reason: unpinned, esm.sh resolves
- * the latest major (v9), which requires React 19 and dies against React 18 with an equally
- * opaque internal error. 8.17.10 is the pair upstream itself develops against.
- */
-const CDN_BASE = 'https://esm.sh';
-const REACT_VERSION = '18.3.1';
-const DEPS = `react@${REACT_VERSION},react-dom@${REACT_VERSION},three@0.169.0,@react-three/fiber@8.17.10`;
+import {
+  decodeGradientPngDataUrl,
+  GradientImageAdmissionError,
+  validateGradientDimensions,
+} from '../../../shared/gradient-image-admission';
+import { buildRenderDocument } from './gradient-render-document';
+import {
+  boundedGradientErrorCode,
+  boundedGradientErrorMessage,
+  isGradientRenderReply,
+} from './gradient-render-protocol';
 
 const IFRAME_LOAD_TIMEOUT_MS = 15_000;
 const RENDER_TIMEOUT_MS = 45_000;
-/** Frames to let the field settle before reading pixels — a first frame is often mid-compile. */
-const SETTLE_FRAMES = 8;
+const randomRenderId = (): string => typeof globalThis.crypto?.randomUUID === 'function'
+  ? globalThis.crypto.randomUUID()
+  : `gradient_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
 export interface GradientRenderRequest {
   readonly props: ShaderGradientProps;
-  /** Target pixel size of the baked image. */
   readonly width: number;
   readonly height: number;
-  /** Device-pixel multiplier; the produced image is width*scale by height*scale. */
   readonly scale: number;
-  /** Freeze the field at its current uTime rather than animating before capture. */
   readonly staticFrame: boolean;
 }
 
 export class GradientRenderError extends Error {
   readonly code: string;
   constructor(code: string, message: string) {
-    super(message);
-    this.code = code;
+    super(boundedGradientErrorMessage(message));
+    this.code = boundedGradientErrorCode(code);
     this.name = 'GradientRenderError';
   }
 }
 
-/**
- * The document rendered inside the offscreen iframe. It imports the pinned renderer,
- * mounts one field at the exact bake size, waits for it to settle, then posts either
- * a data URL or a structured failure back to this frame.
- *
- * Everything the field needs is passed in as JSON — the iframe never reads outer scope.
- *
- * Exported so scripts/verify-gradient-render.mjs can render THE REAL DOCUMENT rather than a
- * hand-written approximation of it. That distinction is not academic: the dual-React defect
- * lived in this function's import block, and a harness that rebuilt its own HTML would have
- * rendered fine while the shipped document stayed broken.
- */
-export function buildRenderDocument(req: GradientRenderRequest, token: string): string {
-  const w = Math.round(req.width * req.scale);
-  const h = Math.round(req.height * req.scale);
-  const config = JSON.stringify({ props: req.props, staticFrame: req.staticFrame, settle: SETTLE_FRAMES });
+export { buildRenderDocument } from './gradient-render-document';
 
-  return `<!doctype html>
-<html><head><meta charset="utf-8"><style>
-  html,body{margin:0;padding:0;background:transparent;overflow:hidden}
-  #stage{width:${w}px;height:${h}px}
-</style></head>
-<body><div id="stage"></div>
-<script type="module">
-const TOKEN = ${JSON.stringify(token)};
-const CFG = ${config};
-const send = (msg) => parent.postMessage({ __gradientToken: TOKEN, ...msg }, '*');
-const fail = (code, message) => send({ ok: false, code, message: String(message) });
-
-// A module-level error (a failed import, a bad specifier) never reaches the try/catch
-// below, so it is caught here — otherwise the bake would hang until its timeout with
-// no reason recorded, which is the failure mode this whole file exists to avoid.
-window.addEventListener('error', (e) => fail('E_RENDER_SCRIPT', e.message || 'render script error'));
-window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.reason && e.reason.message) || 'render promise rejected'));
-
-(async () => {
-  try {
-    const probe = document.createElement('canvas');
-    const gl = probe.getContext('webgl2') || probe.getContext('webgl');
-    if (!gl) { fail('E_NO_WEBGL', 'this environment provides no WebGL context'); return; }
-
-    const [React, ReactDOMClient, SG] = await Promise.all([
-      import(${JSON.stringify(`${CDN_BASE}/react@${REACT_VERSION}`)}),
-      import(${JSON.stringify(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
-      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
-    ]);
-
-    const { ShaderGradientCanvas, ShaderGradient } = SG;
-    if (!ShaderGradientCanvas || !ShaderGradient) {
-      fail('E_RENDERER_SHAPE', 'the pinned renderer did not export ShaderGradientCanvas/ShaderGradient');
-      return;
+/** Decode and admit the exact PNG representation emitted by canvas.toDataURL. */
+export function decodePngDataUrl(
+  dataUrl: unknown,
+  expected?: { width: number; height: number },
+): Uint8Array {
+  try { return decodeGradientPngDataUrl(dataUrl, expected); }
+  catch (error) {
+    if (error instanceof GradientImageAdmissionError) {
+      throw new GradientRenderError('E_INVALID_IMAGE', error.message);
     }
-
-    const props = { ...CFG.props };
-    if (CFG.staticFrame) props.animate = 'off';
-
-    const el = React.createElement(
-      ShaderGradientCanvas,
-      {
-        style: { width: '100%', height: '100%' },
-        pixelDensity: 1,
-        fov: props.fov,
-        // Required to read pixels back at all: without it the drawing buffer may be
-        // cleared before toDataURL runs and the capture comes back empty.
-        preserveDrawingBuffer: true,
-        lazyLoad: false,
-      },
-      React.createElement(ShaderGradient, props),
-    );
-
-    ReactDOMClient.createRoot(document.getElementById('stage')).render(el);
-
-    // Settle: let the renderer compile, upload, and draw a few frames. A single rAF
-    // routinely captures a black frame mid shader-compile.
-    await new Promise((resolve) => {
-      let n = 0;
-      const tick = () => { if (++n >= CFG.settle) resolve(); else requestAnimationFrame(tick); };
-      requestAnimationFrame(tick);
-    });
-
-    const canvas = document.querySelector('#stage canvas');
-    if (!canvas) { fail('E_NO_CANVAS', 'the renderer mounted no canvas'); return; }
-
-    const dataUrl = canvas.toDataURL('image/png');
-    if (!dataUrl || dataUrl.length < 128) { fail('E_EMPTY_CAPTURE', 'the captured frame was empty'); return; }
-    send({ ok: true, dataUrl });
-  } catch (err) {
-    fail('E_RENDER_FAILED', (err && err.message) || err);
+    throw error;
   }
-})();
-</script></body></html>`;
 }
 
-/** Decode a `data:image/png;base64,...` URL into raw bytes. */
-export function decodePngDataUrl(dataUrl: string): Uint8Array {
-  const comma = dataUrl.indexOf(',');
-  if (!dataUrl.startsWith('data:image/png') || comma === -1) {
-    throw new GradientRenderError('E_EMPTY_CAPTURE', 'capture was not a PNG data URL');
-  }
-  const b64 = dataUrl.slice(comma + 1);
-  const bin = atob(b64);
-  const out = new Uint8Array(bin.length);
-  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-  return out;
-}
-
-/**
- * Render one gradient field offscreen and return its PNG bytes.
- *
- * Throws GradientRenderError with a specific code on every failure path. It never
- * returns a blank or placeholder image: a silent empty bake would land on the canvas
- * looking like a deliberate design choice, and the user would have no way to tell.
- */
+/** Render one gradient in an opaque child and return an admitted PNG. */
 export async function renderGradientToPng(req: GradientRenderRequest): Promise<Uint8Array> {
-  if (!(req.width > 0) || !(req.height > 0)) {
-    throw new GradientRenderError('E_INVALID_ARGS', 'gradient bake needs a positive width and height');
+  let size: { width: number; height: number };
+  try { size = validateGradientDimensions(req.width, req.height, req.scale); }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'gradient bake dimensions are invalid';
+    throw new GradientRenderError('E_INVALID_ARGS', message);
   }
-
-  // Correlates replies to THIS render. Two bakes in flight would otherwise resolve
-  // each other's promises, and the mismatch would be invisible — both produce an image.
-  const token = `gr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-
+  const renderId = randomRenderId();
+  let source: string;
+  try { source = buildRenderDocument(req, renderId); }
+  catch (error) {
+    throw new GradientRenderError(
+      'E_RENDER_SETUP',
+      error instanceof Error ? error.message : 'gradient renderer document setup failed',
+    );
+  }
   const iframe = document.createElement('iframe');
+  iframe.setAttribute('sandbox', 'allow-scripts');
   iframe.setAttribute('aria-hidden', 'true');
-  iframe.style.position = 'absolute';
-  iframe.style.left = '-100000px';
-  iframe.style.top = '0';
-  iframe.style.width = `${Math.round(req.width * req.scale)}px`;
-  iframe.style.height = `${Math.round(req.height * req.scale)}px`;
-  iframe.style.border = '0';
-  document.body.appendChild(iframe);
+  Object.assign(iframe.style, {
+    position: 'fixed',
+    left: '0',
+    top: '0',
+    opacity: '0',
+    pointerEvents: 'none',
+    width: `${size.width}px`,
+    height: `${size.height}px`,
+    border: '0',
+  });
 
-  let onMessage: ((e: MessageEvent) => void) | null = null;
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  return new Promise<Uint8Array>((resolve, reject) => {
+    let settled = false;
+    let loadAttached = false;
+    let messageAttached = false;
+    let loadTimer: ReturnType<typeof setTimeout> | null = null;
+    let renderTimer: ReturnType<typeof setTimeout> | null = null;
+    const clearLoad = (): void => {
+      if (loadTimer !== null) { clearTimeout(loadTimer); loadTimer = null; }
+      if (loadAttached) { iframe.removeEventListener('load', onLoad); loadAttached = false; }
+    };
+    const finish = (bytes?: Uint8Array, error?: GradientRenderError): void => {
+      if (settled) return;
+      settled = true;
+      clearLoad();
+      if (renderTimer !== null) { clearTimeout(renderTimer); renderTimer = null; }
+      if (messageAttached) { window.removeEventListener('message', receive); messageAttached = false; }
+      iframe.remove();
+      if (error) reject(error);
+      else resolve(bytes!);
+    };
+    const onLoad = (): void => clearLoad();
+    const receive = (event: MessageEvent): void => {
+      if (event.source !== iframe.contentWindow || event.origin !== 'null') return;
+      if (!isGradientRenderReply(event.data, renderId)) return;
+      if (event.data.type === 'error') {
+        finish(undefined, new GradientRenderError(
+          boundedGradientErrorCode(event.data.code),
+          boundedGradientErrorMessage(event.data.message),
+        ));
+        return;
+      }
+      try { finish(decodePngDataUrl(event.data.dataUrl, size)); }
+      catch (error) {
+        finish(undefined, error instanceof GradientRenderError
+          ? error
+          : new GradientRenderError('E_INVALID_IMAGE', 'gradient renderer returned invalid image data'));
+      }
+    };
 
-  try {
-    const dataUrl = await new Promise<string>((resolve, reject) => {
-      timer = setTimeout(
-        () => reject(new GradientRenderError('E_TIMEOUT', `gradient render exceeded ${RENDER_TIMEOUT_MS}ms`)),
-        RENDER_TIMEOUT_MS,
-      );
-
-      onMessage = (e: MessageEvent): void => {
-        const d = e.data as { __gradientToken?: string; ok?: boolean; dataUrl?: string; code?: string; message?: string };
-        if (!d || d.__gradientToken !== token) return; // not ours
-        if (d.ok === true && typeof d.dataUrl === 'string') resolve(d.dataUrl);
-        else reject(new GradientRenderError(d.code ?? 'E_RENDER_FAILED', d.message ?? 'gradient render failed'));
-      };
-      window.addEventListener('message', onMessage);
-
-      const loadGuard = setTimeout(() => {
-        // srcdoc never fired load. Proceed anyway is WRONG here (unlike the HTML
-        // converter, which can still walk a partial DOM) — there is nothing to read.
-        reject(new GradientRenderError('E_IFRAME_LOAD', 'the render iframe never loaded'));
+    try {
+      renderTimer = setTimeout(() => {
+        renderTimer = null;
+        finish(undefined, new GradientRenderError('E_TIMEOUT', `gradient render exceeded ${RENDER_TIMEOUT_MS}ms`));
+      }, RENDER_TIMEOUT_MS);
+      window.addEventListener('message', receive);
+      messageAttached = true;
+      loadTimer = setTimeout(() => {
+        loadTimer = null;
+        finish(undefined, new GradientRenderError('E_IFRAME_LOAD', 'the render iframe never loaded'));
       }, IFRAME_LOAD_TIMEOUT_MS);
-      iframe.addEventListener('load', () => clearTimeout(loadGuard), { once: true });
-
-      iframe.srcdoc = buildRenderDocument(req, token);
-    });
-
-    return decodePngDataUrl(dataUrl);
-  } finally {
-    if (timer !== null) clearTimeout(timer);
-    if (onMessage !== null) window.removeEventListener('message', onMessage);
-    // Teardown always runs: an orphaned iframe keeps its WebGL context alive, and
-    // Figma's UI frame has a small, shared context budget.
-    iframe.remove();
-  }
+      iframe.addEventListener('load', onLoad);
+      loadAttached = true;
+      iframe.srcdoc = source;
+      document.body.appendChild(iframe);
+    } catch (error) {
+      finish(undefined, error instanceof GradientRenderError
+        ? error
+        : new GradientRenderError('E_RENDER_SETUP', error instanceof Error ? error.message : 'gradient renderer setup failed'));
+    }
+  });
 }

--- a/plugin/src/ui/gradient-render-document.ts
+++ b/plugin/src/ui/gradient-render-document.ts
@@ -1,0 +1,113 @@
+import type { GradientRenderRequest } from './gradient-host';
+import { validateGradientDimensions } from '../../../shared/gradient-image-admission';
+import {
+  GRADIENT_RENDER_CHANNEL,
+  GRADIENT_RENDER_VERSION,
+  MAX_GRADIENT_ERROR_CODE_LENGTH,
+  MAX_GRADIENT_ERROR_MESSAGE_LENGTH,
+} from './gradient-render-protocol';
+
+const RENDERER_VERSION = '2.4.20';
+const CDN_BASE = 'https://esm.sh';
+const REACT_VERSION = '18.3.1';
+const DEPS = `react@${REACT_VERSION},react-dom@${REACT_VERSION},three@0.169.0,@react-three/fiber@8.17.10`;
+const SETTLE_FRAMES = 8;
+
+function serializeInline(value: unknown): string {
+  return JSON.stringify(value).replace(/[<>&\u2028\u2029]/g, (character) => {
+    switch (character) {
+      case '<': return '\\u003c';
+      case '>': return '\\u003e';
+      case '&': return '\\u0026';
+      case '\u2028': return '\\u2028';
+      default: return '\\u2029';
+    }
+  });
+}
+
+/** The complete opaque child document, exported for the network verifier. */
+export function buildRenderDocument(req: GradientRenderRequest, renderId: string): string {
+  const size = validateGradientDimensions(req.width, req.height, req.scale);
+  const config = serializeInline({
+    props: req.props,
+    staticFrame: req.staticFrame,
+    settle: SETTLE_FRAMES,
+  });
+
+  return `<!doctype html>
+<html><head><meta charset="utf-8"><style>
+  html,body{margin:0;padding:0;background:transparent;overflow:hidden}
+  #stage{width:${size.width}px;height:${size.height}px}
+</style></head>
+<body><div id="stage"></div>
+<script type="module">
+const CHANNEL = ${serializeInline(GRADIENT_RENDER_CHANNEL)};
+const VERSION = ${GRADIENT_RENDER_VERSION};
+const RENDER_ID = ${serializeInline(renderId)};
+const CFG = ${config};
+let terminal = false;
+const send = (message) => {
+  if (terminal) return;
+  terminal = true;
+  parent.postMessage({ channel: CHANNEL, version: VERSION, renderId: RENDER_ID, ...message }, '*');
+};
+const fail = (code, message) => send({
+  type: 'error',
+  code: String(code || 'E_RENDER_FAILED').slice(0, ${MAX_GRADIENT_ERROR_CODE_LENGTH}),
+  message: String(message || 'gradient render failed').slice(0, ${MAX_GRADIENT_ERROR_MESSAGE_LENGTH}),
+});
+
+window.addEventListener('error', (event) => fail('E_RENDER_SCRIPT', event.message || 'render script error'));
+window.addEventListener('unhandledrejection', (event) => fail(
+  'E_RENDER_SCRIPT',
+  (event.reason && event.reason.message) || 'render promise rejected',
+));
+
+(async () => {
+  try {
+    const probe = document.createElement('canvas');
+    const gl = probe.getContext('webgl2') || probe.getContext('webgl');
+    if (!gl) { fail('E_NO_WEBGL', 'this environment provides no WebGL context'); return; }
+
+    const [React, ReactDOMClient, SG] = await Promise.all([
+      import(${serializeInline(`${CDN_BASE}/react@${REACT_VERSION}`)}),
+      import(${serializeInline(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
+      import(${serializeInline(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
+    ]);
+    const { ShaderGradientCanvas, ShaderGradient } = SG;
+    if (!ShaderGradientCanvas || !ShaderGradient) {
+      fail('E_RENDERER_SHAPE', 'the pinned renderer did not export ShaderGradientCanvas/ShaderGradient');
+      return;
+    }
+
+    const props = { ...CFG.props };
+    if (CFG.staticFrame) props.animate = 'off';
+    const element = React.createElement(
+      ShaderGradientCanvas,
+      {
+        style: { width: '100%', height: '100%' },
+        pixelDensity: 1,
+        fov: props.fov,
+        preserveDrawingBuffer: true,
+        lazyLoad: false,
+      },
+      React.createElement(ShaderGradient, props),
+    );
+    ReactDOMClient.createRoot(document.getElementById('stage')).render(element);
+
+    await new Promise((resolve) => {
+      let frames = 0;
+      const tick = () => { if (++frames >= CFG.settle) resolve(); else requestAnimationFrame(tick); };
+      requestAnimationFrame(tick);
+    });
+    const canvas = document.querySelector('#stage canvas');
+    if (!canvas) { fail('E_NO_CANVAS', 'the renderer mounted no canvas'); return; }
+    const dataUrl = canvas.toDataURL('image/png');
+    if (!dataUrl) { fail('E_EMPTY_CAPTURE', 'the captured frame was empty'); return; }
+    send({ type: 'result', dataUrl });
+  } catch (error) {
+    fail('E_RENDER_FAILED', (error && error.message) || error);
+  }
+})();
+</script></body></html>`;
+}

--- a/plugin/src/ui/gradient-render-protocol.ts
+++ b/plugin/src/ui/gradient-render-protocol.ts
@@ -1,0 +1,35 @@
+export const GRADIENT_RENDER_CHANNEL = 'design-os-gradient-render-v1';
+export const GRADIENT_RENDER_VERSION = 1;
+export const MAX_GRADIENT_ERROR_CODE_LENGTH = 64;
+export const MAX_GRADIENT_ERROR_MESSAGE_LENGTH = 512;
+
+export type GradientRenderReply = {
+  channel?: unknown;
+  version?: unknown;
+  renderId?: unknown;
+  type?: unknown;
+  dataUrl?: unknown;
+  code?: unknown;
+  message?: unknown;
+};
+
+export function isGradientRenderReply(value: unknown, renderId: string): value is GradientRenderReply {
+  const reply = value as GradientRenderReply | null;
+  return !!reply
+    && reply.channel === GRADIENT_RENDER_CHANNEL
+    && reply.version === GRADIENT_RENDER_VERSION
+    && reply.renderId === renderId
+    && (reply.type === 'result' || reply.type === 'error');
+}
+
+export function boundedGradientErrorCode(value: unknown): string {
+  return typeof value === 'string' && value !== ''
+    ? value.slice(0, MAX_GRADIENT_ERROR_CODE_LENGTH)
+    : 'E_RENDER_FAILED';
+}
+
+export function boundedGradientErrorMessage(value: unknown): string {
+  return typeof value === 'string' && value !== ''
+    ? value.slice(0, MAX_GRADIENT_ERROR_MESSAGE_LENGTH)
+    : 'gradient render failed';
+}

--- a/plugin/src/ui/ui-relay.ts
+++ b/plugin/src/ui/ui-relay.ts
@@ -377,10 +377,10 @@ async function handleRequest(req: RequestMsg): Promise<void> {
           requestId: req.id,
           cmd: 'IMPORT_GRADIENT',
           expectedFile: req.expectedFile,
-          // Array.from, not the Uint8Array: postMessage does not preserve a typed
-          // array's type, and main reconstructs from a plain numeric collection.
+          // Figma explicitly supports Uint8Array in UI messages. Main retains bounded
+          // array/object compatibility for panels built before this direct transport.
           params: {
-            bytes: Array.from(bytes),
+            bytes,
             nodeId: p.nodeId, config: p.config, slug: p.slug ?? null, renderer: p.renderer,
           },
         },

--- a/plugin/ui.html
+++ b/plugin/ui.html
@@ -1868,7 +1868,7 @@ body {
   var syncBadge = el("fga-sync-badge");
   var activityView = new ActivityView(el("fga-failure-count"));
   var thinkingOrb = mountThinkingOrb(orbHost);
-  var BUILD_LINE = `v0.1.0 \xB7 ${true ? "d94eccf" : "dev"}`;
+  var BUILD_LINE = `v0.1.0 \xB7 ${true ? "578bd17" : "dev"}`;
   var SYNC_RESULT_HOLD_MS = 4e3;
   var payload = null;
   var hadConnection = false;
@@ -3066,42 +3066,199 @@ body {
     });
   }
 
-  // plugin/src/ui/gradient-host.ts
+  // shared/gradient-image-admission.ts
+  var MAX_GRADIENT_IMAGE_SIDE = 4096;
+  var MAX_GRADIENT_PNG_BYTES = 68 * 1024 * 1024;
+  var MAX_GRADIENT_PNG_BASE64_CHARS = 4 * Math.ceil(MAX_GRADIENT_PNG_BYTES / 3);
+  var PNG_DATA_URL_PREFIX = "data:image/png;base64,";
+  var PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10];
+  var PNG_HEADER_BYTES = 33;
+  var GradientImageAdmissionError = class extends Error {
+    constructor(message) {
+      super(message);
+      __publicField(this, "code", "E_INVALID_ARGS");
+      this.name = "GradientImageAdmissionError";
+    }
+  };
+  function validateGradientDimensions(width, height, scale) {
+    if (![width, height, scale].every((value) => Number.isFinite(value) && value > 0)) {
+      throw new GradientImageAdmissionError("gradient bake needs finite positive width, height, and scale");
+    }
+    const pixelWidth = Math.round(width * scale);
+    const pixelHeight = Math.round(height * scale);
+    if (!Number.isSafeInteger(pixelWidth) || !Number.isSafeInteger(pixelHeight) || pixelWidth < 1 || pixelHeight < 1) {
+      throw new GradientImageAdmissionError("gradient bake produced invalid integer pixel dimensions");
+    }
+    if (pixelWidth > MAX_GRADIENT_IMAGE_SIDE || pixelHeight > MAX_GRADIENT_IMAGE_SIDE) {
+      throw new GradientImageAdmissionError(`gradient images cannot exceed ${MAX_GRADIENT_IMAGE_SIDE}px on either side`);
+    }
+    return { width: pixelWidth, height: pixelHeight };
+  }
+  function assertGradientPngByteLength(length) {
+    if (!Number.isSafeInteger(length) || length < PNG_HEADER_BYTES || length > MAX_GRADIENT_PNG_BYTES) {
+      throw new GradientImageAdmissionError(`gradient PNG must be ${PNG_HEADER_BYTES}-${MAX_GRADIENT_PNG_BYTES} bytes`);
+    }
+  }
+  function assertGradientPngBase64Length(length) {
+    if (!Number.isSafeInteger(length) || length < 4 || length > MAX_GRADIENT_PNG_BASE64_CHARS || length % 4 !== 0) {
+      throw new GradientImageAdmissionError(`gradient PNG base64 length is outside the supported bound`);
+    }
+  }
+  function isBase64Character(code) {
+    return code >= 65 && code <= 90 || code >= 97 && code <= 122 || code >= 48 && code <= 57 || code === 43 || code === 47;
+  }
+  function base64Value(code) {
+    if (code >= 65 && code <= 90) return code - 65;
+    if (code >= 97 && code <= 122) return code - 71;
+    if (code >= 48 && code <= 57) return code + 4;
+    return code === 43 ? 62 : 63;
+  }
+  function decodedLengthOfCanonicalBase64(value) {
+    assertGradientPngBase64Length(value.length);
+    const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+    const contentLength = value.length - padding;
+    for (let index = 0; index < contentLength; index++) {
+      if (!isBase64Character(value.charCodeAt(index))) {
+        throw new GradientImageAdmissionError("gradient PNG data URL must contain canonical base64");
+      }
+    }
+    for (let index = contentLength; index < value.length; index++) {
+      if (value.charCodeAt(index) !== 61) {
+        throw new GradientImageAdmissionError("gradient PNG data URL must contain canonical base64 padding");
+      }
+    }
+    if (padding === 2 && (base64Value(value.charCodeAt(contentLength - 1)) & 15) !== 0 || padding === 1 && (base64Value(value.charCodeAt(contentLength - 1)) & 3) !== 0) {
+      throw new GradientImageAdmissionError("gradient PNG data URL must use zeroed canonical base64 padding bits");
+    }
+    const decodedLength = value.length / 4 * 3 - padding;
+    assertGradientPngByteLength(decodedLength);
+    return decodedLength;
+  }
+  function readUint32(bytes, offset) {
+    return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, false);
+  }
+  function validateGradientPngHeader(bytes, expected) {
+    assertGradientPngByteLength(bytes.length);
+    for (let index = 0; index < PNG_SIGNATURE.length; index++) {
+      if (bytes[index] !== PNG_SIGNATURE[index]) {
+        throw new GradientImageAdmissionError("gradient image is missing the PNG signature");
+      }
+    }
+    if (readUint32(bytes, 8) !== 13 || bytes[12] !== 73 || bytes[13] !== 72 || bytes[14] !== 68 || bytes[15] !== 82) {
+      throw new GradientImageAdmissionError("gradient image is missing a canonical IHDR chunk");
+    }
+    const width = readUint32(bytes, 16);
+    const height = readUint32(bytes, 20);
+    if (width < 1 || height < 1 || width > MAX_GRADIENT_IMAGE_SIDE || height > MAX_GRADIENT_IMAGE_SIDE) {
+      throw new GradientImageAdmissionError("gradient PNG dimensions are outside the supported bound");
+    }
+    if (expected && (width !== expected.width || height !== expected.height)) {
+      throw new GradientImageAdmissionError(
+        `gradient PNG dimensions ${width}x${height} do not match requested ${expected.width}x${expected.height}`
+      );
+    }
+    return { width, height };
+  }
+  function decodeGradientPngDataUrl(dataUrl, expected) {
+    if (typeof dataUrl !== "string" || !dataUrl.startsWith(PNG_DATA_URL_PREFIX)) {
+      throw new GradientImageAdmissionError(`gradient capture must use the exact ${PNG_DATA_URL_PREFIX} prefix`);
+    }
+    assertGradientPngBase64Length(dataUrl.length - PNG_DATA_URL_PREFIX.length);
+    const base64 = dataUrl.slice(PNG_DATA_URL_PREFIX.length);
+    const predictedLength = decodedLengthOfCanonicalBase64(base64);
+    const decodeBase64 = globalThis.atob;
+    if (typeof decodeBase64 !== "function") {
+      throw new GradientImageAdmissionError("gradient PNG decoding is unavailable in this environment");
+    }
+    let binary;
+    try {
+      binary = decodeBase64.call(globalThis, base64);
+    } catch {
+      throw new GradientImageAdmissionError("gradient PNG data URL contains invalid base64");
+    }
+    if (binary.length !== predictedLength) {
+      throw new GradientImageAdmissionError("gradient PNG decoded length did not match its canonical base64");
+    }
+    assertGradientPngByteLength(binary.length);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+    validateGradientPngHeader(bytes, expected);
+    return bytes;
+  }
+
+  // plugin/src/ui/gradient-render-protocol.ts
+  var GRADIENT_RENDER_CHANNEL = "design-os-gradient-render-v1";
+  var GRADIENT_RENDER_VERSION = 1;
+  var MAX_GRADIENT_ERROR_CODE_LENGTH = 64;
+  var MAX_GRADIENT_ERROR_MESSAGE_LENGTH = 512;
+  function isGradientRenderReply(value, renderId) {
+    const reply = value;
+    return !!reply && reply.channel === GRADIENT_RENDER_CHANNEL && reply.version === GRADIENT_RENDER_VERSION && reply.renderId === renderId && (reply.type === "result" || reply.type === "error");
+  }
+  function boundedGradientErrorCode(value) {
+    return typeof value === "string" && value !== "" ? value.slice(0, MAX_GRADIENT_ERROR_CODE_LENGTH) : "E_RENDER_FAILED";
+  }
+  function boundedGradientErrorMessage(value) {
+    return typeof value === "string" && value !== "" ? value.slice(0, MAX_GRADIENT_ERROR_MESSAGE_LENGTH) : "gradient render failed";
+  }
+
+  // plugin/src/ui/gradient-render-document.ts
   var RENDERER_VERSION = "2.4.20";
   var CDN_BASE = "https://esm.sh";
   var REACT_VERSION = "18.3.1";
   var DEPS = `react@${REACT_VERSION},react-dom@${REACT_VERSION},three@0.169.0,@react-three/fiber@8.17.10`;
-  var IFRAME_LOAD_TIMEOUT_MS2 = 15e3;
-  var RENDER_TIMEOUT_MS2 = 45e3;
   var SETTLE_FRAMES = 8;
-  var GradientRenderError = class extends Error {
-    constructor(code, message) {
-      super(message);
-      this.code = code;
-      this.name = "GradientRenderError";
-    }
-  };
-  function buildRenderDocument(req, token) {
-    const w = Math.round(req.width * req.scale);
-    const h = Math.round(req.height * req.scale);
-    const config = JSON.stringify({ props: req.props, staticFrame: req.staticFrame, settle: SETTLE_FRAMES });
+  function serializeInline(value) {
+    return JSON.stringify(value).replace(/[<>&\u2028\u2029]/g, (character) => {
+      switch (character) {
+        case "<":
+          return "\\u003c";
+        case ">":
+          return "\\u003e";
+        case "&":
+          return "\\u0026";
+        case "\u2028":
+          return "\\u2028";
+        default:
+          return "\\u2029";
+      }
+    });
+  }
+  function buildRenderDocument(req, renderId) {
+    const size = validateGradientDimensions(req.width, req.height, req.scale);
+    const config = serializeInline({
+      props: req.props,
+      staticFrame: req.staticFrame,
+      settle: SETTLE_FRAMES
+    });
     return `<!doctype html>
 <html><head><meta charset="utf-8"><style>
   html,body{margin:0;padding:0;background:transparent;overflow:hidden}
-  #stage{width:${w}px;height:${h}px}
+  #stage{width:${size.width}px;height:${size.height}px}
 </style></head>
 <body><div id="stage"></div>
 <script type="module">
-const TOKEN = ${JSON.stringify(token)};
+const CHANNEL = ${serializeInline(GRADIENT_RENDER_CHANNEL)};
+const VERSION = ${GRADIENT_RENDER_VERSION};
+const RENDER_ID = ${serializeInline(renderId)};
 const CFG = ${config};
-const send = (msg) => parent.postMessage({ __gradientToken: TOKEN, ...msg }, '*');
-const fail = (code, message) => send({ ok: false, code, message: String(message) });
+let terminal = false;
+const send = (message) => {
+  if (terminal) return;
+  terminal = true;
+  parent.postMessage({ channel: CHANNEL, version: VERSION, renderId: RENDER_ID, ...message }, '*');
+};
+const fail = (code, message) => send({
+  type: 'error',
+  code: String(code || 'E_RENDER_FAILED').slice(0, ${MAX_GRADIENT_ERROR_CODE_LENGTH}),
+  message: String(message || 'gradient render failed').slice(0, ${MAX_GRADIENT_ERROR_MESSAGE_LENGTH}),
+});
 
-// A module-level error (a failed import, a bad specifier) never reaches the try/catch
-// below, so it is caught here \u2014 otherwise the bake would hang until its timeout with
-// no reason recorded, which is the failure mode this whole file exists to avoid.
-window.addEventListener('error', (e) => fail('E_RENDER_SCRIPT', e.message || 'render script error'));
-window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.reason && e.reason.message) || 'render promise rejected'));
+window.addEventListener('error', (event) => fail('E_RENDER_SCRIPT', event.message || 'render script error'));
+window.addEventListener('unhandledrejection', (event) => fail(
+  'E_RENDER_SCRIPT',
+  (event.reason && event.reason.message) || 'render promise rejected',
+));
 
 (async () => {
   try {
@@ -3110,11 +3267,10 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
     if (!gl) { fail('E_NO_WEBGL', 'this environment provides no WebGL context'); return; }
 
     const [React, ReactDOMClient, SG] = await Promise.all([
-      import(${JSON.stringify(`${CDN_BASE}/react@${REACT_VERSION}`)}),
-      import(${JSON.stringify(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
-      import(${JSON.stringify(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
+      import(${serializeInline(`${CDN_BASE}/react@${REACT_VERSION}`)}),
+      import(${serializeInline(`${CDN_BASE}/react-dom@${REACT_VERSION}/client?deps=react@${REACT_VERSION}`)}),
+      import(${serializeInline(`${CDN_BASE}/@shadergradient/react@${RENDERER_VERSION}?deps=${DEPS}`)}),
     ]);
-
     const { ShaderGradientCanvas, ShaderGradient } = SG;
     if (!ShaderGradientCanvas || !ShaderGradient) {
       fail('E_RENDERER_SHAPE', 'the pinned renderer did not export ShaderGradientCanvas/ShaderGradient');
@@ -3123,95 +3279,156 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
 
     const props = { ...CFG.props };
     if (CFG.staticFrame) props.animate = 'off';
-
-    const el = React.createElement(
+    const element = React.createElement(
       ShaderGradientCanvas,
       {
         style: { width: '100%', height: '100%' },
         pixelDensity: 1,
         fov: props.fov,
-        // Required to read pixels back at all: without it the drawing buffer may be
-        // cleared before toDataURL runs and the capture comes back empty.
         preserveDrawingBuffer: true,
         lazyLoad: false,
       },
       React.createElement(ShaderGradient, props),
     );
+    ReactDOMClient.createRoot(document.getElementById('stage')).render(element);
 
-    ReactDOMClient.createRoot(document.getElementById('stage')).render(el);
-
-    // Settle: let the renderer compile, upload, and draw a few frames. A single rAF
-    // routinely captures a black frame mid shader-compile.
     await new Promise((resolve) => {
-      let n = 0;
-      const tick = () => { if (++n >= CFG.settle) resolve(); else requestAnimationFrame(tick); };
+      let frames = 0;
+      const tick = () => { if (++frames >= CFG.settle) resolve(); else requestAnimationFrame(tick); };
       requestAnimationFrame(tick);
     });
-
     const canvas = document.querySelector('#stage canvas');
     if (!canvas) { fail('E_NO_CANVAS', 'the renderer mounted no canvas'); return; }
-
     const dataUrl = canvas.toDataURL('image/png');
-    if (!dataUrl || dataUrl.length < 128) { fail('E_EMPTY_CAPTURE', 'the captured frame was empty'); return; }
-    send({ ok: true, dataUrl });
-  } catch (err) {
-    fail('E_RENDER_FAILED', (err && err.message) || err);
+    if (!dataUrl) { fail('E_EMPTY_CAPTURE', 'the captured frame was empty'); return; }
+    send({ type: 'result', dataUrl });
+  } catch (error) {
+    fail('E_RENDER_FAILED', (error && error.message) || error);
   }
 })();
 <\/script></body></html>`;
   }
-  function decodePngDataUrl(dataUrl) {
-    const comma = dataUrl.indexOf(",");
-    if (!dataUrl.startsWith("data:image/png") || comma === -1) {
-      throw new GradientRenderError("E_EMPTY_CAPTURE", "capture was not a PNG data URL");
+
+  // plugin/src/ui/gradient-host.ts
+  var IFRAME_LOAD_TIMEOUT_MS2 = 15e3;
+  var RENDER_TIMEOUT_MS2 = 45e3;
+  var randomRenderId = () => typeof globalThis.crypto?.randomUUID === "function" ? globalThis.crypto.randomUUID() : `gradient_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+  var GradientRenderError = class extends Error {
+    constructor(code, message) {
+      super(boundedGradientErrorMessage(message));
+      this.code = boundedGradientErrorCode(code);
+      this.name = "GradientRenderError";
     }
-    const b64 = dataUrl.slice(comma + 1);
-    const bin = atob(b64);
-    const out = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
-    return out;
+  };
+  function decodePngDataUrl(dataUrl, expected) {
+    try {
+      return decodeGradientPngDataUrl(dataUrl, expected);
+    } catch (error) {
+      if (error instanceof GradientImageAdmissionError) {
+        throw new GradientRenderError("E_INVALID_IMAGE", error.message);
+      }
+      throw error;
+    }
   }
   async function renderGradientToPng(req) {
-    if (!(req.width > 0) || !(req.height > 0)) {
-      throw new GradientRenderError("E_INVALID_ARGS", "gradient bake needs a positive width and height");
-    }
-    const token = `gr_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
-    const iframe = document.createElement("iframe");
-    iframe.setAttribute("aria-hidden", "true");
-    iframe.style.position = "absolute";
-    iframe.style.left = "-100000px";
-    iframe.style.top = "0";
-    iframe.style.width = `${Math.round(req.width * req.scale)}px`;
-    iframe.style.height = `${Math.round(req.height * req.scale)}px`;
-    iframe.style.border = "0";
-    document.body.appendChild(iframe);
-    let onMessage = null;
-    let timer = null;
+    let size;
     try {
-      const dataUrl = await new Promise((resolve, reject) => {
-        timer = setTimeout(
-          () => reject(new GradientRenderError("E_TIMEOUT", `gradient render exceeded ${RENDER_TIMEOUT_MS2}ms`)),
-          RENDER_TIMEOUT_MS2
-        );
-        onMessage = (e) => {
-          const d = e.data;
-          if (!d || d.__gradientToken !== token) return;
-          if (d.ok === true && typeof d.dataUrl === "string") resolve(d.dataUrl);
-          else reject(new GradientRenderError(d.code ?? "E_RENDER_FAILED", d.message ?? "gradient render failed"));
-        };
-        window.addEventListener("message", onMessage);
-        const loadGuard = setTimeout(() => {
-          reject(new GradientRenderError("E_IFRAME_LOAD", "the render iframe never loaded"));
-        }, IFRAME_LOAD_TIMEOUT_MS2);
-        iframe.addEventListener("load", () => clearTimeout(loadGuard), { once: true });
-        iframe.srcdoc = buildRenderDocument(req, token);
-      });
-      return decodePngDataUrl(dataUrl);
-    } finally {
-      if (timer !== null) clearTimeout(timer);
-      if (onMessage !== null) window.removeEventListener("message", onMessage);
-      iframe.remove();
+      size = validateGradientDimensions(req.width, req.height, req.scale);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "gradient bake dimensions are invalid";
+      throw new GradientRenderError("E_INVALID_ARGS", message);
     }
+    const renderId = randomRenderId();
+    let source;
+    try {
+      source = buildRenderDocument(req, renderId);
+    } catch (error) {
+      throw new GradientRenderError(
+        "E_RENDER_SETUP",
+        error instanceof Error ? error.message : "gradient renderer document setup failed"
+      );
+    }
+    const iframe = document.createElement("iframe");
+    iframe.setAttribute("sandbox", "allow-scripts");
+    iframe.setAttribute("aria-hidden", "true");
+    Object.assign(iframe.style, {
+      position: "fixed",
+      left: "0",
+      top: "0",
+      opacity: "0",
+      pointerEvents: "none",
+      width: `${size.width}px`,
+      height: `${size.height}px`,
+      border: "0"
+    });
+    return new Promise((resolve, reject) => {
+      let settled = false;
+      let loadAttached = false;
+      let messageAttached = false;
+      let loadTimer = null;
+      let renderTimer = null;
+      const clearLoad = () => {
+        if (loadTimer !== null) {
+          clearTimeout(loadTimer);
+          loadTimer = null;
+        }
+        if (loadAttached) {
+          iframe.removeEventListener("load", onLoad);
+          loadAttached = false;
+        }
+      };
+      const finish = (bytes, error) => {
+        if (settled) return;
+        settled = true;
+        clearLoad();
+        if (renderTimer !== null) {
+          clearTimeout(renderTimer);
+          renderTimer = null;
+        }
+        if (messageAttached) {
+          window.removeEventListener("message", receive);
+          messageAttached = false;
+        }
+        iframe.remove();
+        if (error) reject(error);
+        else resolve(bytes);
+      };
+      const onLoad = () => clearLoad();
+      const receive = (event) => {
+        if (event.source !== iframe.contentWindow || event.origin !== "null") return;
+        if (!isGradientRenderReply(event.data, renderId)) return;
+        if (event.data.type === "error") {
+          finish(void 0, new GradientRenderError(
+            boundedGradientErrorCode(event.data.code),
+            boundedGradientErrorMessage(event.data.message)
+          ));
+          return;
+        }
+        try {
+          finish(decodePngDataUrl(event.data.dataUrl, size));
+        } catch (error) {
+          finish(void 0, error instanceof GradientRenderError ? error : new GradientRenderError("E_INVALID_IMAGE", "gradient renderer returned invalid image data"));
+        }
+      };
+      try {
+        renderTimer = setTimeout(() => {
+          renderTimer = null;
+          finish(void 0, new GradientRenderError("E_TIMEOUT", `gradient render exceeded ${RENDER_TIMEOUT_MS2}ms`));
+        }, RENDER_TIMEOUT_MS2);
+        window.addEventListener("message", receive);
+        messageAttached = true;
+        loadTimer = setTimeout(() => {
+          loadTimer = null;
+          finish(void 0, new GradientRenderError("E_IFRAME_LOAD", "the render iframe never loaded"));
+        }, IFRAME_LOAD_TIMEOUT_MS2);
+        iframe.addEventListener("load", onLoad);
+        loadAttached = true;
+        iframe.srcdoc = source;
+        document.body.appendChild(iframe);
+      } catch (error) {
+        finish(void 0, error instanceof GradientRenderError ? error : new GradientRenderError("E_RENDER_SETUP", error instanceof Error ? error.message : "gradient renderer setup failed"));
+      }
+    });
   }
 
   // plugin/src/ui/activity-summary.ts
@@ -3645,10 +3862,10 @@ window.addEventListener('unhandledrejection', (e) => fail('E_RENDER_SCRIPT', (e.
             requestId: req.id,
             cmd: "IMPORT_GRADIENT",
             expectedFile: req.expectedFile,
-            // Array.from, not the Uint8Array: postMessage does not preserve a typed
-            // array's type, and main reconstructs from a plain numeric collection.
+            // Figma explicitly supports Uint8Array in UI messages. Main retains bounded
+            // array/object compatibility for panels built before this direct transport.
             params: {
-              bytes: Array.from(bytes),
+              bytes,
               nodeId: p.nodeId,
               config: p.config,
               slug: p.slug ?? null,

--- a/shared/gradient-image-admission.ts
+++ b/shared/gradient-image-admission.ts
@@ -1,0 +1,181 @@
+export const MAX_GRADIENT_IMAGE_SIDE = 4096;
+
+// 4096² RGBA is 67,108,864 raw bytes. PNG adds one filter byte per row;
+// zlib's compressBound formula and required PNG chunks bring the worst-case
+// encoded pixel stream to 67,133,513 bytes. 68 MiB retains ~4 MiB for normal
+// ancillary chunks without admitting unbounded metadata.
+export const MAX_GRADIENT_PNG_BYTES = 68 * 1024 * 1024;
+export const MAX_GRADIENT_PNG_BASE64_CHARS = 4 * Math.ceil(MAX_GRADIENT_PNG_BYTES / 3);
+export const PNG_DATA_URL_PREFIX = 'data:image/png;base64,';
+
+const PNG_SIGNATURE = [137, 80, 78, 71, 13, 10, 26, 10] as const;
+const PNG_HEADER_BYTES = 33;
+
+export class GradientImageAdmissionError extends Error {
+  readonly code = 'E_INVALID_ARGS';
+  constructor(message: string) {
+    super(message);
+    this.name = 'GradientImageAdmissionError';
+  }
+}
+
+export interface GradientPixelSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+export function validateGradientDimensions(width: number, height: number, scale: number): GradientPixelSize {
+  if (![width, height, scale].every((value) => Number.isFinite(value) && value > 0)) {
+    throw new GradientImageAdmissionError('gradient bake needs finite positive width, height, and scale');
+  }
+  const pixelWidth = Math.round(width * scale);
+  const pixelHeight = Math.round(height * scale);
+  if (!Number.isSafeInteger(pixelWidth) || !Number.isSafeInteger(pixelHeight) || pixelWidth < 1 || pixelHeight < 1) {
+    throw new GradientImageAdmissionError('gradient bake produced invalid integer pixel dimensions');
+  }
+  if (pixelWidth > MAX_GRADIENT_IMAGE_SIDE || pixelHeight > MAX_GRADIENT_IMAGE_SIDE) {
+    throw new GradientImageAdmissionError(`gradient images cannot exceed ${MAX_GRADIENT_IMAGE_SIDE}px on either side`);
+  }
+  return { width: pixelWidth, height: pixelHeight };
+}
+
+export function assertGradientPngByteLength(length: number): void {
+  if (!Number.isSafeInteger(length) || length < PNG_HEADER_BYTES || length > MAX_GRADIENT_PNG_BYTES) {
+    throw new GradientImageAdmissionError(`gradient PNG must be ${PNG_HEADER_BYTES}-${MAX_GRADIENT_PNG_BYTES} bytes`);
+  }
+}
+
+export function assertGradientPngBase64Length(length: number): void {
+  if (!Number.isSafeInteger(length) || length < 4 || length > MAX_GRADIENT_PNG_BASE64_CHARS || length % 4 !== 0) {
+    throw new GradientImageAdmissionError(`gradient PNG base64 length is outside the supported bound`);
+  }
+}
+
+function isBase64Character(code: number): boolean {
+  return (code >= 65 && code <= 90)
+    || (code >= 97 && code <= 122)
+    || (code >= 48 && code <= 57)
+    || code === 43
+    || code === 47;
+}
+
+function base64Value(code: number): number {
+  if (code >= 65 && code <= 90) return code - 65;
+  if (code >= 97 && code <= 122) return code - 71;
+  if (code >= 48 && code <= 57) return code + 4;
+  return code === 43 ? 62 : 63;
+}
+
+export function decodedLengthOfCanonicalBase64(value: string): number {
+  assertGradientPngBase64Length(value.length);
+  const padding = value.endsWith('==') ? 2 : value.endsWith('=') ? 1 : 0;
+  const contentLength = value.length - padding;
+  for (let index = 0; index < contentLength; index++) {
+    if (!isBase64Character(value.charCodeAt(index))) {
+      throw new GradientImageAdmissionError('gradient PNG data URL must contain canonical base64');
+    }
+  }
+  for (let index = contentLength; index < value.length; index++) {
+    if (value.charCodeAt(index) !== 61) {
+      throw new GradientImageAdmissionError('gradient PNG data URL must contain canonical base64 padding');
+    }
+  }
+  if ((padding === 2 && (base64Value(value.charCodeAt(contentLength - 1)) & 15) !== 0)
+      || (padding === 1 && (base64Value(value.charCodeAt(contentLength - 1)) & 3) !== 0)) {
+    throw new GradientImageAdmissionError('gradient PNG data URL must use zeroed canonical base64 padding bits');
+  }
+  const decodedLength = (value.length / 4) * 3 - padding;
+  assertGradientPngByteLength(decodedLength);
+  return decodedLength;
+}
+
+function readUint32(bytes: Uint8Array, offset: number): number {
+  return new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength).getUint32(offset, false);
+}
+
+export function validateGradientPngHeader(
+  bytes: Uint8Array,
+  expected?: GradientPixelSize,
+): GradientPixelSize {
+  assertGradientPngByteLength(bytes.length);
+  for (let index = 0; index < PNG_SIGNATURE.length; index++) {
+    if (bytes[index] !== PNG_SIGNATURE[index]) {
+      throw new GradientImageAdmissionError('gradient image is missing the PNG signature');
+    }
+  }
+  if (readUint32(bytes, 8) !== 13
+      || bytes[12] !== 73 || bytes[13] !== 72 || bytes[14] !== 68 || bytes[15] !== 82) {
+    throw new GradientImageAdmissionError('gradient image is missing a canonical IHDR chunk');
+  }
+  const width = readUint32(bytes, 16);
+  const height = readUint32(bytes, 20);
+  if (width < 1 || height < 1 || width > MAX_GRADIENT_IMAGE_SIDE || height > MAX_GRADIENT_IMAGE_SIDE) {
+    throw new GradientImageAdmissionError('gradient PNG dimensions are outside the supported bound');
+  }
+  if (expected && (width !== expected.width || height !== expected.height)) {
+    throw new GradientImageAdmissionError(
+      `gradient PNG dimensions ${width}x${height} do not match requested ${expected.width}x${expected.height}`,
+    );
+  }
+  return { width, height };
+}
+
+export function decodeGradientPngDataUrl(dataUrl: unknown, expected?: GradientPixelSize): Uint8Array {
+  if (typeof dataUrl !== 'string' || !dataUrl.startsWith(PNG_DATA_URL_PREFIX)) {
+    throw new GradientImageAdmissionError(`gradient capture must use the exact ${PNG_DATA_URL_PREFIX} prefix`);
+  }
+  assertGradientPngBase64Length(dataUrl.length - PNG_DATA_URL_PREFIX.length);
+  const base64 = dataUrl.slice(PNG_DATA_URL_PREFIX.length);
+  const predictedLength = decodedLengthOfCanonicalBase64(base64);
+  const decodeBase64 = (globalThis as unknown as { atob?: (value: string) => string }).atob;
+  if (typeof decodeBase64 !== 'function') {
+    throw new GradientImageAdmissionError('gradient PNG decoding is unavailable in this environment');
+  }
+  let binary: string;
+  try { binary = decodeBase64.call(globalThis, base64); }
+  catch { throw new GradientImageAdmissionError('gradient PNG data URL contains invalid base64'); }
+  if (binary.length !== predictedLength) {
+    throw new GradientImageAdmissionError('gradient PNG decoded length did not match its canonical base64');
+  }
+  assertGradientPngByteLength(binary.length);
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index++) bytes[index] = binary.charCodeAt(index);
+  validateGradientPngHeader(bytes, expected);
+  return bytes;
+}
+
+function validateByte(value: unknown, index: number): asserts value is number {
+  if (typeof value !== 'number' || !Number.isInteger(value) || value < 0 || value > 255) {
+    throw new GradientImageAdmissionError(`gradient image byte ${index} is not an integer from 0 to 255`);
+  }
+}
+
+export function gradientBytesFromUnknown(raw: unknown): Uint8Array {
+  if (raw instanceof Uint8Array) {
+    assertGradientPngByteLength(raw.length);
+    return raw;
+  }
+  if (Array.isArray(raw)) {
+    assertGradientPngByteLength(raw.length);
+    const keys = Object.keys(raw);
+    if (keys.length !== raw.length) throw new GradientImageAdmissionError('gradient image array must be dense and carry no extra keys');
+    for (let index = 0; index < raw.length; index++) {
+      if (keys[index] !== String(index)) throw new GradientImageAdmissionError('gradient image array keys must be contiguous');
+      validateByte(raw[index], index);
+    }
+    return new Uint8Array(raw);
+  }
+  if (raw !== null && typeof raw === 'object') {
+    const keys = Reflect.ownKeys(raw);
+    assertGradientPngByteLength(keys.length);
+    const source = raw as Record<string, unknown>;
+    for (let index = 0; index < keys.length; index++) {
+      if (keys[index] !== String(index)) throw new GradientImageAdmissionError('gradient image object keys must be contiguous canonical integers');
+      validateByte(source[String(index)], index);
+    }
+    const bytes = new Uint8Array(keys.length);
+    for (let index = 0; index < keys.length; index++) bytes[index] = source[String(index)] as number;
+    return bytes;
+  }
+  throw new GradientImageAdmissionError('gradient image bytes must be a Uint8Array, dense array, or numeric-keyed object');
+}

--- a/tests/executor-gradient.test.ts
+++ b/tests/executor-gradient.test.ts
@@ -8,69 +8,50 @@
 import { describe, expect, it, beforeEach, vi } from 'vitest';
 
 import { importGradient, toBytes, GRADIENT_DATA_KEY } from '../plugin/src/main/executor-gradient';
-
-interface FakeNode {
-  id: string;
-  name: string;
-  type: string;
-  fills?: unknown;
-  pluginData: Record<string, string>;
-  setPluginData(k: string, v: string): void;
-}
-
-function makeNode(over: Partial<FakeNode> = {}): FakeNode {
-  const node: FakeNode = {
-    id: over.id ?? '1:2',
-    name: over.name ?? 'Hero',
-    type: over.type ?? 'RECTANGLE',
-    fills: 'fills' in over ? over.fills : [],
-    pluginData: {},
-    setPluginData(k, v) { this.pluginData[k] = v; },
-  };
-  if (!('fills' in over)) node.fills = [];
-  else if (over.fills === undefined) delete (node as Partial<FakeNode>).fills;
-  return node;
-}
+import { PNG_DATA_URL } from './gradient-png-fixture';
+import { makeNode, type FakeNode } from './gradient-node-fixture';
 
 let nodes: Record<string, FakeNode>;
 let selection: FakeNode[];
 let createdBytes: Uint8Array[];
+let getNodeByIdAsync: ReturnType<typeof vi.fn>;
+
+const PNG = Uint8Array.from(Buffer.from(PNG_DATA_URL.split(',')[1]!, 'base64'));
 
 beforeEach(() => {
   nodes = {};
   selection = [];
   createdBytes = [];
+  getNodeByIdAsync = vi.fn(async (id: string) => nodes[id] ?? null);
   (globalThis as Record<string, unknown>).figma = {
-    getNodeByIdAsync: vi.fn(async (id: string) => nodes[id] ?? null),
+    getNodeByIdAsync,
     currentPage: { get selection() { return selection; } },
     createImage: (bytes: Uint8Array) => {
-      // Figma throws on empty/invalid image data rather than returning a null hash.
-      if (!bytes || bytes.length === 0) throw new Error('Image data is empty');
+      // Model the native decoder refusal instead of accepting every non-empty array.
+      if (!Buffer.from(bytes).equals(Buffer.from(PNG))) throw new Error('Image data is invalid');
       createdBytes.push(bytes);
       return { hash: `hash_${bytes.length}` };
     },
   };
 });
 
-const PNG = new Uint8Array([137, 80, 78, 71, 13, 10, 26, 10, 1, 2, 3]);
-
-describe('toBytes — the postMessage typed-array problem', () => {
+describe('toBytes — supported Figma message representations', () => {
   it('passes a real Uint8Array through', () => {
     expect(toBytes(PNG)).toEqual(PNG);
   });
 
   it('reconstructs from a plain array', () => {
-    expect(toBytes([1, 2, 3])).toEqual(new Uint8Array([1, 2, 3]));
+    expect(toBytes(Array.from(PNG))).toEqual(PNG);
   });
 
-  it('reconstructs from the numeric-keyed object postMessage actually delivers', () => {
-    // This is the real wire shape — a Uint8Array does not survive postMessage as one.
-    expect(toBytes({ '0': 9, '1': 8 })).toEqual(new Uint8Array([9, 8]));
+  it('retains compatibility with a contiguous numeric-keyed object', () => {
+    const object = Object.fromEntries(Array.from(PNG, (byte, index) => [String(index), byte]));
+    expect(toBytes(object)).toEqual(PNG);
   });
 
   it('throws on data that carries no image bytes', () => {
-    expect(() => toBytes(undefined)).toThrow(/did not carry image data/);
-    expect(() => toBytes('nope')).toThrow(/did not carry image data/);
+    expect(() => toBytes(undefined)).toThrow(/must be a Uint8Array/);
+    expect(() => toBytes('nope')).toThrow(/must be a Uint8Array/);
   });
 });
 
@@ -119,10 +100,26 @@ describe('importGradient — target resolution', () => {
 });
 
 describe('importGradient — the bake itself', () => {
-  it('refuses empty image data before calling createImage', async () => {
+  it('refuses empty image data before resolving a target or calling createImage', async () => {
     nodes['1:2'] = makeNode();
-    await expect(importGradient({ bytes: [], nodeId: '1:2' })).rejects.toThrow(/empty image/);
+    await expect(importGradient({ bytes: [], nodeId: '1:2' })).rejects.toMatchObject({
+      code: 'E_INVALID_ARGS', message: expect.stringMatching(/33-/),
+    });
+    expect(getNodeByIdAsync).not.toHaveBeenCalled();
     expect(createdBytes).toHaveLength(0);
+  });
+
+  it.each([
+    ['sparse array', (() => { const value = Array.from(PNG); delete value[4]; return value; })()],
+    ['out-of-range byte', Array.from(PNG, (byte, index) => index === 4 ? 256 : byte)],
+    ['non-canonical object', { ...Object.fromEntries(Array.from(PNG, (byte, index) => [String(index), byte])), extra: 0 }],
+    ['non-PNG bytes', new Uint8Array(PNG.length)],
+  ])('refuses %s before any scene or image API call', async (_label, bytes) => {
+    nodes['1:2'] = makeNode();
+    await expect(importGradient({ bytes, nodeId: '1:2' })).rejects.toMatchObject({ code: 'E_INVALID_ARGS' });
+    expect(getNodeByIdAsync).not.toHaveBeenCalled();
+    expect(createdBytes).toHaveLength(0);
+    expect(nodes['1:2']!.fills).toEqual([]);
   });
 
   it('replaces every existing paint rather than layering over it', async () => {
@@ -174,6 +171,15 @@ describe('importGradient — the bake itself', () => {
     await expect(
       importGradient({ bytes: Array.from(PNG), nodeId: '1:2', config: 'a=1' }),
     ).rejects.toThrow('Image data is invalid');
+    expect(nodes['1:2']!.pluginData[GRADIENT_DATA_KEY]).toBeUndefined();
+  });
+
+  it('leaves final decodability to Figma after bounded PNG header admission', async () => {
+    nodes['1:2'] = makeNode({ fills: [{ type: 'SOLID' }] });
+    const headerOnly = PNG.slice(0, 33);
+    await expect(importGradient({ bytes: headerOnly, nodeId: '1:2', config: 'a=1' }))
+      .rejects.toThrow('Image data is invalid');
+    expect(nodes['1:2']!.fills).toEqual([{ type: 'SOLID' }]);
     expect(nodes['1:2']!.pluginData[GRADIENT_DATA_KEY]).toBeUndefined();
   });
 });

--- a/tests/gradient-image-admission.test.ts
+++ b/tests/gradient-image-admission.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  assertGradientPngBase64Length,
+  assertGradientPngByteLength,
+  decodeGradientPngDataUrl,
+  decodedLengthOfCanonicalBase64,
+  gradientBytesFromUnknown,
+  MAX_GRADIENT_PNG_BASE64_CHARS,
+  MAX_GRADIENT_PNG_BYTES,
+  validateGradientDimensions,
+  validateGradientPngHeader,
+} from '../shared/gradient-image-admission';
+import { PNG_DATA_URL } from './gradient-png-fixture';
+
+const PNG = Uint8Array.from(Buffer.from(PNG_DATA_URL.split(',')[1]!, 'base64'));
+
+describe('gradient dimensions', () => {
+  it('returns the integer canvas dimensions used by the renderer', () => {
+    expect(validateGradientDimensions(480, 300, 2)).toEqual({ width: 960, height: 600 });
+    expect(validateGradientDimensions(0.6, 0.6, 1)).toEqual({ width: 1, height: 1 });
+  });
+
+  it.each([
+    [0, 10, 1], [10, -1, 1], [10, 10, 0], [Number.NaN, 10, 1],
+    [10, Number.POSITIVE_INFINITY, 1], [4097, 1, 1], [2048, 1, 2.001],
+  ])('refuses invalid or unsupported dimensions (%s, %s, %s)', (width, height, scale) => {
+    expect(() => validateGradientDimensions(width, height, scale)).toThrow();
+  });
+});
+
+describe('gradient PNG limits and data URL admission', () => {
+  it('derives a cap above the worst-case 4096² RGBA zlib envelope', () => {
+    const filteredRgba = 4096 * 4096 * 4 + 4096;
+    const zlibBound = filteredRgba
+      + (filteredRgba >>> 12) + (filteredRgba >>> 14) + (filteredRgba >>> 25) + 13;
+    const pngEnvelope = zlibBound + 57;
+    expect(MAX_GRADIENT_PNG_BYTES).toBeGreaterThan(pngEnvelope);
+    expect(MAX_GRADIENT_PNG_BYTES).toBe(68 * 1024 * 1024);
+    expect(MAX_GRADIENT_PNG_BASE64_CHARS).toBe(4 * Math.ceil(MAX_GRADIENT_PNG_BYTES / 3));
+  });
+
+  it('refuses impossible lengths before allocating encoded or decoded storage', () => {
+    expect(() => assertGradientPngBase64Length(MAX_GRADIENT_PNG_BASE64_CHARS + 4)).toThrow(/length/);
+    expect(() => assertGradientPngByteLength(MAX_GRADIENT_PNG_BYTES + 1)).toThrow(/bytes/);
+  });
+
+  it('rejects prefix, length, and alphabet before invoking atob', () => {
+    const decode = vi.spyOn(globalThis, 'atob');
+    try {
+      expect(() => decodeGradientPngDataUrl('image/png;base64,AAAA', { width: 1, height: 1 })).toThrow(/exact/);
+      expect(() => decodeGradientPngDataUrl('data:image/png;base64,AAA', { width: 1, height: 1 })).toThrow(/length/);
+      expect(() => decodeGradientPngDataUrl(`data:image/png;base64,${'!'.repeat(PNG_DATA_URL.split(',')[1]!.length)}`, { width: 1, height: 1 })).toThrow(/canonical/);
+      expect(decode).not.toHaveBeenCalled();
+    } finally { decode.mockRestore(); }
+  });
+
+  it('accepts only the exact canonical PNG data URL and expected dimensions', () => {
+    expect(decodeGradientPngDataUrl(PNG_DATA_URL, { width: 1, height: 1 })).toEqual(PNG);
+    expect(() => decodeGradientPngDataUrl(PNG_DATA_URL, { width: 2, height: 1 })).toThrow(/do not match/);
+    expect(() => decodeGradientPngDataUrl(PNG_DATA_URL.replace('data:image/png;base64,', 'data:image/png;charset=utf-8;base64,'), { width: 1, height: 1 })).toThrow(/exact/);
+    expect(() => decodeGradientPngDataUrl(`${PNG_DATA_URL}\n`, { width: 1, height: 1 })).toThrow(/length|canonical/);
+    expect(() => decodeGradientPngDataUrl(`${PNG_DATA_URL.slice(0, -2)}J=`, { width: 1, height: 1 })).toThrow(/padding bits/);
+  });
+
+  it('computes canonical decoded length without decoding', () => {
+    const base64 = PNG_DATA_URL.split(',')[1]!;
+    expect(decodedLengthOfCanonicalBase64(base64)).toBe(PNG.length);
+    expect(() => decodedLengthOfCanonicalBase64(`${base64.slice(0, -1)}!`)).toThrow(/canonical/);
+  });
+
+  it('checks signature, IHDR, and bounded header dimensions', () => {
+    expect(validateGradientPngHeader(PNG)).toEqual({ width: 1, height: 1 });
+    const wrongSignature = PNG.slice();
+    wrongSignature[0] = 0;
+    expect(() => validateGradientPngHeader(wrongSignature)).toThrow(/signature/);
+    const oversized = PNG.slice();
+    new DataView(oversized.buffer).setUint32(16, 4097);
+    expect(() => validateGradientPngHeader(oversized)).toThrow(/dimensions/);
+  });
+});
+
+describe('legacy byte representation admission', () => {
+  it('accepts Uint8Array, dense arrays, and contiguous numeric objects', () => {
+    expect(gradientBytesFromUnknown(PNG)).toBe(PNG);
+    expect(gradientBytesFromUnknown(Array.from(PNG))).toEqual(PNG);
+    expect(gradientBytesFromUnknown(Object.fromEntries(Array.from(PNG, (byte, index) => [String(index), byte])))).toEqual(PNG);
+  });
+
+  it('refuses holes, extra keys, gaps, and invalid byte values before conversion', () => {
+    const sparse = Array.from(PNG) as Array<number | undefined>;
+    delete sparse[4];
+    expect(() => gradientBytesFromUnknown(sparse)).toThrow(/dense/);
+    const extra = Array.from(PNG) as number[] & { extra?: number };
+    extra.extra = 1;
+    expect(() => gradientBytesFromUnknown(extra)).toThrow(/dense/);
+    expect(() => gradientBytesFromUnknown(Array.from(PNG, (byte, index) => index === 4 ? Number.NaN : byte))).toThrow(/integer/);
+    expect(() => gradientBytesFromUnknown(Array.from(PNG, (byte, index) => index === 4 ? 1.5 : byte))).toThrow(/integer/);
+    const gap = Object.fromEntries(Array.from(PNG, (byte, index) => [String(index), byte]));
+    delete gap['4'];
+    expect(() => gradientBytesFromUnknown(gap)).toThrow(/contiguous/);
+    expect(() => gradientBytesFromUnknown({ ...Object.fromEntries(Array.from(PNG, (byte, index) => [String(index), byte])), name: 1 })).toThrow(/canonical/);
+  });
+});

--- a/tests/gradient-node-fixture.ts
+++ b/tests/gradient-node-fixture.ts
@@ -1,0 +1,22 @@
+export interface FakeNode {
+  id: string;
+  name: string;
+  type: string;
+  fills?: unknown;
+  pluginData: Record<string, string>;
+  setPluginData(k: string, v: string): void;
+}
+
+export function makeNode(over: Partial<FakeNode> = {}): FakeNode {
+  const node: FakeNode = {
+    id: over.id ?? '1:2',
+    name: over.name ?? 'Hero',
+    type: over.type ?? 'RECTANGLE',
+    fills: 'fills' in over ? over.fills : [],
+    pluginData: {},
+    setPluginData(k, v) { this.pluginData[k] = v; },
+  };
+  if (!('fills' in over)) node.fills = [];
+  else if (over.fills === undefined) delete (node as Partial<FakeNode>).fills;
+  return node;
+}

--- a/tests/gradient-png-fixture.ts
+++ b/tests/gradient-png-fixture.ts
@@ -1,0 +1,3 @@
+/** Valid 1x1 PNG used across UI and main admission tests. */
+export const PNG_DATA_URL =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=';

--- a/tests/gradient-render-browser-fixture.ts
+++ b/tests/gradient-render-browser-fixture.ts
@@ -1,0 +1,83 @@
+import * as esbuild from 'esbuild';
+import type { Browser, Page } from 'playwright';
+import { chromium } from 'playwright';
+import { fileURLToPath } from 'node:url';
+export { PNG_DATA_URL } from './gradient-png-fixture';
+
+export const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const CHROME = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome';
+
+export async function launchGradientChrome(): Promise<Browser> {
+  const options = {
+    headless: true,
+    args: ['--enable-unsafe-swiftshader', '--use-gl=angle', '--use-angle=swiftshader'],
+  } as const;
+  if (process.platform === 'darwin') return chromium.launch({ ...options, executablePath: CHROME });
+  try { return await chromium.launch(options); }
+  catch { return chromium.launch({ ...options, channel: 'chrome' }); }
+}
+
+export async function buildGradientHostBundle(): Promise<string> {
+  const result = await esbuild.build({
+    stdin: {
+      contents: "import { renderGradientToPng } from './plugin/src/ui/gradient-host.ts'; window.__renderGradient = renderGradientToPng;",
+      resolveDir: ROOT,
+      loader: 'ts',
+    },
+    bundle: true,
+    platform: 'browser',
+    format: 'iife',
+    target: 'es2020',
+    write: false,
+    logLevel: 'silent',
+  });
+  return result.outputFiles[0].text;
+}
+
+export async function openInstrumentedPage(browser: Browser, bundle: string): Promise<Page> {
+  const page = await browser.newPage();
+  await instrumentGradientPage(page, bundle);
+  return page;
+}
+
+export async function instrumentGradientPage(page: Page, bundle: string): Promise<void> {
+  await page.setContent('<main id="parent-marker">safe</main>');
+  await page.evaluate(() => {
+    const probe = {
+      messageListeners: new Set<EventListenerOrEventListenerObject>(),
+      timers: new Set<number>(),
+    };
+    const add = window.addEventListener.bind(window);
+    const remove = window.removeEventListener.bind(window);
+    const schedule = window.setTimeout.bind(window);
+    const cancel = window.clearTimeout.bind(window);
+    (window as any).__gradientProbe = probe;
+    window.addEventListener = ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions) => {
+      if (type === 'message') probe.messageListeners.add(listener);
+      add(type, listener, options);
+    }) as typeof window.addEventListener;
+    window.removeEventListener = ((type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions) => {
+      if (type === 'message') probe.messageListeners.delete(listener);
+      remove(type, listener, options);
+    }) as typeof window.removeEventListener;
+    window.setTimeout = ((handler: TimerHandler, timeout?: number, ...args: unknown[]) => {
+      let id = 0;
+      id = schedule(() => { probe.timers.delete(id); if (typeof handler === 'function') handler(...args); }, timeout);
+      probe.timers.add(id);
+      return id;
+    }) as typeof window.setTimeout;
+    window.clearTimeout = ((id?: number) => {
+      if (id !== undefined) probe.timers.delete(id);
+      cancel(id);
+    }) as typeof window.clearTimeout;
+  });
+  await page.addScriptTag({ content: bundle });
+}
+
+export async function cleanupState(page: Page): Promise<{ iframes: number; listeners: number; timers: number }> {
+  return page.evaluate(() => ({
+    iframes: document.querySelectorAll('iframe').length,
+    listeners: (window as any).__gradientProbe.messageListeners.size,
+    timers: (window as any).__gradientProbe.timers.size,
+  }));
+}

--- a/tests/gradient-render-document.test.ts
+++ b/tests/gradient-render-document.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { buildRenderDocument } from '../plugin/src/ui/gradient-host';
+
+describe('gradient render document', () => {
+  it('escapes script-closing sequences in both config and correlation data', () => {
+    const attack = '</script><script>parent.document.body.dataset.owned="true"</script>';
+    const document = buildRenderDocument({
+      props: { shader: attack } as never,
+      width: 1,
+      height: 1,
+      scale: 1,
+      staticFrame: true,
+    }, attack);
+    expect(document).not.toContain(attack);
+    expect(document.match(/<\/script>/g)).toHaveLength(1);
+    expect(document).toContain('\\u003c/script\\u003e');
+  });
+
+  it('keeps the pinned settle-frame contract', () => {
+    const document = buildRenderDocument({ props: {} as never, width: 1, height: 1, scale: 1, staticFrame: true }, 'id');
+    expect(document).toContain('"settle":8');
+  });
+});

--- a/tests/gradient-render-isolation-browser.test.ts
+++ b/tests/gradient-render-isolation-browser.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser } from 'playwright';
+import {
+  buildGradientHostBundle,
+  launchGradientChrome,
+  openInstrumentedPage,
+  PNG_DATA_URL,
+} from './gradient-render-browser-fixture';
+
+let browser: Browser;
+let bundle: string;
+
+beforeAll(async () => {
+  bundle = await buildGradientHostBundle();
+  browser = await launchGradientChrome();
+}, 30_000);
+
+afterAll(async () => { await browser?.close(); });
+
+describe('opaque gradient renderer isolation', () => {
+  it('prevents the render child from reading or changing parent DOM', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      const result = await page.evaluate(async (dataUrl) => {
+        const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+        Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
+          ...descriptor,
+          set(source: string) {
+            const token = /const (?:RENDER_ID|TOKEN) = ("[^"]+")/.exec(source)?.[1] ?? '"missing"';
+            const child = `<script>let blocked=false;try{parent.document.getElementById('parent-marker').textContent='owned'}catch{blocked=true}parent.postMessage({channel:'design-os-gradient-render-v1',version:1,renderId:${token},type:'result',__gradientToken:${token},ok:true,dataUrl:${JSON.stringify(dataUrl)},blocked},'*')<\/script>`;
+            descriptor.set!.call(this, child);
+          },
+        });
+        const bytes = await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true });
+        return { bytes: Array.from(bytes), marker: document.getElementById('parent-marker')?.textContent };
+      }, PNG_DATA_URL);
+      expect(result.marker).toBe('safe');
+      expect(result.bytes.length).toBeGreaterThan(32);
+    } finally { await page.close(); }
+  });
+
+  it('rejects a same-origin sibling that knows the correlation token', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      const result = await page.evaluate(async (dataUrl) => {
+        const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+        Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
+          ...descriptor,
+          set(source: string) {
+            const token = /const (?:RENDER_ID|TOKEN) = ("[^"]+")/.exec(source)?.[1] ?? '"missing"';
+            if ((this as HTMLIFrameElement).id !== 'attacker') {
+              const attacker = document.createElement('iframe');
+              attacker.id = 'attacker';
+              descriptor.set!.call(attacker, `<script>parent.postMessage({channel:'design-os-gradient-render-v1',version:1,renderId:${token},type:'result',__gradientToken:${token},ok:true,dataUrl:${JSON.stringify(dataUrl.replace('Nk+A8', 'Nk+Q8'))}},'*')<\/script>`);
+              document.body.appendChild(attacker);
+            }
+            descriptor.set!.call(this, `<script>setTimeout(()=>parent.postMessage({channel:'design-os-gradient-render-v1',version:1,renderId:${token},type:'result',__gradientToken:${token},ok:true,dataUrl:${JSON.stringify(dataUrl)}},'*'),50)<\/script>`);
+          },
+        });
+        const bytes = await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true });
+        document.getElementById('attacker')?.remove();
+        return Array.from(bytes);
+      }, PNG_DATA_URL);
+      const expected = Array.from(Uint8Array.from(atob(PNG_DATA_URL.split(',')[1]!), (char) => char.charCodeAt(0)));
+      expect(result).toEqual(expected);
+    } finally { await page.close(); }
+  });
+});

--- a/tests/gradient-render-protocol-browser.test.ts
+++ b/tests/gradient-render-protocol-browser.test.ts
@@ -1,0 +1,196 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { Browser, Page } from 'playwright';
+import {
+  buildGradientHostBundle,
+  cleanupState,
+  instrumentGradientPage,
+  launchGradientChrome,
+  openInstrumentedPage,
+  PNG_DATA_URL,
+} from './gradient-render-browser-fixture';
+
+let browser: Browser;
+let bundle: string;
+
+beforeAll(async () => {
+  bundle = await buildGradientHostBundle();
+  browser = await launchGradientChrome();
+}, 30_000);
+afterAll(async () => { await browser?.close(); });
+
+async function installChild(page: Page, body: string): Promise<void> {
+  await page.evaluate(({ code, png }) => {
+    const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+    Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
+      ...descriptor,
+      set(source: string) {
+        const renderId = /const RENDER_ID = ("[^"]+")/.exec(source)?.[1] ?? '"missing"';
+        (window as any).__frameSnapshot = {
+          sandbox: this.getAttribute('sandbox'),
+          style: this.getAttribute('style'),
+        };
+        descriptor.set!.call(this, `<script>${code.replaceAll('__ID__', renderId).replaceAll('__PNG__', JSON.stringify(png))}<\/script>`);
+      },
+    });
+  }, { code: body, png: PNG_DATA_URL });
+}
+
+const resultReply = "{channel:'design-os-gradient-render-v1',version:1,renderId:__ID__,type:'result',dataUrl:__PNG__}";
+
+describe('gradient renderer protocol and lifecycle', () => {
+  it('refuses invalid dimensions before allocating an iframe or host resources', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      const error = await page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: Number.NaN, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      expect(error).toEqual({ code: 'E_INVALID_ARGS', message: 'gradient bake needs finite positive width, height, and scale' });
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('bounds document serialization failures before allocating host resources', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      const error = await page.evaluate(async () => {
+        const props: Record<string, unknown> = {};
+        props.circular = props;
+        try { await (window as any).__renderGradient({ props, width: 1, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, length: (caught as Error).message.length }; }
+        return null;
+      });
+      expect(error?.code).toBe('E_RENDER_SETUP');
+      expect(error?.length).toBeLessThanOrEqual(512);
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('uses the opaque in-viewport placement and completes an eight-frame child', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      await installChild(page, `let n=0;const tick=()=>{if(++n<8)requestAnimationFrame(tick);else parent.postMessage(${resultReply},'*')};requestAnimationFrame(tick)`);
+      const bytes = await page.evaluate(() => (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }).then(Array.from));
+      expect(bytes.length).toBeGreaterThan(32);
+      expect(await page.evaluate(() => (window as any).__frameSnapshot)).toEqual(expect.objectContaining({
+        sandbox: 'allow-scripts',
+        style: expect.stringMatching(/position: fixed;.*left: 0px;.*top: 0px;.*opacity: 0;.*pointer-events: none/),
+      }));
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('ignores wrong token and wrong-origin messages before the genuine result', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      await page.evaluate((png) => {
+        const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+        Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', {
+          ...descriptor,
+          set(source: string) {
+            const quoted = /const RENDER_ID = ("[^"]+")/.exec(source)?.[1] ?? '"missing"';
+            const id = JSON.parse(quoted);
+            const reply = { channel: 'design-os-gradient-render-v1', version: 1, renderId: id, type: 'result', dataUrl: png };
+            queueMicrotask(() => {
+              window.dispatchEvent(new MessageEvent('message', { source: this.contentWindow, origin: 'https://attacker.test', data: reply }));
+            });
+            descriptor.set!.call(this, `<script>parent.postMessage({...${JSON.stringify(reply)},renderId:'wrong'},'*');setTimeout(()=>parent.postMessage(${JSON.stringify(reply)},'*'),25)<\/script>`);
+          },
+        });
+      }, PNG_DATA_URL);
+      const bytes = await page.evaluate(() => (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }).then(Array.from));
+      expect(bytes.length).toBeGreaterThan(32);
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('bounds child error code and message, settles once, and cleans resources', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      await installChild(page, `parent.postMessage({channel:'design-os-gradient-render-v1',version:1,renderId:__ID__,type:'error',code:'E'.repeat(200),message:'x'.repeat(2000)},'*');parent.postMessage(${resultReply},'*')`);
+      const error = await page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      expect(error?.code).toHaveLength(64);
+      expect(error?.message).toHaveLength(512);
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('rejects a PNG whose header does not match the requested render size', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      await installChild(page, `parent.postMessage(${resultReply},'*')`);
+      const error = await page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: 2, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      expect(error).toEqual({ code: 'E_INVALID_IMAGE', message: 'gradient PNG dimensions 1x1 do not match requested 2x1' });
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('cleans all resources when assigning the child document throws', async () => {
+    const page = await openInstrumentedPage(browser, bundle);
+    try {
+      await page.evaluate(() => {
+        const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+        Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', { ...descriptor, set() { throw new Error('fixture srcdoc refused'); } });
+      });
+      const error = await page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      expect(error).toEqual({ code: 'E_RENDER_SETUP', message: 'fixture srcdoc refused' });
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('enforces the render deadline and cleans the silent child', async () => {
+    const page = await browser.newPage();
+    try {
+      await page.clock.install();
+      await instrumentGradientPage(page, bundle);
+      await installChild(page, 'void 0');
+      const pending = page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      await page.waitForSelector('iframe');
+      await page.clock.fastForward(45_001);
+      expect(await pending).toEqual({ code: 'E_TIMEOUT', message: 'gradient render exceeded 45000ms' });
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+
+  it('enforces the load deadline and cleans a child that never loads', async () => {
+    const page = await browser.newPage();
+    try {
+      await page.clock.install();
+      await instrumentGradientPage(page, bundle);
+      await page.evaluate(() => {
+        const add = HTMLIFrameElement.prototype.addEventListener;
+        HTMLIFrameElement.prototype.addEventListener = function (type, listener, options) {
+          if (type !== 'load') add.call(this, type, listener, options);
+        };
+        const descriptor = Object.getOwnPropertyDescriptor(HTMLIFrameElement.prototype, 'srcdoc')!;
+        Object.defineProperty(HTMLIFrameElement.prototype, 'srcdoc', { ...descriptor, set() { /* fixture never loads */ } });
+      });
+      const pending = page.evaluate(async () => {
+        try { await (window as any).__renderGradient({ props: {}, width: 1, height: 1, scale: 1, staticFrame: true }); }
+        catch (caught) { return { code: (caught as any).code, message: (caught as Error).message }; }
+        return null;
+      });
+      await page.waitForSelector('iframe');
+      await page.clock.fastForward(15_001);
+      expect(await pending).toEqual({ code: 'E_IFRAME_LOAD', message: 'the render iframe never loaded' });
+      expect(await cleanupState(page)).toEqual({ iframes: 0, listeners: 0, timers: 0 });
+    } finally { await page.close(); }
+  });
+});

--- a/tests/gradient-renderer-pin.test.ts
+++ b/tests/gradient-renderer-pin.test.ts
@@ -19,15 +19,17 @@ const REPO_ROOT = dirname(dirname(fileURLToPath(import.meta.url)));
 const read = (rel: string): string => readFileSync(join(REPO_ROOT, rel), 'utf8');
 
 const HOST = read('plugin/src/ui/gradient-host.ts');
+const DOCUMENT = read('plugin/src/ui/gradient-render-document.ts');
 const CLI = read('cli/src/commands/shader-gradient.ts');
+const RELAY = read('plugin/src/ui/ui-relay.ts');
 const MANIFEST = JSON.parse(read('plugin/manifest.json')) as {
   networkAccess: { allowedDomains: string[]; devAllowedDomains: string[] };
 };
 
 /** The single pinned version, read from its one definition. */
 function hostVersion(): string {
-  const m = /const RENDERER_VERSION = '([^']+)'/.exec(HOST);
-  if (!m) throw new Error('RENDERER_VERSION not found in gradient-host.ts');
+  const m = /const RENDERER_VERSION = '([^']+)'/.exec(DOCUMENT);
+  if (!m) throw new Error('RENDERER_VERSION not found in gradient-render-document.ts');
   return m[1]!;
 }
 
@@ -56,23 +58,23 @@ describe('gradient renderer pin — one React instance', () => {
   it('shares dependencies via a deps pin rather than separate per-package bundles', () => {
     // Without this the renderer resolves its own React and its hooks die on an instance
     // that never mounted: "Cannot read properties of null (reading 'useState')".
-    expect(HOST).toContain('?deps=');
+    expect(DOCUMENT).toContain('?deps=');
   });
 
   it('never loads the renderer as a standalone bundle with unpinned dependencies', () => {
-    const rendererImport = /@shadergradient\/react@\$\{RENDERER_VERSION\}([^`]*)`/.exec(HOST);
+    const rendererImport = /@shadergradient\/react@\$\{RENDERER_VERSION\}([^`]*)`/.exec(DOCUMENT);
     expect(rendererImport, 'renderer import not found').not.toBeNull();
     expect(rendererImport![1]).toContain('?deps=');
   });
 
   it('pins react-dom to the same react build the page imports', () => {
-    expect(HOST).toMatch(/react-dom@\$\{REACT_VERSION\}\/client\?deps=react@\$\{REACT_VERSION\}/);
+    expect(DOCUMENT).toMatch(/react-dom@\$\{REACT_VERSION\}\/client\?deps=react@\$\{REACT_VERSION\}/);
   });
 
   it('pins @react-three/fiber, so the resolver cannot pick a React-19-only major', () => {
     // Unpinned, the latest major (v9) is resolved; it requires React 19 and fails against
     // React 18 with an opaque internal error rather than a version complaint.
-    const deps = /const DEPS = `([^`]+)`/.exec(HOST);
+    const deps = /const DEPS = `([^`]+)`/.exec(DOCUMENT);
     expect(deps, 'DEPS not found').not.toBeNull();
     expect(deps![1]).toMatch(/@react-three\/fiber@\d+\.\d+\.\d+/);
     expect(deps![1]).toMatch(/^react@/);
@@ -82,12 +84,34 @@ describe('gradient renderer pin — one React instance', () => {
 
 describe('gradient renderer pin — manifest declares the host it fetches from', () => {
   it('the CDN base is declared in allowedDomains', () => {
-    const m = /const CDN_BASE = '([^']+)'/.exec(HOST);
+    const m = /const CDN_BASE = '([^']+)'/.exec(DOCUMENT);
     expect(m, 'CDN_BASE not found').not.toBeNull();
     const origin = m![1]!;
     // A fetch to an undeclared origin is blocked by Figma at runtime, so a render host
     // pointing anywhere the manifest does not list can never succeed.
     expect(MANIFEST.networkAccess.allowedDomains).toContain(origin);
     expect(MANIFEST.networkAccess.devAllowedDomains).toContain(origin);
+  });
+});
+
+describe('gradient renderer host — opaque placement contract', () => {
+  it('uses allow-scripts without same-origin access', () => {
+    expect(HOST).toContain("setAttribute('sandbox', 'allow-scripts')");
+    expect(HOST).not.toContain('allow-same-origin');
+  });
+
+  it('keeps the child intersecting the panel without painting or taking input', () => {
+    expect(HOST).toContain("position: 'fixed'");
+    expect(HOST).toContain("left: '0'");
+    expect(HOST).toContain("top: '0'");
+    expect(HOST).toContain("opacity: '0'");
+    expect(HOST).toContain("pointerEvents: 'none'");
+    expect(HOST).not.toMatch(/visibility:\s*['"]hidden/);
+    expect(HOST).not.toMatch(/left:\s*['"]-\d/);
+  });
+
+  it('uses Figma-supported Uint8Array transport while main retains legacy admission', () => {
+    expect(RELAY).toMatch(/params:\s*\{\s*bytes,/);
+    expect(RELAY).not.toContain('bytes: Array.from(bytes)');
   });
 });


### PR DESCRIPTION
Render ShaderGradient inside an opaque `sandbox="allow-scripts"` child. The host accepts only the active child's matching origin and correlated result, and removes listeners, timers and the iframe after success, failure or timeout. Keeping the hidden child inside the viewport preserves animation-frame rendering in the compact panel.

PNG admission now checks dimensions, byte bounds, canonical base64 and PNG headers before decoding or touching the Figma scene. Typed-array messaging remains direct; valid legacy dense arrays and numeric-keyed objects remain supported. Figma's native image decoder still decides full PNG validity. Renderer dependencies, existing deadlines, presets and undo behavior remain unchanged.

Validation: 2,734 tests and all project gates pass on the final integrated candidate. Browser regressions cover parent isolation, spoofed replies, lifecycle cleanup and malformed images. A fresh production-only CDN replay passed normal and compact 480x300, 2048x2048 and 4096x4096 rendering, with no page errors or leftover iframe. One unrelated child-fixture startup assertion failed in an earlier full run; the unchanged isolated test and subsequent full runs pass, and the observation is tracked in #157.

This PR is stacked on the opaque HTML renderer change in #147. Keep it draft until actual Figma source/origin, self-test, scratch bake and visual checks pass. Browser measurements do not establish live Figma latency, process isolation or a cost advantage over MCP. The shared live workflow comparison is tracked in #156.

Closes #142.
